### PR TITLE
Do not extend Base.reduce

### DIFF
--- a/src/Sparse/Module.jl
+++ b/src/Sparse/Module.jl
@@ -1,10 +1,9 @@
 #fin. gen. submodules of Z^n and F_p^n (and possibly more)
 #
-#import Base.show, Base.reduce, Base.inv, Nemo.inv, Base.solve, Hecke.solve,
+#import Base.show, Base.inv, Nemo.inv, Base.solve, Hecke.solve,
 #       Hecke.lift, Hecke.rational_reconstruction, Hecke.elementary_divisors,
 #       Hecke.rank, Hecke.det
 
-import Base.reduce
 export det_mc, id, isid, isupper_triangular, norm2, hadamard_bound2, 
        hnf, hnf!, echelon_with_trafo
 


### PR DESCRIPTION
the method at https://github.com/thofma/Hecke.jl/blob/96d3f56e6e34fc7ee2bbc3c5631a94b7cb7b1214/src/NfMaxOrd/Unit/Reduction.jl#L80 is defined on Base types, which can change the behavior of unrelated code