### PR TITLE
Fix bug in isprincipal_fac_elem

### DIFF
--- a/src/NfOrd/Clgp/Map.jl
+++ b/src/NfOrd/Clgp/Map.jl
@@ -392,7 +392,7 @@ function isprincipal_fac_elem(A::NfOrdIdl)
       return true, A.princ_gen_fac_elem
     else
       if isdefined(A, :princ_gen)
-        A.princ_gen_fac_elem = A.princ_gen.elem_in_nf
+        A.princ_gen_fac_elem = FacElem(A.princ_gen.elem_in_nf)
       end
       return true, FacElem(A.princ_gen_fac_elem)
     end

--- a/test/NfOrd/Ideal.jl
+++ b/test/NfOrd/Ideal.jl
@@ -221,5 +221,16 @@
     @test norm(mP) == 7
   end
 
+  @testset "Is principal" begin
+    Qx, x = QQ["x"]
+    f = x^2 - 5
+    K, a = NumberField(f, "a")
+    OK = maximal_order(K)
+    P = first(keys(factor(3 * OK)))
+    fl, x = Hecke.isprincipal_fac_elem(P)
+    @test fl
+    @test OK(evaluate(x)) * OK == P
+  end
+
   include("Ideal/Prime.jl")
 end


### PR DESCRIPTION
If `princ_gen` was already set, there was a conversion missing.