### PR TITLE
Fix norm for relative finite fields

### DIFF
--- a/src/LocalField/neq.jl
+++ b/src/LocalField/neq.jl
@@ -32,6 +32,13 @@ function one_root(f::Union{gfp_poly, fq_nmod_poly}, F::Union{FqNmodFiniteField, 
    return -coeff(r,0)
 end
 
+function roots(f::Union{gfp_poly, fq_nmod_poly}, F::Union{FqNmodFiniteField, Hecke.RelFinField})
+   g = polynomial(F, [coeff(f,i) for i = 0:degree(f) ] )
+   fac = factor(g)
+   return [-coeff(r,0) for (r, _) in fac if degree(r) == 1]
+end
+
+
 
 function one_root(f::Hecke.AbstractAlgebra.Generic.Poly, F::Hecke.RelFinField)
    g = polynomial(F, [coeff(f,i) for i = 0:degree(f)])
@@ -48,6 +55,9 @@ end
 ######################### norm equation over finite fields ##############
 
 function norm_equation(F::Union{FqNmodFiniteField, Hecke.RelFinField}, b::Union{gfp_elem, fq_nmod})
+   if iszero(b)
+      return zero(F)
+   end
    k = parent(b)
    n = degree_relative(F,k)
    f = polynomial(k,vcat([b],[rand(k) for i = 1:n-1],[1]))

--- a/src/Misc/RelFiniteField.jl
+++ b/src/Misc/RelFiniteField.jl
@@ -351,7 +351,14 @@ end
 
 #TODO: resultant or conjugates?
 function norm(x::RelFinFieldElem)
-  return resultant(x.data, defining_polynomial(parent(x)))
+  return resultant(defining_polynomial(parent(x)), x.data)
+end
+
+function norm_via_powering(x::RelFinFieldElem)
+  q = order(base_field(parent(x)))
+  n = degree(parent(x))
+  y = x^divexact(q^n - 1, q - 1)
+  return y
 end
 
 function assure_traces(F::RelFinField{T}) where T

--- a/test/Misc/RelFinField.jl
+++ b/test/Misc/RelFinField.jl
@@ -58,7 +58,7 @@
     el1 = @inferred absolute_tr(gL)
     @test iszero(el1)
     @test isone(-tr(gL))
-    @test isone(norm(gL))
+    @test isone(-norm(gL))
     f = @inferred Hecke.absolute_minpoly(gL)
     Fx = parent(f)
     x = gen(Fx)
@@ -68,6 +68,13 @@
     Rx = parent(g)
     y = gen(Rx)
     @test g(y+1) == y^5+y^4+y^2+1
+
+    f, o = FiniteField(7, 2, "o");
+    fx, x = f["x"];
+    F, u = FiniteField(x^3 + o + 4, "u");
+    c = 3*u + 5*o + 1;
+    @test norm(c) == 2*o
+    @test Hecke.norm_via_powering(c) == 2*o
   end
 
   @testset "Absolute basis and coordinates" begin


### PR DESCRIPTION
Apparently the order must be swapped? Can you confirm @fieker?
```Julia
julia> f, o = FiniteField(7, 2, "o");

julia> fx, x = f["x"];

julia> F, u = FiniteField(x^3 + o + 4, "u");

julia> c = 3*u + 5*o + 1;

julia> norm(c)
x.data = 3*x + 5*o + 1
defining_polynomial(parent(x)) = x^3 + o + 4
resultant(x.data, defining_polynomial(parent(x))) = 5*o
5*o

julia> c^(divexact(7^6 - 1, 7^2 - 1))
2*o
```