### PR TITLE
update few rand methods according to the Random API

### DIFF
--- a/src/AlgAss/AbsAlgAss.jl
+++ b/src/AlgAss/AbsAlgAss.jl
@@ -550,8 +550,11 @@ end
 #
 ################################################################################
 
-function rand(A::AbsAlgAss{T}) where T
-  c = T[rand(base_ring(A)) for i = 1:dim(A)]
+Random.gentype(::Type{T}) where {T<:AbsAlgAss} = elem_type(T)
+
+function rand(rng::AbstractRNG, Asp::Random.SamplerTrivial{<:AbsAlgAss{T}}) where T
+  A = Asp[]
+  c = rand(rng, base_ring(A), dim(A))
   return A(c)
 end
 

--- a/src/AlgAss/Ideal.jl
+++ b/src/AlgAss/Ideal.jl
@@ -566,11 +566,15 @@ end
 #
 ################################################################################
 
-function rand(a::AbsAlgAssIdl)
+# TODO: implement for ::Type{AbsAlgAssIdl}
+Random.gentype(a::AbsAlgAssIdl) = elem_type(algebra(a))
+
+function rand(rng::AbstractRNG, a_sp::Random.SamplerTrivial{<:AbsAlgAssIdl})
+  a = a_sp[]
   A = algebra(a)
   x = A()
   for b in basis(a, copy = false)
-    x += rand(base_ring(A))*b
+    x += rand(rng, base_ring(A))*b
   end
   return x
 end

--- a/src/EllCrv/Finite.jl
+++ b/src/EllCrv/Finite.jl
@@ -42,13 +42,16 @@ export hasse_interval, order, order_via_bsgs, order_via_legendre,
 #
 ################################################################################
 
+Random.gentype(::Type{EllCrv{T}}) where {T} = EllCrvPt{T}
+
 # only works for short form
 @doc Markdown.doc"""
     rand(E::EllCrv) -> EllCrvPt
 Returns a random point on the elliptic curve $E$ defined over a finite field.
 It is assumed that $E$ is given in short form.
 """
-function rand(E::EllCrv)
+function rand(rng::AbstractRNG, Esp::Random.SamplerTrivial{<:EllCrv})
+  E = Esp[]
   R = base_field(E)
 
   if E.short == false
@@ -58,7 +61,7 @@ function rand(E::EllCrv)
   while true
   # choose random x-coordinate and check if it is a square in F_q
   # if not, choose new x-coordinate
-    x = rand(R)
+    x = rand(rng, R)
     square = x^3 + E.coeff[1]*x + E.coeff[2]
 
     a = issquare(square)

--- a/src/Misc/Integer.jl
+++ b/src/Misc/Integer.jl
@@ -302,11 +302,11 @@ function rand(rng::AbstractRNG, a::StepRange{fmpz, fmpz})
     s = fmpz(0)
     for i=1:nl
       s = s << (8*sizeof(Base.GMP.Limb))
-      s += rand(Base.GMP.Limb)
+      s += rand(rng, Base.GMP.Limb)
     end
     if high >0
       s = s << high
-      s += rand(0:Base.GMP.Limb(mask))
+      s += rand(rng, 0:Base.GMP.Limb(mask))
     end
     if s <= m break; end
   end

--- a/src/NfOrd/ResidueRing.jl
+++ b/src/NfOrd/ResidueRing.jl
@@ -616,13 +616,16 @@ end
 #
 ################################################################################
 
-function rand(Q::NfOrdQuoRing)
+Random.gentype(::Type{NfOrdQuoRing}) = elem_type(NfOrdQuoRing)
+
+function rand(rng::AbstractRNG, Qsp::Random.SamplerTrivial{NfOrdQuoRing})
+  Q = Qsp[]
   A = basis_matrix(Q)
   B = basis(base_ring(Q))
-  z = rand(fmpz(1):A[1,1]) * B[1]
+  z = rand(rng, fmpz(1):A[1,1]) * B[1]
 
   for i in 2:nrows(A)
-    z = z + rand(fmpz(1):A[i, i]) * B[i]
+    z = z + rand(rng, fmpz(1):A[i, i]) * B[i]
   end
 
   return Q(z)

--- a/test/AlgAss/AbsAlgAss.jl
+++ b/test/AlgAss/AbsAlgAss.jl
@@ -161,4 +161,21 @@
 
   end
 
+  @testset "rand" begin
+    Fp = GF(3)
+    G = small_group(8, 4)
+    FpG = group_algebra(Fp, G)
+    A = AlgAss(FpG)[1]
+    @assert A isa Hecke.AbsAlgAss
+
+    E = elem_type(A)
+    @test rand(A) isa E
+    @test rand(rng, A) isa E
+    @test rand(A, 2, 3) isa Matrix{E}
+
+    Random.seed!(rng, rand_seed)
+    a = rand(rng, A)
+    Random.seed!(rng, rand_seed)
+    @test a == rand(rng, A)
+  end
 end

--- a/test/AlgAss/Ideal.jl
+++ b/test/AlgAss/Ideal.jl
@@ -65,4 +65,18 @@
     end
   end
 
+  @testset "rand" begin
+    A = matrix_algebra(GF(7), 2)
+    I = A[2]*A
+
+    E = elem_type(A)
+    @test rand(I) isa E
+    @test rand(rng, I) isa E
+    @test rand(rng, I, 2, 3) isa Matrix{E}
+
+    Random.seed!(rng, rand_seed)
+    a = rand(rng, I)
+    Random.seed!(rng, rand_seed)
+    @test a == rand(rng, I)
+  end
 end

--- a/test/EllCrv/Finite.jl
+++ b/test/EllCrv/Finite.jl
@@ -15,6 +15,15 @@
     @inferred rand(E2)
     @inferred rand(E3)
     @inferred rand(E4)
+
+    T = EllCrvPt{Hecke.Nemo.nmod}
+    @test rand(rng, E1) isa T
+    @test rand(rng, E1, 3) isa Vector{T}
+
+    Random.seed!(rng, rand_seed)
+    a = rand(rng, E1)
+    Random.seed!(rng, rand_seed)
+    @test a == rand(rng, E1)
   end
 
   @testset "Order computation (Legendre)" begin

--- a/test/NfOrd/ResidueRing.jl
+++ b/test/NfOrd/ResidueRing.jl
@@ -7,3 +7,20 @@
   @test c^8 == b
 end
 
+@testset "rand" begin
+  Qx,  x = PolynomialRing(FlintQQ, "x");
+  K,  a = NumberField(x,"a");
+  O = maximal_order(K)
+  m0 = O(9)*O
+  Q = NfOrdQuoRing(O, m0)
+
+  for f in (rand(Q), rand(rng, Q))
+    @test f isa elem_type(Q)
+  end
+  @test rand(Q, 2) isa Vector{elem_type(Q)}
+
+  Random.seed!(rng, rand_seed)
+  x = rand(rng, Q)
+  Random.seed!(rng, rand_seed)
+  @test x == rand(rng, Q)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,11 @@ k, a = quadratic_field(5)
 
 push!(Base.LOAD_PATH, "@v#.#")
 
+using Random
+
+const rng = MersenneTwister()
+const rand_seed = rand(UInt128)
+
 try
   using GAP
   @time include("FieldFactory.jl")
@@ -41,5 +46,3 @@ end
 @time include("Sparse.jl")
 @time include("QuadForm.jl")
 @time include("LocalField.jl")
-
-


### PR DESCRIPTION
This is a modest first step, which concerns only `rand` methods taking only one object (i.e. this does not use RandomExtensions.jl).
This PR depends on the merged https://github.com/Nemocas/Nemo.jl/pull/878, which is not a breaking change (so a Nemo patch release could be made).