### PR TITLE
Use `get_cached!` some more, changing semantics a bit

### DIFF
--- a/src/AlgAss/Types.jl
+++ b/src/AlgAss/Types.jl
@@ -155,48 +155,42 @@ mutable struct AlgGrp{T, S, R} <: AbsAlgAss{T}
   end
 
   function AlgGrp(K::Ring, G; op = *, cached = true)
-    if cached && haskey(AlgGrpDict, (K, G, op))
-      return AlgGrpDict[(K, G, op)]::AlgGrp{elem_type(K), typeof(G), elem_type(G)}
-    end
+    return get_cached!(AlgGrpDict, (K, G, op), cached) do
+      A = new{elem_type(K), typeof(G), elem_type(G)}()
+      A.iscommutative = 0
+      A.issimple = 0
+      A.issemisimple = 0
+      A.base_ring = K
+      A.group = G
+      d = Int(order(G))
+      A.group_to_base = Dict{elem_type(G), Int}()
+      A.base_to_group = Dict{Int, elem_type(G)}()
+      A.mult_table = zeros(Int, d, d)
 
-    A = new{elem_type(K), typeof(G), elem_type(G)}()
-    A.iscommutative = 0
-    A.issimple = 0
-    A.issemisimple = 0
-    A.base_ring = K
-    A.group = G
-    d = Int(order(G))
-    A.group_to_base = Dict{elem_type(G), Int}()
-    A.base_to_group = Dict{Int, elem_type(G)}()
-    A.mult_table = zeros(Int, d, d)
-
-    for (i, g) in enumerate(G)
-      A.group_to_base[deepcopy(g)] = i
-      A.base_to_group[i] = deepcopy(g)
-    end
-
-    v = Vector{elem_type(K)}(undef, d)
-    for i in 1:d
-      v[i] = zero(K)
-    end
-    v[1] = one(K)
-
-    A.one = v
-
-    for (i, g) in enumerate(G)
-      for (j, h) in enumerate(G)
-        l = op(g, h)
-        A.mult_table[i, j] = A.group_to_base[l]
+      for (i, g) in enumerate(G)
+        A.group_to_base[deepcopy(g)] = i
+        A.base_to_group[i] = deepcopy(g)
       end
-    end
 
-    @assert all(A.mult_table[1, i] == i for i in 1:dim(A))
+      v = Vector{elem_type(K)}(undef, d)
+      for i in 1:d
+        v[i] = zero(K)
+      end
+      v[1] = one(K)
 
-    if cached
-      AlgGrpDict[(K, G, op)] = A
-    end
+      A.one = v
 
-    return A
+      for (i, g) in enumerate(G)
+        for (j, h) in enumerate(G)
+          l = op(g, h)
+          A.mult_table[i, j] = A.group_to_base[l]
+        end
+      end
+
+      @assert all(A.mult_table[1, i] == i for i in 1:dim(A))
+
+      return A
+    end::AlgGrp{elem_type(K), typeof(G), elem_type(G)}
   end
 end
 

--- a/src/AlgAssAbsOrd/Types.jl
+++ b/src/AlgAssAbsOrd/Types.jl
@@ -35,9 +35,7 @@
 
   function AlgAssAbsOrd{S, T}(A::S) where {S, T}
     # "Default" constructor with default values.
-    O = new{S, T}()
-    O.algebra = A
-    O.dim = dim(A)
+    O = new{S, T}(A, dim(A))
     O.ismaximal = 0
     O.isnice = false
     O.tcontain = FakeFmpqMat(zero_matrix(FlintZZ, 1, dim(A)))
@@ -45,48 +43,36 @@
   end
 
   function AlgAssAbsOrd{S, T}(A::S, M::FakeFmpqMat, Minv::FakeFmpqMat, B::Vector{T}, cached::Bool = false) where {S, T}
-    if cached && haskey(AlgAssAbsOrdID, (A, M))
-      return AlgAssAbsOrdID[(A, M)]::AlgAssAbsOrd{S, T}
-    end
-    O = AlgAssAbsOrd{S, T}(A)
-    O.basis_alg = B
-    O.basis_matrix = M
-    O.basis_mat_inv = Minv
-    if cached
-      AlgAssAbsOrdID[(A, M)] = O
-    end
-    return O
+    return get_cached!(AlgAssAbsOrdID, (A, M), cached) do
+      O = AlgAssAbsOrd{S, T}(A)
+      O.basis_alg = B
+      O.basis_matrix = M
+      O.basis_mat_inv = Minv
+      return O
+    end::AlgAssAbsOrd{S, T}
   end
 
   function AlgAssAbsOrd{S, T}(A::S, M::FakeFmpqMat, cached::Bool = false) where {S, T}
-    if cached && haskey(AlgAssAbsOrdID, (A, M))
-      return AlgAssAbsOrdID[(A, M)]::AlgAssAbsOrd{S, T}
-    end
-    O = AlgAssAbsOrd{S, T}(A)
-    d = dim(A)
-    O.basis_matrix = M
-    O.basis_alg = Vector{T}(undef, d)
-    for i in 1:d
-      O.basis_alg[i] = elem_from_mat_row(A, M.num, i, M.den)
-    end
-    if cached
-      AlgAssAbsOrdID[(A, M)] = O
-    end
-    return O
+    return get_cached!(AlgAssAbsOrdID, (A, M), cached) do
+      O = AlgAssAbsOrd{S, T}(A)
+      d = dim(A)
+      O.basis_matrix = M
+      O.basis_alg = Vector{T}(undef, d)
+      for i in 1:d
+        O.basis_alg[i] = elem_from_mat_row(A, M.num, i, M.den)
+      end
+      return O
+    end::AlgAssAbsOrd{S, T}
   end
 
   function AlgAssAbsOrd{S, T}(A::S, B::Vector{T}, cached::Bool = false) where {S, T}
-    O = AlgAssAbsOrd{S, T}(A)
     M = basis_matrix(B, FakeFmpqMat)
-    if cached && haskey(AlgAssAbsOrdID, (A, M))
-      return AlgAssAbsOrdID[(A, M)]::AlgAssAbsOrd{S, T}
-    end
-    O.basis_alg = B
-    O.basis_matrix = M
-    if cached
-      AlgAssAbsOrdID[(A, M)] = O
-    end
-    return O
+    return get_cached!(AlgAssAbsOrdID, (A, M), cached) do
+      O = AlgAssAbsOrd{S, T}(A)
+      O.basis_alg = B
+      O.basis_matrix = M
+      return O
+    end::AlgAssAbsOrd{S, T}
   end
 end
 

--- a/src/Hecke.jl
+++ b/src/Hecke.jl
@@ -63,6 +63,7 @@ using Requires
 using LinearAlgebra, Markdown, InteractiveUtils, Libdl, Distributed, Printf, SparseArrays, Serialization, Random, Pkg, Test
 
 import AbstractAlgebra
+import AbstractAlgebra: get_cached!
 
 import LinearAlgebra: dot, istriu, nullspace, rank, ishermitian
 

--- a/src/HeckeTypes.jl
+++ b/src/HeckeTypes.jl
@@ -715,25 +715,18 @@ export NfOrd, NfAbsOrd
   end
 
   function NfAbsOrd{S, T}(K::S, x::FakeFmpqMat, xinv::FakeFmpqMat, B::Vector{T}, cached::Bool = false) where {S, T}
-    if cached && haskey(NfAbsOrdID, (K, x))
-      return NfAbsOrdID[(K, x)]::NfAbsOrd{S, T}
-    else
+    return get_cached!(NfAbsOrdID, (K, x), cached) do
       z = NfAbsOrd{S, T}(K)
       n = degree(K)
       z.basis_nf = B
       z.basis_matrix = x
       z.basis_mat_inv = xinv
-      if cached
-        NfAbsOrdID[(K, x)] = z
-      end
-      return z::NfAbsOrd{S, T}
-    end
+      return z
+    end::NfAbsOrd{S, T}
   end
 
   function NfAbsOrd{S, T}(K::S, x::FakeFmpqMat, cached::Bool = false) where {S, T}
-    if cached && haskey(NfAbsOrdID, (K, x))
-      return NfAbsOrdID[(K, x)]::NfAbsOrd{S, T}
-    else
+    return get_cached!(NfAbsOrdID, (K, x), cached) do
       z = NfAbsOrd{S, T}(K)
       n = degree(K)
       B_K = basis(K)
@@ -743,27 +736,19 @@ export NfOrd, NfAbsOrd
       end
       z.basis_nf = d
       z.basis_matrix = x
-      if cached
-        NfAbsOrdID[(K, x)] = z
-      end
-      return z::NfAbsOrd{S, T}
-    end
+      return z
+    end::NfAbsOrd{S, T}
   end
 
   function NfAbsOrd{S, T}(b::Vector{T}, cached::Bool = false) where {S, T}
     K = parent(b[1])
     A = basis_matrix(b, FakeFmpqMat)
-    if cached && haskey(NfAbsOrdID, (K,A))
-      return NfAbsOrdID[(K,A)]::NfAbsOrd{S, T}
-    else
+    return get_cached!(NfAbsOrdID, (K, A), cached) do
       z = NfAbsOrd{parent_type(T), T}(K)
       z.basis_nf = b
       z.basis_matrix = A
-      if cached
-        NfAbsOrdID[(K, A)] = z
-      end
-      return z::NfAbsOrd{S, T}
-    end
+      return z
+    end::NfAbsOrd{S, T}
   end
 end
 

--- a/src/Misc/OrdLocalization.jl
+++ b/src/Misc/OrdLocalization.jl
@@ -13,15 +13,9 @@ mutable struct OrdLoc{T<:nf_elem} <: Hecke.Ring
    comp::Bool
 
    function OrdLoc{T}(OK::NfAbsOrd{AnticNumberField,T}, prime::NfAbsOrdIdl{AnticNumberField,T}, cached::Bool = true, comp::Bool = false) where {T <: nf_elem}
-      if cached && haskey(OrdLocDict, (OK, prime, comp))
-         return OrdLocDict[OK, prime, comp]::OrdLoc{T}
-      else
-         z = new(OK, prime, comp)
-         if cached
-            OrdLocDict[OK, prime, comp] = z
-         end
-         return z
-      end
+      return get_cached!(OrdLocDict, (OK, prime, comp), cached) do
+         return new(OK, prime, comp)
+      end::OrdLoc{T}
    end
 end
 


### PR DESCRIPTION
This contains PR #567 plus one extra commit. The extra commit uses `get_cached!` in a few more places where it seems sensible; but this time around, semantics change: the old code always tried to get data from the cache, even if `cached` was set to `false`. The new code uses `get_cached!`, and hence will never access the cache when `cached == false`.

I cannot judge whether this is change is OK, or not. If it is not OK, then I suggest that besides closing this PR, also a few comments are added to state explicitly why the behavior is different.