### PR TITLE
neq.jl

### DIFF
--- a/src/LocalField/neq.jl
+++ b/src/LocalField/neq.jl
@@ -1,0 +1,216 @@
+#export: degree_relative, random_elem, one_root, norm_equation  
+
+
+degree_relative(L::Hecke.LocalField,K::Hecke.LocalField) = Int(absolute_degree(L)//absolute_degree(K)
+)
+
+ degree_relative(L::Hecke.RelFinField,K:: Hecke.RelFinField)  = Int(absolute_degree(L)//absolute_degree(K))
+degree_relative(L::Hecke.RelFinField,K::FqNmodFiniteField)  = Int(absolute_degree(L)//absolute_degree(K))
+
+degree_relative(L::FqNmodFiniteField, K::Hecke.Nemo.GaloisField)  = Int(absolute_degree(L)//absolute_degree(K))
+
+
+##############################################
+#random element with small coefficients
+##############################################
+
+function random_elem(L::Hecke.LocalField)
+     b = basis(L)
+     n = degree(L)
+     r = [rand(1:5*n) for i in 1:n]
+return sum( [ r[i]*b[i] for i in 1:n])
+end
+
+
+function random_elem(L::FlintQadicField)
+     b = basis_qadic(L)
+     n = degree(L)
+     r = [rand(1:5*n) for i in 1:n]
+return sum( [ r[i]*b[i] for i in 1:n])
+end
+
+
+
+
+
+function one_root( f::fq_nmod_poly, F:: Hecke.RelFinField)
+   g = polynomial(F, [coeff(f,i) for i = 0:degree(f) ] )
+   fac = factor(g)
+   if length(fac)  == 1
+      return []
+   end
+   r = [x for x in fac ][1][1]
+   @assert degree(r) == 1
+return -coeff(r,0)
+end
+
+
+function one_root( f::gfp_poly, F:: FqNmodFiniteField)
+   g = polynomial(F, [coeff(f,i) for i = 0:degree(f) ] )
+   fac = factor(g)
+   if length(fac)  == 1
+      return []
+   end
+   r = [x for x in fac ][1][1]
+   @assert degree(r) == 1
+return -coeff(r,0)
+end
+
+
+
+function one_root( f::Hecke.AbstractAlgebra.Generic.Poly, F:: Hecke.RelFinField)
+   g = polynomial(F, [coeff(f,i) for i = 0:degree(f) ] )
+   fac = factor(g)
+   if length(fac)  == 1
+      return []
+   end
+   r = [x for x in fac ][1][1]
+   @assert degree(r) == 1
+return -coeff(r,0)
+end
+
+function one_root( f::gfp_poly, F:: Hecke.RelFinField)
+   g = polynomial(F, [coeff(f,i) for i = 0:degree(f) ] )
+   fac = factor(g)
+   if length(fac)  == 1
+      return []
+   end
+   r = [x for x in fac ][1][1]
+   @assert degree(r) == 1
+return -coeff(r,0)
+end
+
+
+#########################################################################
+# Alternative way of computing the norm due to some problem in resultant
+#
+##########################################################################
+
+function norm_det(a)
+   L = parent(a)
+   m = matrix([[coeff(a*x, i-1) for i in 1:degree(L)] for x in basis(L)])
+return det(m)
+end
+
+
+######################### norm equation over finite fields ##############
+
+function norm_equation(F::FqNmodFiniteField, b::Union{gfp_elem, fq_nmod})
+    k = parent(b)
+    n = degree_relative(F,k)
+    Qx,x = PolynomialRing(k,"x")
+    Qz,z = PolynomialRing(F,"z")
+    f = polynomial(k,vcat([b],[rand(k) for i = 1:n-1],[1] ) )
+    while !isirreducible(f)
+       f = polynomial(k,vcat([b],[rand(k) for i = 1:n-1],[1] ) )
+    end
+return one_root(f,F)
+end
+
+function norm_equation(F::Hecke.RelFinField, b::gfp_elem)
+    k = parent(b)
+    n = degree_relative(F,k)
+    Qx,x = PolynomialRing(k,"x")
+    Qz,z = PolynomialRing(F,"z")
+    f = polynomial(k,vcat([b],[rand(k) for i = 1:n-1],[1] ) )
+    while !isirreducible(f)
+       f = polynomial(k,vcat([b],[rand(k) for i = 1:n-1],[1] ) )
+    end
+return one_root(f,F)
+end
+
+
+
+function norm_equation(F::Hecke.RelFinField, b::fq_nmod)
+    k = parent(b)
+    n = degree_relative(F,k)
+    Qx,x = PolynomialRing(k,"x")
+    Qz,z = PolynomialRing(F,"z")
+    f = polynomial(k,vcat([b],[rand(k) for i = 1:n-1],[1] ) )
+    while !isirreducible(f)
+       f = polynomial(k,vcat([b],[rand(k) for i = 1:n-1],[1] ) )
+    end
+return one_root(f,F)
+end
+
+
+
+
+function norm_equation(R:: Hecke.LocalField, b::Union{qadic,Hecke.LocalFieldElem})
+   K = parent(b)
+   prec_b = precision(b)
+   @assert base_field(R) == K  #"since trace(a,_)" is not defiend"
+   f,mf = ResidueField(K);
+   F,mF = ResidueField(R);
+   ee = absolute_ramification_index(K)
+   if degree(R) == ramification_index(R) && mf(b) !=f(1)
+     return "To be implemented"
+   end
+   if mf(b) == f(1)
+      f_nm = R(1)
+   else
+      f_nm = norm_equation(F,mf(b))
+      f_nm = mF\(f_nm)
+   end
+   b = b //norm((f_nm))
+   b = setprecision(b,prec_b)
+   p = prime(R)
+  # @assert valuation(b-1) > e//(p-1)
+   if valuation(b-1) < ee//(p-1)+1//ee
+     return "To be implemented or try norm_equation_unramified"
+   end
+   r = random_elem(R);
+   while valuation(trace(r)) != 0 ||  valuation(r // R(trace(r))) != 0
+         r = random_elem(R);
+   end
+   s = r *R(trace(r)^-1) * R(log(b))
+return exp(s)*f_nm
+end
+
+
+############### ##############################################
+#   once the problem of norm using "resultant" is solved we can replace norm_det by norm
+##############################################################
+
+function norm_equation_unramified(L::Hecke.LocalField, b::Hecke.LocalFieldElem)
+   K = parent(b)
+   @assert degree(L) == inertia_degree(L)
+   prec_b = precision(b)
+   piK = uniformizer(K);
+   piL = uniformizer(L);
+   f,mf = ResidueField(K);
+   F,mF = ResidueField(L);
+   ee = absolute_ramification_index(K)
+   if mf(b) == f(1)
+      f_nm = L(1)
+   else
+      f_nm = norm_equation(F,mf(b))
+      f_nm = mF\(f_nm)
+   end
+   b = b //norm((f_nm))
+   b = setprecision(b,prec_b)
+   c = L(1)
+   C = [L(1)]
+   n = ee*valuation((b //  norm_det(C[1]))-1)
+   r = random_elem(L);
+   while valuation(trace(r)) != 0 ||  valuation(r // L(trace(r))) != 0
+         r = random_elem(L);
+   end
+   z = ((b // norm_det(c))-1) // piK^ZZ(n);
+   push!(C, 1+ piL^ZZ(n)* (L(z)*r // L(trace(r))));
+   c = prod(C)
+   n = ee*valuation( (b// norm_det(c))-1);
+   while prec_b >= n+2 #   == n 
+         z = ((b // norm_det(c))-1) * piK^-ZZ(n);
+         push!(C, 1+ piL^ZZ(n)* (L(z)*r // L(trace(r))));
+         c = prod(C);
+         chk = (norm_det(c) * b^-1)-1
+         if iszero(chk) == true
+            n = prec_b
+         else
+            n = ee*valuation((b// norm_det(c))-1);
+         end
+    end
+return c*f_nm;
+end
+


### PR DESCRIPTION
norm equations over finite and local fields extensions:

[3] L = number_field(x^6-6*x^4+9*x^2+23)[1]
[4] P = prime_decomposition(maximal_order(L),23)[1][1]
[5] lp,mp = Hecke.generic_completion(L,P)
[6] a = uniformizer(lp)
[7] Qy,y = PolynomialRing(lp,"y")
[8] N = Hecke.unramified_extension(y^2+y+1)[1]
[9] #include("neq.jl")
[10] b=21*(1+uniformizer(lp))
[11] norm_equation(N,(b))
[12] norm_equation_unramified(N,b)
[13] norm_det(ans)*b^-1-1 ##norm_det is a norm function using matrix representation
[14] f,mf = ResidueField(lp);
[15] F,mF = ResidueField(N);
[16] norm_equation(F,f(21))
[17] norm(ans) == f(21)
[18] Hecke.percent_P()
[19] k= base_field(lp)
[20] b=(1+uniformizer(k)^3)
[21] norm_equation(lp,b)
[22] norm_det(ans)*b^-1-1
[23] Hecke.percent_P()

