### PR TITLE
Fix docstring for absolute_simple_field

### DIFF
--- a/src/NumField/NfRel/absolute_field.jl
+++ b/src/NumField/NfRel/absolute_field.jl
@@ -89,9 +89,9 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    absolute_simple_field(L::NumField) -> NumField, Map
+    absolute_simple_field(K::NumField) -> NumField, Map
 
-Given a number field $L$, this function returns an absolute simple number field
+Given a number field $K$, this function returns an absolute simple number field
 $M/\mathbf{Q}$ together with a $\mathbf{Q}$-linear isomorphism $M \to K$.
 """
 absolute_simple_field(::NumField)


### PR DESCRIPTION
The argument was named L but the text referenced also K. I am guessing those are the same. Since all actual methods I saw for this function call their first parameter `K` and not `L`, I chose to replace `L` by `K` instead of the other way around.