### PR TITLE
Don't link to 'latest' versions of docs

### DIFF
--- a/docs/src/function_fields/basics.md
+++ b/docs/src/function_fields/basics.md
@@ -9,4 +9,4 @@ end
 
 For details on creation of rational function fields and extensions thereof, refer to
 the AbstractAlgebra documentation which can be found here
-[https://nemocas.github.io/AbstractAlgebra.jl/latest/function_field/](https://nemocas.github.io/AbstractAlgebra.jl/latest/function_field/).
+<https://nemocas.github.io/AbstractAlgebra.jl/stable/function_field/>.

--- a/docs/src/function_fields/elements.md
+++ b/docs/src/function_fields/elements.md
@@ -6,4 +6,4 @@ CurrentModule = Hecke
 
 For details on element arithmetic in rational function fields and extensions, refer
 to the AbstractAlgebra documentation which can be found at
-[https://nemocas.github.io/AbstractAlgebra.jl/latest/function_field/](https://nemocas.github.io/AbstractAlgebra.jl/latest/function_field/).
+<https://nemocas.github.io/AbstractAlgebra.jl/stable/function_field/>.


### PR DESCRIPTION
These link forms have been deprecated in Documented for a long time now
