### PR TITLE
Hack around non-existing matrices for noncommutative rings (Fixes #419)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [compat]
-AbstractAlgebra = "^0.22.0"
+AbstractAlgebra = "^0.22.1"
 Nemo = "^0.27.0"
 RandomExtensions = "0.4.3"
 Requires = "^0.5.2, 1.0"

--- a/src/AlgAss/AlgMat.jl
+++ b/src/AlgAss/AlgMat.jl
@@ -319,7 +319,7 @@ If `isbasis` is `true`, it is assumed that the given matrices are an $R$-basis
 of this algebra, i. e. that the spanned $R$-module is closed under
 multiplication.
 """
-function matrix_algebra(R::Ring, S::Ring, gens::Vector{<:MatElem}; isbasis::Bool = false)
+function matrix_algebra(R::AbstractAlgebra.NCRing, S::AbstractAlgebra.NCRing, gens::Vector{<:MatElem}; isbasis::Bool = false)
   @assert length(gens) > 0
   A = AlgMat{elem_type(R), dense_matrix_type(elem_type(S))}(R, S)
   A.degree = nrows(gens[1])

--- a/src/AlgAss/AlgMatElem.jl
+++ b/src/AlgAss/AlgMatElem.jl
@@ -245,17 +245,17 @@ function (A::AlgMat{T, S})(M::S) where { T, S }
   return AlgMatElem{T, typeof(A), S}(A, deepcopy(M))
 end
 
-function (A::AlgMat{T, S})(a::T) where { T, S }
-  return a*one(A)
-end
-
-function (A::AlgMat)(x::fmpz)
-  return x * one(A)
-end
-
-function (A::AlgMat)(x::Integer)
-  return x * one(A)
-end
+#function (A::AlgMat{T, S})(a::T) where { T, S }
+#  return a*one(A)
+#end
+#
+#function (A::AlgMat)(x::fmpz)
+#  return x * one(A)
+#end
+#
+#function (A::AlgMat)(x::Integer)
+#  return x * one(A)
+#end
 
 function (A::AlgMat{T, S})(v::Vector{T}) where { T, S }
   @assert length(v) == dim(A)

--- a/src/AlgAss/Types.jl
+++ b/src/AlgAss/Types.jl
@@ -342,3 +342,13 @@ mutable struct AlgMatElem{T, S, Mat} <: AbsAlgAssElem{T}
     return z
   end
 end
+
+################################################################################
+#
+#  Polynomial ring hack
+#
+################################################################################
+
+function AbstractAlgebra.PolynomialRing(A::AbsAlgAss, s::Symbol; cached::Bool = true)
+  return invoke(Generic.PolynomialRing, Tuple{AbstractAlgebra.NCRing, Symbol}, A, s; cached = cached)
+end

--- a/src/AlgAssAbsOrd/Conjugacy/Conjugacy.jl
+++ b/src/AlgAssAbsOrd/Conjugacy/Conjugacy.jl
@@ -368,6 +368,8 @@ function _isGLZ_conjugate_integral(A::fmpq_mat, B::fmpq_mat)
   end
 
   OO = Order(AA, ordergens)
+  @show factor(discriminant(OO))
+  @show dim(AA)
   OI = ideal_from_lattice_gens(AA, idealgens)
   @hassert :Conjugacy 1 OO == right_order(OI)
   @vprint :Conjugacy 1 "Testing if ideal is principal...\n"


### PR DESCRIPTION
- AA does not have matrices for noncommutative rings (yet)
- We make our algberas/orders subtypes of Ring (to make matrices work)
- But we want NCPolynomialRing for polynomials over this ring
