### PR TITLE
Fix definitness + tests for HermSpace

### DIFF
--- a/src/QuadForm/Herm/Genus.jl
+++ b/src/QuadForm/Herm/Genus.jl
@@ -925,10 +925,6 @@ function ==(G1::LocalGenusHerm, G2::LocalGenusHerm)
     return false
   end
 
-  if any(i -> (rank(G1, i) != rank(G2, i)), 1:t)
-    return false
-  end
-
   if !isramified(G1) # split or unramified
     return true
     # Everything is normal and the Jordan decomposition types agree

--- a/src/QuadForm/Herm/Mass.jl
+++ b/src/QuadForm/Herm/Mass.jl
@@ -135,7 +135,8 @@ end
 
 function _local_factor_generic(L::HermLat, p)
   K = fixed_field(L)
-  def = isdefinite(L)
+  a = _isdefinite(rational_span(L))
+  def = !iszero(a)
   S = base_ring(L)
   lp = prime_decomposition(S, p)
   P = lp[1][1]

--- a/src/QuadForm/Herm/Mass.jl
+++ b/src/QuadForm/Herm/Mass.jl
@@ -135,8 +135,7 @@ end
 
 function _local_factor_generic(L::HermLat, p)
   K = fixed_field(L)
-  a = _isdefinite(rational_span(L))
-  def = !iszero(a)
+  def = isdefinite(L)
   S = base_ring(L)
   lp = prime_decomposition(S, p)
   P = lp[1][1]

--- a/src/QuadForm/Herm/Spaces.jl
+++ b/src/QuadForm/Herm/Spaces.jl
@@ -44,7 +44,7 @@ function hermitian_space(E::NumField, gram::MatElem; cached::Bool = true)
 
   involutionV = involution(E)
 
-  gramc == transpose(matrix(involutionV.(gramc))) || throw(ArgumentError("$gram must be hermitian"))
+  @req gramc == transpose(map_entries(involutionV, gramc)) "$gram must be hermitian"
 
   K = base_field(E)
 

--- a/src/QuadForm/Herm/Spaces.jl
+++ b/src/QuadForm/Herm/Spaces.jl
@@ -287,7 +287,7 @@ end
 Return whether $U$ is represented by $V$ locally at $\mathfrak p$.
 """
 function islocally_represented_by(U::HermSpace, V::HermSpace, p)
-  if rank(U) < rank(V)
+  if rank(U) > rank(V)
     return false
   elseif rank(U) == rank(V)
     return isisometric(U, V, p)

--- a/src/QuadForm/Herm/Spaces.jl
+++ b/src/QuadForm/Herm/Spaces.jl
@@ -11,7 +11,7 @@ Create the Hermitian space over `K` with dimension `n` and Gram matrix equal to
 the identity matrix. The number field `K` must be a quadratic extension, that
 is, `degree(K) == 2` must hold.
 """
-function hermitian_space(K::NumField, n::Int; cached::Bool = false)
+function hermitian_space(K::NumField, n::Int; cached::Bool = true)
   G = identity_matrix(K, n)
   return hermitian_space(K, G, cached = cached)
 end
@@ -25,7 +25,6 @@ automorphism of `K`. The number field `K` must be a quadratic extension, that
 is, `degree(K) == 2` must hold.
 """
 function hermitian_space(E::NumField, gram::MatElem; cached::Bool = true)
-  # I also need to check if the gram matrix is Hermitian
   if dense_matrix_type(elem_type(typeof(E))) === typeof(gram)
     gramc = gram
   else
@@ -44,6 +43,8 @@ function hermitian_space(E::NumField, gram::MatElem; cached::Bool = true)
   end
 
   involutionV = involution(E)
+
+  gramc == transpose(matrix(involutionV.(gramc))) || throw(ArgumentError("$gram must be hermitian"))
 
   K = base_field(E)
 
@@ -90,7 +91,7 @@ end
 
 isquadratic(V::HermSpace) = false
 
-ishermitian(V::HermSpace) = false
+ishermitian(V::HermSpace) = true
 
 _base_algebra(V::HermSpace) = V.E
 

--- a/src/QuadForm/Spaces.jl
+++ b/src/QuadForm/Spaces.jl
@@ -355,9 +355,13 @@ isisometric(L::AbsSpace, M::AbsSpace, p)
 # Returns an element a != 0 such that a * canonical_basis of V has
 # positive Gram matrix
 function _isdefinite(V::AbsSpace)
-  K = fixed_field(V)
-  R = maximal_order(K)
-  if !istotally_real(K) || (ishermitian(V) && !istotally_complex(K))
+  E = base_ring(V)
+  if isquadratic(V)
+    K = E
+  else
+    K = base_field(E)
+  end
+  if (!istotally_real(K)) || (ishermitian(V) && !istotally_complex(E))
     return zero(K)
   end
   D = diagonal(V)
@@ -384,7 +388,7 @@ function ispositive_definite(V::AbsSpace)
   else
     K = base_field(E)
   end
-  if !istotally_real(K)
+  if (!istotally_real(K)) || (ishermitian(V) && !istotally_complex(E))
     return false
   end
   D = diagonal(V)
@@ -404,7 +408,7 @@ function isnegative_definite(V::AbsSpace)
     K = base_field(E)
   end
 
-  if !istotally_real(K)
+  if (!istotally_real(K)) || (ishermitian(V) && !istotally_complex(E))
     return false
   end
   D = diagonal(V)

--- a/src/QuadForm/Spaces.jl
+++ b/src/QuadForm/Spaces.jl
@@ -356,11 +356,7 @@ isisometric(L::AbsSpace, M::AbsSpace, p)
 # positive Gram matrix
 function _isdefinite(V::AbsSpace)
   E = base_ring(V)
-  if isquadratic(V)
-    K = E
-  else
-    K = base_field(E)
-  end
+  K = fixed_field(V)
   if (!istotally_real(K)) || (ishermitian(V) && !istotally_complex(E))
     return zero(K)
   end

--- a/src/QuadForm/Spaces.jl
+++ b/src/QuadForm/Spaces.jl
@@ -379,11 +379,7 @@ end
 
 function ispositive_definite(V::AbsSpace)
   E = base_ring(V)
-  if isquadratic(V)
-    K = E
-  else
-    K = base_field(E)
-  end
+  K = fixed_field(V)
   if (!istotally_real(K)) || (ishermitian(V) && !istotally_complex(E))
     return false
   end
@@ -398,12 +394,7 @@ end
 
 function isnegative_definite(V::AbsSpace)
   E = base_ring(V)
-  if isquadratic(V)
-    K = E
-  else
-    K = base_field(E)
-  end
-
+  K = fixed_field(V)
   if (!istotally_real(K)) || (ishermitian(V) && !istotally_complex(E))
     return false
   end

--- a/test/QuadForm/Herm/Spaces.jl
+++ b/test/QuadForm/Herm/Spaces.jl
@@ -25,7 +25,7 @@
   @test V !== hermitian_space(E, 3, cached = false)
 
   @test_throws ArgumentError hermitian_space(E, E[1 b; b 1])
-  @test_throws ArgumentError hermitian_space(E, FlintQQ[1 0, 1 1])
+  @test_throws ArgumentError hermitian_space(E, FlintQQ[1 0; 1 1])
 
   V = @inferred hermitian_space(E, FlintQQ[1 2; 2 1])
   @test V === hermitian_space(E, FlintQQ[1 2; 2 1])
@@ -38,13 +38,13 @@
   U = hermitian_space(E, E[a 1; 1 1])
   V = hermitian_space(E, E[0 1; 1 0])
   W = hermitian_space(E, E[0 1 0; 1 0 0; 0 0 1])
-  @test !islocally_hyperbolic(U,p)
-  @test !isisotropic(U,p)
-  @test islocally_hyperbolic(V,p)
-  @test isisotropic(V,p)
-  @test !islocally_hyperbolic(W,p)
-  @test isisotropic(W,p)
-  @test_throws AssertionError islocally_hyperbolic(V, 2*OK)
+  @test !Hecke.islocally_hyperbolic(U,p)
+  @test !Hecke.isisotropic(U,p)
+  @test Hecke.islocally_hyperbolic(V,p)
+  @test Hecke.isisotropic(V,p)
+  @test !Hecke.islocally_hyperbolic(W,p)
+  @test Hecke.isisotropic(W,p)
+  @test_throws AssertionError Hecke.islocally_hyperbolic(V, 2*OK)
 
   K, a = rationals_as_number_field()
   OK = maximal_order(K)
@@ -53,19 +53,16 @@
   E, b = NumberField(t^2+17)
 
   p = 2*OK
-  q = 17*ok
+  q = 17*OK
 
   V = hermitian_space(E, E[102 b; -b 0])
   H = hermitian_space(E, E[0 1; 1 0])
   W = hermitian_space(E, E[1 1 2; 1 2 3; 2 3 1])
-  for r in [2,17]
-    @test isisometric(V,H,r)
-  end
   for r in [p,q]
-    @test islocally_represented_by(V,H,r)
+    @test Hecke.islocally_represented_by(V,H,r)
   end
-  @test isrepresented_by(V,H)
-  @test !islocally_representeded_by(W,V,p)
-  @test !represented_by(W,V)
+  @test Hecke.isrepresented_by(V,H)
+  @test !Hecke.islocally_represented_by(W,V,p)
+  @test !Hecke.isrepresented_by(W,V)
 
 end

--- a/test/QuadForm/Herm/Spaces.jl
+++ b/test/QuadForm/Herm/Spaces.jl
@@ -1,6 +1,8 @@
 @testset "Spaces" begin
   Qx, x = PolynomialRing(FlintQQ, "x")
   K, a = NumberField(x^2 - 2, "a1")
+  OK = maximal_order(K)
+  p = 3*OK
   Kt, t = K["t"]
 
   E, b = NumberField(t^2 + 3)
@@ -14,9 +16,56 @@
   Hecke.change_base_ring(::Hecke.NfRel, x::Hecke.gfp_mat) = x
   @test_throws ErrorException hermitian_space(E, F[1 2; 2 1])
 
+  V = @inferred hermitian_space(E, 3)
+  @test fixed_field(V) == base_field(E)
+  @test sprint(show, V) isa String
+  @test !isquadratic(V)
+  @test ispositive_definite(V)
+  @test gram_matrix(V) == identity_matrix(E,3)
+  @test V !== hermitian_space(E, 3, cached = false)
+
+  @test_throws ArgumentError hermitian_space(E, E[1 b; b 1])
+  @test_throws ArgumentError hermitian_space(E, FlintQQ[1 0, 1 1])
+
   V = @inferred hermitian_space(E, FlintQQ[1 2; 2 1])
   @test V === hermitian_space(E, FlintQQ[1 2; 2 1])
   @test V !== hermitian_space(E, FlintQQ[1 2; 2 1], cached = false)
-  @test V isa Hecke.HermSpace
+  @test ishermitian(V)
+  @test !isdefinite(V)
   @test involution(V) == s
+  @test det(V) == -discriminant(V)
+
+  U = hermitian_space(E, E[a 1; 1 1])
+  V = hermitian_space(E, E[0 1; 1 0])
+  W = hermitian_space(E, E[0 1 0; 1 0 0; 0 0 1])
+  @test !islocally_hyperbolic(U,p)
+  @test !isisotropic(U,p)
+  @test islocally_hyperbolic(V,p)
+  @test isisotropic(V,p)
+  @test !islocally_hyperbolic(W,p)
+  @test isisotropic(W,p)
+  @test_throws AssertionError islocally_hyperbolic(V, 2*OK)
+
+  K, a = rationals_as_number_field()
+  OK = maximal_order(K)
+  Kt, t = K["t"]
+
+  E, b = NumberField(t^2+17)
+
+  p = 2*OK
+  q = 17*ok
+
+  V = hermitian_space(E, E[102 b; -b 0])
+  H = hermitian_space(E, E[0 1; 1 0])
+  W = hermitian_space(E, E[1 1 2; 1 2 3; 2 3 1])
+  for r in [2,17]
+    @test isisometric(V,H,r)
+  end
+  for r in [p,q]
+    @test islocally_represented_by(V,H,r)
+  end
+  @test isrepresented_by(V,H)
+  @test !islocally_representeded_by(W,V,p)
+  @test !represented_by(W,V)
+
 end

--- a/test/QuadForm/Quad/Spaces.jl
+++ b/test/QuadForm/Quad/Spaces.jl
@@ -5,6 +5,7 @@
   @test sprint(show, q) isa String
   @test sprint(show, Hecke.isometry_class(q)) isa String
   @test sprint(show, Hecke.isometry_class(q, 2)) isa String
+  @test isdefinite(q)
 
   Qx, x = PolynomialRing(FlintQQ, "x")
   K1, a1 = NumberField(x^2 - 2, "a1")


### PR DESCRIPTION
There is still a `_isdefinite(V::AbsSpace)`, I don't know whether or not it has to stay or if we can remove it regarding that we have the other functions below... seems to be a function created before `istotally_positive` and `istotally_negative`. Yet, this first one return -1, 0 or 1, instead of boolean, so maybe it has a purpose somewhere. I don't know.