### PR TITLE
fix documentation typo for quadratic_field

### DIFF
--- a/src/NumField/NfAbs/NfAbs.jl
+++ b/src/NumField/NfAbs/NfAbs.jl
@@ -121,7 +121,7 @@ end
 @doc Markdown.doc"""
     quadratic_field(d::Union{fmpz, Integer}) -> AnticNumberField, nf_elem
 
-Returns the field with defining polynomial $x^n -d$.
+Returns the field with defining polynomial $x^2 - d$.
 
 # Examples
 


### PR DESCRIPTION
A quadratic field extension should have a polynomial of degree 2, not n.

I found the typo here: https://oscar-system.github.io/Oscar.jl/stable/Hecke/number_fields/fields/#quadratic_field-Tuple{fmpz}