### PR TITLE
Move dense_poly_type from Hecke to AbstractAlgebra and Nemo.

### DIFF
--- a/src/Misc/Poly.jl
+++ b/src/Misc/Poly.jl
@@ -22,34 +22,6 @@ end
 
 ################################################################################
 #
-#  Dense polynomial types
-#
-################################################################################
-
-dense_poly_type(::Type{arb}) = arb_poly
-
-dense_poly_type(::Type{acb}) = acb_poly
-
-dense_poly_type(::Type{fq}) = fq_poly
-
-dense_poly_type(::Type{fq_nmod}) = fq_nmod_poly
-
-dense_poly_type(::Type{gfp_elem}) = gfp_poly
-
-dense_poly_type(::Type{Generic.ResF{fmpz}}) = gfp_fmpz_poly
-
-dense_poly_type(::Type{fmpz}) = fmpz_poly
-
-dense_poly_type(::Type{fmpq}) = fmpq_poly
-
-dense_poly_type(::Type{nmod}) = nmod_poly
-
-dense_poly_type(::Type{Generic.Res{fmpz}}) = fmpz_mod_poly
-
-dense_poly_type(::Type{T}) where {T} = Generic.Poly{T}
-
-################################################################################
-#
 #  Content
 #
 ################################################################################


### PR DESCRIPTION
This is the Hecke counterpart to https://github.com/Nemocas/AbstractAlgebra.jl/pull/845 and https://github.com/Nemocas/Nemo.jl/pull/1047

It is not expected to pass until those are merged.