### PR TITLE
Remove ^(::fmpz, ::fmpz) because of (probable) implementation in Nemo

### DIFF
--- a/src/Misc/Integer.jl
+++ b/src/Misc/Integer.jl
@@ -116,27 +116,6 @@ function (a::FlintIntegerRing)(b::fmpq)
   return deepcopy(numerator(b))
 end
 
-function ^(a::fmpz, k::fmpz)
-  if a == 0
-    if k == 0
-      return fmpz(1)
-    end
-    return fmpz(0)
-  end
- 
-  if a == 1
-    return fmpz(1)
-  end
-  if a == -1
-    if isodd(k)
-      return fmpz(-1)
-    else
-      return fmpz(1)
-    end
-  end
-  return a^Int(k)
-end
-
 function ^(a::fmpq, k::fmpz)
   if a == 0
     if k == 0


### PR DESCRIPTION
See https://github.com/Nemocas/Nemo.jl/pull/985