### PR TITLE
Deploy documentation to website using GitHub Actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
-    
+
     steps:
       - uses: actions/checkout@v2
       - name: "Set up Julia"
@@ -53,3 +53,28 @@ jobs:
 
     # don't run ci twice on own PRs
     if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
+
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: '1'
+      - name: Cache artifacts
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-docdeploy@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
... this was lost with the removal of Travis (resp. with Travis stopping to work).

However, for the final step (the actual deployment) to work, someone with admin rights for this repo may have to set a `DOCUMENTER_KEY`. To generate one, you can do this:
```julia
julia> using DocumenterTools, Hecke
julia> DocumenterTools.genkeys(Hecke)
```
Then go to "Settings" -> "Deploy Keys" (should be something like <https://github.com/thofma/Hecke.jl/settings/keys>) and add it there.
