### PR TITLE
switch to AA's partial fractions

### DIFF
--- a/examples/MPolyFact.jl
+++ b/examples/MPolyFact.jl
@@ -713,8 +713,10 @@ function field(RC::RootCtx, m::MatElem)
       end
     end
 
-    #TODO: allow continue to lift
-    @vtime :AbsFact 1 el = Main.MFactor.lift_prime_power(P*inv(coeff(P, 1)), el, [0], [degree(P, 2)], pr)
+    # lift mod p^1 -> p^pr
+    @vtime :AbsFact 1 (ok, el) = Main.MFactor.lift_prime_power(P*inv(coeff(P, 1)), el, [0], 1, pr)
+    @assert ok  # can fail but should fail for only finitely many p
+
 
     pk = prime(Qq)^pr
 


### PR DESCRIPTION
It would be nice to have some test code for the abs factorer - i.e. examples that currently are supposed to work.

The previous code was doing a power series lift (mod y^d) so all of the coefficients on y^d, y^(d+1),... of the error were junk. The last boolean argument of pfrac controls this.