### PR TITLE
Fix bug in Smith normal form

### DIFF
--- a/src/Misc/Matrix.jl
+++ b/src/Misc/Matrix.jl
@@ -1308,6 +1308,16 @@ function snf_with_transform(A::fmpz_mat, l::Bool = true, r::Bool = true)
     end
   end
 
+  # It might be the case that S was diagonal with negative diagonal entries.
+  for i in 1:min(nrows(S), ncols(S))
+    if S[i, i] < 0
+      if l
+        multiply_column!(L, fmpz(-1), i)
+      end
+      S[i, i] = -S[i, i]
+    end
+  end
+
   if l
     if r
       return S, L, R'

--- a/test/GrpAb/GrpAbFinGen.jl
+++ b/test/GrpAb/GrpAbFinGen.jl
@@ -79,6 +79,11 @@
     @test S.snf == fmpz[45, 0]
     @test codomain(mS) == G
     @test domain(mS) == S
+
+    M = FlintZZ[-4 0; 0 4]
+    G = abelian_group(M)
+    S, mS = @inferred snf(G)
+    @test S.snf == fmpz[4, 4]
   end
 
   @testset "Finiteness" begin


### PR DESCRIPTION
We were passing through diagonal matrices, even if the diagonal had negative entries.