### PR TITLE
only define factor and isprime for Integer if not extending Base

### DIFF
--- a/src/Misc/Integer.jl
+++ b/src/Misc/Integer.jl
@@ -4,8 +4,12 @@
 #
 ################################################################################
 
-isprime(a::Integer) = isprime(fmpz(a))
-factor(a::Integer) = factor(fmpz(a))
+if !isdefined(Base, :isprime)
+  isprime(a::Integer) = isprime(fmpz(a))
+end
+if !isdefined(Base, :factor)
+  factor(a::Integer) = factor(fmpz(a))
+end
 
 function next_prime(x::UInt, proof::Bool)
   z = ccall((:n_nextprime, :libflint), UInt, (UInt, Cint), x, Cint(proof))


### PR DESCRIPTION
otherwise importing Hecke can globally modify method tables and change the behavior of unrelated code that's trying to use Primes.jl, for example