### PR TITLE
Various, unfortunately:

### DIFF
--- a/src/LocalField/Conjugates.jl
+++ b/src/LocalField/Conjugates.jl
@@ -91,8 +91,13 @@ mutable struct qAdicConj
   cache::Dict{nf_elem, Any}
 
   function qAdicConj(K::AnticNumberField, p::Int; splitting_field::Bool = false)
+    if discriminant(map_coeffs(GF(p), Globals.Zx(K.pol))) == 0
+      error("cannot deal with difficult primes yet")
+    end
+    #=
     isindex_divisor(maximal_order(K), p) && error("cannot deal with index divisors yet")
     isramified(maximal_order(K), p) && error("cannot deal with ramification yet")
+    =#
     if splitting_field
       Zx = PolynomialRing(FlintZZ, cached = false)[1]
       C = qAdicRootCtx(Zx(K.pol), p, splitting_field = true)

--- a/src/Misc/toHecke.jl
+++ b/src/Misc/toHecke.jl
@@ -40,16 +40,16 @@ end
 # use as include(...)
 ################################################################################
 function to_hecke(io::IOStream, A::fmpz_mat; name = "A")
-  println(io, name, " = MatrixSpace(FlintZZ, ", nrows(A), ", ", ncols(A), ")([")
+  println(io, name, " = matrix(FlintZZ, ", nrows(A), ", ", ncols(A), "fmpz[")
   for i = 1:nrows(A)
     for j = 1:ncols(A)
       print(io, A[i,j])
       if j < ncols(A)
-        print(io, " ")
+        print(io, ", ")
       end
     end
     if i<nrows(A)
-      println(io, ";")
+      println(io, ", ")
     end
   end
   println(io, "]);")


### PR DESCRIPTION
  toHecke: fmpz_mat: change format to allow larger matrices
  zassenhaus: allow non-integral (wrt. equation order) factors
  van_hoej: yet another iteration of precision
  qAdicConj: do NOT compute the maximal order....