### PR TITLE
try to imporve ispower for integral elements

### DIFF
--- a/src/NfOrd/Hensel.jl
+++ b/src/NfOrd/Hensel.jl
@@ -370,9 +370,12 @@ function _hensel(f::Generic.Poly{nf_elem},
 
   ##lets start:
   
+  
   f_coeff_ZX = Vector{fmpz_poly}(undef, length(f))
-  for j in 0:degree(f)
-    f_coeff_ZX[j + 1] = ZX(coeff(f, j))
+  if !ispure
+    for j in 0:degree(f)
+      f_coeff_ZX[j + 1] = ZX(coeff(f, j))
+    end
   end
 
   n = degree(K)
@@ -417,7 +420,7 @@ function _hensel(f::Generic.Poly{nf_elem},
     Mi, d = pseudo_inv(M)
 
     if ispure
-      ap = Qt(ZX(-coeff(f, 0)))
+      ap = Qt((-coeff(f, 0)))
       bp = powmod(ap, degree(f)-1, pgg)
       minv = invmod(fmpz(degree(f)), pp)
     end
@@ -570,13 +573,6 @@ end
 
 #identical to hasroot - which one do we want?
 function ispower(a::NfOrdElem, n::Int)
-  Ox, x = PolynomialRing(parent(a), "x", cached=false)
-  f = x^n - a
-  r = _roots_hensel(f, max_roots = 1)
-  
-  if length(r) == 0
-    return false, zero(parent(a))
-  else
-    return true, r[1]
-  end
+  fl, r = ispower(nf(parent(a))(a), n, isintegral = true)
+  return fl, parent(a)(r)
 end

--- a/src/NumField/NfAbs/Elem.jl
+++ b/src/NumField/NfAbs/Elem.jl
@@ -714,7 +714,7 @@ the root is returned.
 If the field $K$ is known to contain the $n$-th roots of unity,
 one can set `with_roots_unity` to `true`.
 """
-function ispower(a::nf_elem, n::Int; with_roots_unity::Bool = false)
+function ispower(a::nf_elem, n::Int; with_roots_unity::Bool = false, isintegral::Bool = false)
   @assert n > 0
   if n == 1
     return true, a
@@ -723,7 +723,11 @@ function ispower(a::nf_elem, n::Int; with_roots_unity::Bool = false)
     return true, a
   end
 
-  d = denominator(a)
+  if isintegral
+    d = fmpz(1)
+  else
+    d = denominator(a)
+  end
 
   Ky, y = PolynomialRing(parent(a), "y", cached = false)
 


### PR DESCRIPTION
Assuming b is a mathematically integral element
  - do not clear the visible denominator
  - rely on the f'(alpha) trick to work in the field
  - provide is_integral as a flag
  - provide ispower for order-elemts this way
required some minor work in the hensel core