### PR TITLE
Set prec val length

### DIFF
--- a/src/LocalField/Poly.jl
+++ b/src/LocalField/Poly.jl
@@ -332,11 +332,11 @@ function divexact(f::AbstractAlgebra.PolyElem{T}, g::AbstractAlgebra.PolyElem{T}
       q1 = d[lenf - leng + 1] = divexact(coeff(f, lenf - 1), coeff(g, leng - 1))
       f = f - shift_left(q1*g, lenf - leng)
       if length(f) == lenf # inexact case
-         set_length!(f, normalise(f, lenf - 1))
+         f = set_length!(f, normalise(f, lenf - 1))
       end
    end
    q = parent(f)(d)
-   set_length!(q, lenq)
+   q = set_length!(q, lenq)
    K = base_ring(f)
    Kt = parent(f)
    p = prime(K)

--- a/src/Misc/Poly.jl
+++ b/src/Misc/Poly.jl
@@ -1345,7 +1345,7 @@ function divhigh(a::PolyElem{T}, b::PolyElem{T}, n0::Int) where {T}
     #set_length(, -1) fails
     return r
   end
-  Hecke.set_length!(r, Hecke.normalise(r, length(r) - 1))
+  r = Hecke.set_length!(r, Hecke.normalise(r, length(r) - 1))
   return r
 end
 
@@ -1471,7 +1471,7 @@ function mod(f::AbstractAlgebra.PolyElem{T}, g::AbstractAlgebra.PolyElem{T}) whe
         u = addeq!(u, c)
         f = setcoeff!(f, i + length(f) - length(g) - 1, u)
       end
-      set_length!(f, normalise(f, length(f) - 1))
+      f = set_length!(f, normalise(f, length(f) - 1))
     end
   end
   return f
@@ -1502,7 +1502,7 @@ function Base.divrem(f::AbstractAlgebra.PolyElem{T}, g::AbstractAlgebra.PolyElem
         u = addeq!(u, c)
         f = setcoeff!(f, i + length(f) - length(g) - 1, u)
      end
-     set_length!(f, normalise(f, length(f) - 1))
+     f = set_length!(f, normalise(f, length(f) - 1))
   end
   return q, f
 end

--- a/src/Misc/Poly.jl
+++ b/src/Misc/Poly.jl
@@ -747,7 +747,7 @@ function power_sums_to_polynomial(P::Array{T, 1}) where T <: FieldElem
     end
     n = length(la)-1
     while n > 0
-      set_prec!(r, la[n])
+      r = set_prec!(r, la[n])
       rr = derivative(r)*inv(r)
       md = -(rr+s)
       m = S([R(1)], 1, la[n], 0)+integral(md)

--- a/src/Misc/Series.jl
+++ b/src/Misc/Series.jl
@@ -3,7 +3,7 @@ function inv(a::RelSeriesElem{<:Nemo.FieldElem})
   @assert valuation(a)==0
   # x -> x*(2-xa) is the lifting recursion
   x = parent(a)(inv(coeff(a, 0)))
-  set_prec!(x, 1)
+  x = set_prec!(x, 1)
   p = precision(a)
   la = [p]
   while la[end]>1
@@ -11,13 +11,13 @@ function inv(a::RelSeriesElem{<:Nemo.FieldElem})
   end
 
   two = parent(a)(base_ring(a)(2))
-  set_prec!(two, p)
+  two = set_prec!(two, p)
 
   n = length(la)-1
   y = parent(a)()
   while n>0
-    set_prec!(x, la[n])
-    set_prec!(y, la[n])
+    x = set_prec!(x, la[n])
+    y = set_prec!(y, la[n])
 #    y = mul!(y, a, x)
 #    y = two-y #sub! is missing...
 #    x = mul!(x, x, y)
@@ -47,8 +47,8 @@ function exp(a::RelSeriesElem{<:Nemo.FieldElem})
   n = length(la)-1
   # x -> x*(1-log(a)+a) is the recursion
   while n>0
-    set_prec!(x, la[n])
-    set_prec!(one, la[n])
+    x = set_prec!(x, la[n])
+    one = set_prec!(one, la[n])
     x = x*(one - log(x) + a) # TODO: can be optimized...
     n -=1 
   end
@@ -61,10 +61,10 @@ Return the derivative of the power series $f$.
 """
 function derivative(f::RelSeriesElem{T}) where T
   g = parent(f)()
-  set_prec!(g, precision(f)-1)
+  g = set_prec!(g, precision(f)-1)
   fit!(g, pol_length(f))
   v = valuation(f)
-  set_val!(g, 0)
+  g = set_val!(g, 0)
   if v==0
     for i=1:Nemo.pol_length(f)
       setcoeff!(g, i-1, (i+v)*Nemo.polcoeff(f, i))
@@ -73,7 +73,7 @@ function derivative(f::RelSeriesElem{T}) where T
     for i=0:Nemo.pol_length(f)
       setcoeff!(g, i, (i+v)*Nemo.polcoeff(f, i))
     end
-    set_val!(g, v-1)
+    g = set_val!(g, v-1)
   end
   Nemo.renormalize!(g)  
   return g
@@ -89,9 +89,9 @@ Return the integral of the power series $f$.
 function Nemo.integral(f::RelSeriesElem{T}) where T
   g = parent(f)()
   fit!(g, precision(f)+1)
-  set_prec!(g, precision(f)+1)
+  g = set_prec!(g, precision(f)+1)
   v = valuation(f)
-  Nemo.set_val!(g, v+1)
+  g = Nemo.set_val!(g, v+1)
   for i=0:Nemo.pol_length(f)
     setcoeff!(g, i, divexact(Nemo.polcoeff(f, i), i+v+1))
   end

--- a/src/NumField/NfAbs/Simplify.jl
+++ b/src/NumField/NfAbs/Simplify.jl
@@ -156,7 +156,7 @@ function _block(a::nf_elem, R::Array{fq_nmod, 1}, ap::fq_nmod_poly)
   nf_elem_to_gfp_poly!(_tmp, a, false) # ignore denominator
   set_length!(ap, length(_tmp))
   for i in 0:(length(_tmp) - 1)
-    setcoeff!(ap, i, base_ring(ap)(_get_coeff_raw(_tmp, i)))
+    ap = setcoeff!(ap, i, base_ring(ap)(_get_coeff_raw(_tmp, i)))
   end
 #  ap = Ft(Zx(a*denominator(a)))
   s = fq_nmod[evaluate(ap, x) for x = R]


### PR DESCRIPTION
Update set_length!, set_prec!, set_val! and set_scale! to return their argument to support polynomials and series with immutable types.

Requires AbstractAlgebra # 602 and Nemo # 841 to be merged first. It is not urgent that this patch be applied immediately after those two. This patch is also not breaking.

Oscar.jl and Singular.jl are unaffected by these changes and do not need to be updated.