### PR TITLE
Fix #83

### DIFF
--- a/src/RCF/conductor.jl
+++ b/src/RCF/conductor.jl
@@ -1338,16 +1338,15 @@ function norm(m::T, a::FacElem{nf_elem, AnticNumberField}) where T <: Map{AnticN
   h = gcd(gen(k) - evaluate(Qt(m(gen(k))), t), evaluate(K.pol, t))
   d = Dict{nf_elem, fmpz}()
   for (e,v) = a.fac
-    n = resultant(h, mod(evaluate(Qt(e), t), h))
+    n = resultant(h, mod(change_base_ring(k, Qt(e), parent = kt), h))
     if haskey(d, n)
       d[n] += v
     else
       d[n] = v
     end
   end
-  return FacElem(d)
+  return FacElem(k, d)
 end
-
 
 #TODO: change order!!! this only works for maximal orders
 function Base.intersect(I::NfAbsOrdIdl, R::NfAbsOrd)
@@ -1359,6 +1358,7 @@ function Base.intersect(I::NfAbsOrdIdl, R::NfAbsOrd)
   @assert fl
   return minimum(m, I)
 end
+
 Base.intersect(R::NfAbsOrd, I::NfAbsOrdIdl) = intersect(I, R)
 
 function Base.intersect(I::NfOrdFracIdl, R::NfAbsOrd)

--- a/test/NfAbs/Elem.jl
+++ b/test/NfAbs/Elem.jl
@@ -121,3 +121,16 @@ end
   @test length(r) == 3
   @test all(iszero, (f(b) for b in r))
 end
+
+@testset "Norm of factored element" begin
+  Qx, x = QQ["x"]
+  f = x^3 - 2
+  K, a = number_field(f, "a")
+  Kt, t = K["t"]
+  L, b = number_field(x^6 - 6*x^4 - 4*x^3 + 12*x^2 - 24*x - 4)
+  h = hom(K, L, -12//155*b^5 - 9//310*b^4 + 16//31*b^3 + 78//155*b^2 - 76//155*b + 182//155)
+  z = -3*b^5 - 4*b^3 + 3*b^2 + 6*b + 2
+  @test norm(h, z) == 1620*a^2 - 3342*a + 1120
+  @test evaluate(norm(h, FacElem(z))) == evaluate(FacElem(K, Dict(1620*a^2 - 3342*a + 1120 => 1)))
+  @test evaluate(norm(h, FacElem(L))) == evaluate(FacElem(K))
+end


### PR DESCRIPTION
FacElem(::Dict) should be replaced by FacElem(K, D::Dict) where K is the
base field. This way we can also handle factored elements with an empty
product.