### PR TITLE
rfc: hashing for abelian groups?

### DIFF
--- a/src/GrpAb/GrpAbFinGen.jl
+++ b/src/GrpAb/GrpAbFinGen.jl
@@ -265,15 +265,7 @@ end
 #
 ################################################################################
 
-hash_snf(A::GrpAbFinGen, h::UInt) = hash(A.snf, h)
-
-function hash(A::GrpAbFinGen, h::UInt)
-  if issnf(A)
-    return hash_snf(A, h)
-  else
-    return hash_snf(snf(A)[1], h)
-  end
-end
+# We use the default hash, since we use === as == for abelian groups
 
 ################################################################################
 #


### PR DESCRIPTION
This requires some thought:
 - `==` takes the lattice into account, thus will not work with objectid
 - just because groups are isomorphic (same snf) does not render them equal
 - `snf` is (cometimes) slow...