### PR TITLE
fix coefficient_ring call in trace / norm of qadics

### DIFF
--- a/src/LocalField/qAdic.jl
+++ b/src/LocalField/qAdic.jl
@@ -67,13 +67,13 @@ function Base.setprecision(a::Generic.MatSpaceElem{qadic}, N::Int)
 end
 
 function trace(r::qadic)
-  t = base_ring(parent(r))()
+  t = coefficient_ring(parent(r))()
   ccall((:qadic_trace, :libflint), Nothing, (Ref{padic}, Ref{qadic}, Ref{FlintQadicField}), t, r, parent(r))
   return t
 end
 
 function norm(r::qadic)
-  t = base_ring(parent(r))()
+  t = coefficient_ring(parent(r))()
   ccall((:qadic_norm, :libflint), Nothing, (Ref{padic}, Ref{qadic}, Ref{FlintQadicField}), t, r, parent(r))
   return t
 end


### PR DESCRIPTION
trace seems to be very broken to me, it gives random output (something is not being initialised properly? but norm looks like it works now)