### PR TITLE
remove _representatives_for_equivalence

### DIFF
--- a/src/QuadForm/Quad/Genus.jl
+++ b/src/QuadForm/Quad/Genus.jl
@@ -1258,29 +1258,6 @@ end
 
 # Find a_1,...,a_n in p^n such that for y in p^n we have
 # y = a_i \mod p^m for some i. (\mod = the "quadratic" equivalence)
-function _representatives_for_equivalence(p, n, m)
-  @assert n <= m
-  u = elem_in_nf(uniformizer(p))^n
-  G, mG = local_multiplicative_group_modulo_squares(p)
-  k = ngens(G)
-  reps = typeof(u)[ u * mG(g) for g in G if iszero(g[k])]
-  finer_reps = typeof(u)[reps[1]]
-  for j in 2:length(reps)
-    uu = reps[j]
-    new = true
-    for k in 1:length(finer_reps)
-      if _is_isometric_quadratic(uu, finer_reps[k], p, m)
-        new = false
-        break
-      end
-    end
-    if new
-      push!(finer_reps, uu)
-    end
-  end
-  return finer_reps
-end
-
 function _representatives_for_equivalence_and_witt(p, n, m, c)
   @assert n <= m
   u = elem_in_nf(uniformizer(p))^n


### PR DESCRIPTION
Seems to be superseeded by
`_representatives_for_equivalence_and_witt`