### PR TITLE
Make matrix(::Vector{Vector{}}) return the correct matrix

### DIFF
--- a/src/LocalField/Conjugates.jl
+++ b/src/LocalField/Conjugates.jl
@@ -340,7 +340,7 @@ function special_gram(m::Vector{Vector{qadic}})
 end
 
 function special_gram(m::Vector{Vector{padic}})
-  n = matrix(m)
+  n = transpose(matrix(m))
   n = n'*n
   return [[n[i,j] for j=1:ncols(n)] for i = 1:nrows(n)]
 end
@@ -357,7 +357,7 @@ In either case, Leopold's conjecture states that the regulator is zero iff the u
 """
 function regulator(u::Vector{T}, C::qAdicConj, n::Int = 10; flat::Bool = true) where {T<: Union{nf_elem, FacElem{nf_elem, AnticNumberField}}}
   c = map(x -> conjugates_log(x, C, n, all = !flat, flat = flat), u)
-  return det(matrix(special_gram(c)))
+  return det(transpose(matrix(special_gram(c))))
 end
 
 function regulator(K::AnticNumberField, C::qAdicConj, n::Int = 10; flat::Bool = false)
@@ -398,7 +398,7 @@ function regulator_iwasawa(R::NfAbsOrd, C::qAdicConj, n::Int = 10)
 end
 
 function matrix(a::Vector{Vector{T}}) where {T}
-  return matrix(hcat(a...))
+  return matrix(permutedims(reduce(hcat, a), (2, 1)))
 end
 
 

--- a/src/NumField/NfAbs/MPolyAbsFact.jl
+++ b/src/NumField/NfAbs/MPolyAbsFact.jl
@@ -749,7 +749,7 @@ function combination(RC::RootCtx)
     R = R .* ld
     @assert precision(R[1]) >= n
 
-    mn = matrix([[Fp(coeff(coeff(x^pow, pow*d+j), lk)) for lk = 0:k-1] for x = R])
+    mn = transpose(matrix([[Fp(coeff(coeff(x^pow, pow*d+j), lk)) for lk = 0:k-1] for x = R]))
 
     if false && iszero(mn)
       @vprint :AbsFact 2 "found zero column, disgarding\n"
@@ -1112,12 +1112,12 @@ function field(RC::RootCtx, m::MatElem)
 
     @vprint :AbsFact 1  "using as number field: $k\n"
 
-    m = matrix([[pe(x)^l for x = fl] for l=0:degree(k)-1])
+    m = transpose(matrix([[pe(x)^l for x = fl] for l=0:degree(k)-1]))
     kx, x = PolynomialRing(k, "x", cached = false)
     kX, _ = PolynomialRing(k, ["X", "Y"], cached = false)
     B = MPolyBuildCtx(kX)
     for j=1:length(el[1])
-      n = matrix([[coeff(x, j)] for x = fl])
+      n = transpose(matrix([[coeff(x, j)] for x = fl]))
       s = solve(m, transpose(n))
       @assert all(x->iszero(coeff(s[x, 1], 1)), 1:degree(k))
       s = [rational_reconstruction(coeff(s[i, 1], 0)) for i=1:degree(k)]


### PR DESCRIPTION
Before:
```julia
julia> matrix(F, [[0, 0], [1, 0]])
[0   0]
[1   0]

julia> matrix([[F(0), F(0)], [F(1), F(0)]])
[0   1]
[0   0]
```
@fieker: This was only used in the conjugate code for local fields and some factorization code. I believe the GModule code in Oscar is also using it wrongly (this is how I found it).