### PR TITLE
Don't print trailing newline in show method for maps

### DIFF
--- a/src/Map/Map.jl
+++ b/src/Map/Map.jl
@@ -21,7 +21,6 @@ function show(io::IO, M::Map)
   print(io, "\nCodomain:\n")
   print(io, "=========\n")
   print(io, codomain(M))
-  print(io, "\n")
 end
 
 function preimage(M::Map{D, C}, a) where {D, C}
@@ -48,7 +47,7 @@ end
 function show(io::IO, M::InverseMap)
   @show_name(io, M)
   println(io, "inverse of")
-  println(io, " ", M.origin)
+  print(io, " ", M.origin)
 end
 
 function pseudo_inv(a::Map)

--- a/src/Map/MapType.jl
+++ b/src/Map/MapType.jl
@@ -216,7 +216,7 @@ function Base.show(io::IO, M::MapFromFunc)
   print(io, " defined by a julia-function")
   if isdefined(M, :g)
 #    println(io, "with inverse by $(M.g)")
-    println(io, " with inverse")
+    print(io, " with inverse")
   end
 end
 
@@ -237,5 +237,3 @@ function Base.inv(M::MapFromFunc)
 end
 
 export MapFromFunc
-
-


### PR DESCRIPTION
`show` is not supposed to include that trailing newline; having it causes extra newlines to be printed. E.g. from some Oscar examples:
```
julia> homogeneous_component(H, D[0])
(H_[0] of dim 2, Map from
H_[0] of dim 2 to H defined by a julia-function with inverse
)

julia>
```