### PR TITLE
norm_or_resultant_does_not_terminate

### DIFF
--- a/src/LocalField/Poly.jl
+++ b/src/LocalField/Poly.jl
@@ -553,7 +553,7 @@ function _resultant(f::Generic.Poly{T}, g::Generic.Poly{T}) where T <: Union{pad
   res1 = _resultant(f, g2)
   g1r = reverse(g1)
   fr = reverse(f)
-  res2 = (-1)^(degree(f)*degree(g1))*(constant_coefficient(g1)^(degree(f) - degree(fr)))*_resultant(fr, g1r)
+  res2 = (-1)^(degree(f)*degree(g1))*(constant_coefficient(g1)^(degree(f) - degree(fr)))*_resultant(fr, g1r)   # "_resultant does not terminate while computing norm"
   return res*res1*res2
 end
 


### PR DESCRIPTION
Qx,x = FlintQQ["x"] 
L = number_field(x^6-6*x^4+9*x^2+23)[1] 
P = prime_decomposition(maximal_order(L),23)[1][1] 
lp,mp = Hecke.generic_completion(L,P) 
a = uniformizer(lp) 
Qy,y = PolynomialRing(lp,"y")
 N = Hecke.unramified_extension(y^2+y+1)[1] 
b = basis(N) 
t = N(lp(25304801357238415531813663034458593890092701) *a + lp(17703453641185767478560675776638921282857589))*b[1] +  N(lp(3163365177269430549483795389432007727889393)*a + lp(32556005832220463029604469696352770558999695))*b[2]
 norm(t)  # "the loop of resultant does not terminate!"
 Hecke.resultant(t.data,defining_polynomial(parent(t)))  #"Problem in this fucntion"