### PR TITLE
zero_matrix(Int... -> zero_matrix(::Type{Int}...

### DIFF
--- a/src/QuadForm/Morphism.jl
+++ b/src/QuadForm/Morphism.jl
@@ -1735,7 +1735,7 @@ end
 
 fmpz_mat(M::Matrix{Int}) = matrix(FlintZZ, M)
 
-zero_matrix(Int, r, c) = zeros(Int, r, c)
+zero_matrix(::Type{Int}, r, c) = zeros(Int, r, c)
 
 base_ring(::Vector{Int}) = Int
 


### PR DESCRIPTION
Otherwise it will be interpreted as
```
zero_matrix(Int, r, c) in Hecke at /home/albin/jlpkg/Hecke.jl/src/QuadForm/Morphism.jl:1738
julia> zero_matrix(
```
and not as the type `Int`.