### PR TITLE
Fix: isupper_triangular

### DIFF
--- a/src/Misc/Matrix.jl
+++ b/src/Misc/Matrix.jl
@@ -1426,7 +1426,7 @@ end
 function isupper_triangular(M::MatElem)
   n = nrows(M)
   for i = 2:n
-    for j = 1:max(i-1, ncols(M))
+    for j = 1:min(i-1, ncols(M))
       if !iszero(M[i, j])
         return false
       end


### PR DESCRIPTION
isupper_triangular should check matrix M row i only up to min(i-1,ncols(M)), not max(i-1, ncols(M)) which would be until the end of the row for small i. (bug found while debbuging pAdicSolver with Avi)