### PR TITLE
Added involution for quadratic extensions

### DIFF
--- a/src/Map/automorphisms.jl
+++ b/src/Map/automorphisms.jl
@@ -185,7 +185,7 @@ function set_automorphisms(K::NfAbsNS, auts::Vector{NfAbsNSToNfAbsNS})
 end
 
 function involution(K::Union{NfRel, AnticNumberField})
-  @assert degree(K) == 2
+  @req degree(K) == 2 "Number field must have degree 2 over its base field"
   a = gen(K)
   A = automorphisms(K)
   if A[1](a) == a

--- a/src/Map/automorphisms.jl
+++ b/src/Map/automorphisms.jl
@@ -184,6 +184,16 @@ function set_automorphisms(K::NfAbsNS, auts::Vector{NfAbsNSToNfAbsNS})
   return nothing
 end
 
+function involution(K::Union{NfRel, AnticNumberField})
+  @assert degree(K) == 2
+  a = gen(K)
+  A = automorphisms(K)
+  if A[1](a) == a
+    return A[2]
+  else 
+    return A[1]
+  end
+end
 
 ################################################################################
 #

--- a/src/QuadForm/Herm/Genus.jl
+++ b/src/QuadForm/Herm/Genus.jl
@@ -393,9 +393,7 @@ function gram_matrix(G::LocalGenusHerm, l::Int)
   E = base_field(G)
   K = base_field(E)
   p = elem_in_nf(p_uniformizer(prime(G)))
-  A = automorphisms(E)
-  _a = gen(E)
-  conj = A[1](_a) == _a ? A[2] : A[1]
+  conj = involution(E)
 
   if !isramified(G)
     return diagonal_matrix([E(p)^i for j in 1:m])
@@ -1337,9 +1335,7 @@ function _hermitian_form_invariants(M)
   E = base_ring(M)
   K = base_field(E)
   @assert degree(E) == 2
-  A = automorphisms(E)
-  a = gen(E)
-  v = A[1](a) == a ? A[2] : A[1]
+  v = involution(E)
 
   @assert M == transpose(_map(M, v))
   d = coeff(det(M), 0) # K(det(M))

--- a/src/QuadForm/Herm/Lattices.jl
+++ b/src/QuadForm/Herm/Lattices.jl
@@ -36,19 +36,12 @@ function hermitian_lattice(K::NumField, B::PMat; gram_ambient_space = nothing, g
     return HermLat(K, gram_ambient_space, B)
   end
   if gram_ambient_space === nothing && gram !== nothing
-    @assert degree(K) == 2
-    A = automorphisms(K)
-    a = gen(K)
-    if A[1](a) == a
-      involution = A[2]
-    else
-      involution = A[1]
-    end
+    involutionL = involution(K)
 
     z = HermLat{typeof(K), typeof(base_field(K)), typeof(gram), typeof(B), morphism_type(typeof(K))}()
     z.pmat = P
     z.gram = gram
-    z.involution = involution
+    z.involution = involutionL
     z.base_algebra = K
     return z
   end
@@ -74,20 +67,13 @@ function hermitian_lattice(K::NumField, B::MatElem; gram_ambient_space = nothing
     return HermLat(K, gram_ambient_space, pseudo_matrix(B))
   end
   if gram_ambient_space === nothing && gram !== nothing
-    @assert degree(K) == 2
-    A = automorphisms(K)
-    a = gen(K)
-    if A[1](a) == a
-      involution = A[2]
-    else
-      involution = A[1]
-    end
+    involutionL = involution(K)
 
     P = pseudo_matrix(B)
     z = HermLat{typeof(K), typeof(base_field(K)), typeof(B), typeof(P), morphism_type(typeof(K))}()
     z.pmat = P
     z.gram = gram
-    z.involution = involution
+    z.involution = involutionL
     z.base_algebra = K
     return z
   end

--- a/src/QuadForm/Herm/Spaces.jl
+++ b/src/QuadForm/Herm/Spaces.jl
@@ -43,18 +43,11 @@ function hermitian_space(E::NumField, gram::MatElem; cached::Bool = true)
     end
   end
 
-  @assert degree(E) == 2
-  A = automorphisms(E)
-  a = gen(E)
-  if A[1](a) == a
-    involution = A[2]
-  else
-    involution = A[1]
-  end
+  involutionV = involution(E)
 
   K = base_field(E)
 
-  return HermSpace(E, K, gramc, involution, cached)
+  return HermSpace(E, K, gramc, involutionV, cached)
 end
 
 ################################################################################

--- a/src/QuadForm/Herm/Types.jl
+++ b/src/QuadForm/Herm/Types.jl
@@ -19,22 +19,15 @@
   end
 
   function HermLat(E::S, G::U, P::V) where {S, U, V}
-    @assert degree(E) == 2
-    A = automorphisms(E)
-    a = gen(E)
-    if A[1](a) == a
-      involution = A[2]
-    else
-      involution = A[1]
-    end
+    involutionL = involution(E)
 
     K = base_field(E)
 
     space = hermitian_space(E, G)
 
-    z = new{S, typeof(K), U, V, typeof(involution)}(space, P)
+    z = new{S, typeof(K), U, V, typeof(involutionL)}(space, P)
     z.base_algebra = E
-    z.involution = involution
+    z.involution = involutionL
     return z
   end
 

--- a/src/QuadForm/Misc.jl
+++ b/src/QuadForm/Misc.jl
@@ -186,7 +186,7 @@ function preimage(f::NfToNfRel, I::NfRelOrdIdl)
   return preimage(f, I, OK)
 end
 
-function image(S::T, A::NfOrdFracIdl) where {T <: Map}
+function image(S::T, A::NfOrdFracIdl) where {T <: Hecke.NumFieldMor}
   return S(numerator(A))//denominator(A)
 end
 

--- a/test/Map/NumField.jl
+++ b/test/Map/NumField.jl
@@ -2,10 +2,13 @@
   # AnticNumberField -> AnticNumberField
   Qx, x = FlintQQ["x"]
   K, a = NumberField(x^2 - 2, "a")
+  s = involution(K)
 
   f = @inferred hom(K, K, -a)
   @test f(a) == -a
   @test f\(-a) == a
+  @test s(s(a)) == a
+  @test f == s
 
   for i in 1:10
     z = rand(K, -2:2)
@@ -37,6 +40,7 @@
   f = @inferred hom(k, K, a^3)
   @test_throws ErrorException hom(k, K, a)
   @test f(b) == a^3
+  @test_throws AssertionError s = involution(K)
 
   h = @inferred id_hom(K)
   l = @inferred f * h

--- a/test/Map/NumField.jl
+++ b/test/Map/NumField.jl
@@ -40,7 +40,7 @@
   f = @inferred hom(k, K, a^3)
   @test_throws ErrorException hom(k, K, a)
   @test f(b) == a^3
-  @test_throws AssertionError s = involution(K)
+  @test_throws ArgumentError s = involution(K)
 
   h = @inferred id_hom(K)
   l = @inferred f * h

--- a/test/QuadForm/Herm/Spaces.jl
+++ b/test/QuadForm/Herm/Spaces.jl
@@ -4,6 +4,7 @@
   Kt, t = K["t"]
 
   E, b = NumberField(t^2 + 3)
+  s = involution(E)
 
   F = GF(3)
 
@@ -17,4 +18,5 @@
   @test V === hermitian_space(E, FlintQQ[1 2; 2 1])
   @test V !== hermitian_space(E, FlintQQ[1 2; 2 1], cached = false)
   @test V isa Hecke.HermSpace
+  @test involution(V) == s
 end


### PR DESCRIPTION
Up to now, we get the involution of a quadratic extension only via a `HermLat` or a `HermSpace`. I made available directly for any quadratic extensions and uses this function to create the involutions associated to `HermLat` and `HermSpace`. It seems to be more intuitive to get the involution directly from the field.