### PR TITLE
_minkowski_multiple: a fix, some tweaking, and tests

### DIFF
--- a/src/QuadForm/MassQuad.jl
+++ b/src/QuadForm/MassQuad.jl
@@ -1043,6 +1043,8 @@ end
 # Bounds for the orders of the finite subgroups of G(k)
 # It is also in Feit:
 # Finite linear groups and .. Minkowski ... Schur
+#
+# See also http://oeis.org/A053657
 
 # https://mathoverflow.net/questions/15127/the-maximum-order-of-finite-subgroups-in-gln-q?noredirect=1&lq=1
 #
@@ -1061,18 +1063,16 @@ end
 #
 #𝑛=10,𝑊(𝐸8)×𝑊(𝐺2), order 8360755200 (reducible).
 
-function _multiple_of_finite_group_order_glnz(n::Int)
-  return _minkowski_multiple(n)
-end
 
 function _minkowski_multiple(n)
   if n == 1
-    return fmpz(1)
+    return fmpz(2)
   elseif n == 2
     return fmpz(24)
   elseif n == 3
     return fmpz(48)
   else
+    bernoulli_cache(n)
     if isodd(n)
       return 2 * _minkowski_multiple(n - 1)
     else
@@ -1132,6 +1132,10 @@ function _minkowski_multiple(K, n)
   end
   return cand
 end
+
+# Also allow QQ, to allow for more uniform code calling _minkowski_multiple
+_minkowski_multiple(K::FlintRationalField, n) = _minkowski_multiple(n)
+
 
 ################################################################################
 #

--- a/test/QuadForm/MassQuad.jl
+++ b/test/QuadForm/MassQuad.jl
@@ -428,6 +428,18 @@
   @test Hecke._bernoulli_kronecker(1, -1) == -1//2
 end
 
+@testset "Minkowski bound" begin
+  # reference value, taken from http://oeis.org/A053657
+  ref = fmpz[2, 24, 48, 5760, 11520, 2903040, 5806080,
+             1393459200, 2786918400, 367873228800, 735746457600,
+             24103053950976000, 48206107901952000, 578473294823424000,
+             1156946589646848000, 9440684171518279680000,
+             18881368343036559360000, 271211974879377138647040000]
+
+  @test map(Hecke._minkowski_multiple, 1:18) == ref
+  @test map(n -> Hecke._minkowski_multiple(QQ, n), 1:18) == ref
+end
+
 @testset "Exact totally real Dedekind zeta functions" begin
   Qx, x = FlintQQ["x"]
   K, a = quadratic_field(5)


### PR DESCRIPTION
`_minkowski_multiple(1)` is 2 not 1 (there is a 1x1 rational matrix
group of order 2). This also agrees with the formulas.

Call `bernoulli_cache` for a very minor potential performance boost.

Allow `_minkowski_multiple(QQ, n)` as alias for `_minkowski_multiple(n)`,
to make it easier to write code uniformly dealing with both number fields
and the rationals.

Remove unused `_multiple_of_finite_group_order_glnz`
