### PR TITLE
Update Elem.jl

### DIFF
--- a/src/LocalField/Elem.jl
+++ b/src/LocalField/Elem.jl
@@ -198,12 +198,12 @@ end
 
 function (K::LocalField{S, T})(a::Integer) where {S <: FieldElem, T <: LocalFieldParameter}
   el =  K(parent(defining_polynomial(K))(a))
-  return setprecision!(el, precision(K))
+  return el
 end
 
 function (K::LocalField{S, T})(a::Union{fmpz, fmpq}) where {S <: FieldElem, T <: LocalFieldParameter}
   el =  K(parent(defining_polynomial(K))(a))
-  return setprecision!(el, precision(K))
+  return el
 end
 
 function (K::LocalField{S, T})(a::U) where {U <: Union{padic, qadic}, S <: FieldElem, T <: LocalFieldParameter}


### PR DESCRIPTION
Remove the reduced precision because of the following occur->
K= QadicField(3,2,10)[1]
 Qx,x = PolynomialRing(K);
L=Hecke.eisenstein_extension(x^8+3)[1]
L(3^10) #ior higher power is zero . I think we are working with model with higher powering of uniformizer