### PR TITLE
Remove _get_fac_elem_mon_of_nf

### DIFF
--- a/src/Hecke.jl
+++ b/src/Hecke.jl
@@ -204,11 +204,6 @@ function __init__()
   global _get_maximal_order_of_nf_rel = t[1]
   global _set_maximal_order_of_nf_rel = t[2]
 
-  t = create_accessors(AnticNumberField, FacElemMon{AnticNumberField}, get_handle())
-
-  global _get_fac_elem_mon_of_nf = t[1]
-  global _set_fac_elem_mon_of_nf = t[2]
-
   t = Hecke.create_accessors(AnticNumberField, Dict{Int, Tuple{qAdicRootCtx, Dict{nf_elem, Any}}}, get_handle())
   global _get_nf_conjugate_data_qAdic = t[1]
   global _set_nf_conjugate_data_qAdic = t[2]

--- a/src/HeckeTypes.jl
+++ b/src/HeckeTypes.jl
@@ -557,21 +557,17 @@ mutable struct FacElemMon{S} <: Ring
     if haskey(FacElemMonDict, R)
       return FacElemMonDict[R]::FacElemMon{AnticNumberField}
     end
-    try
-      F = _get_fac_elem_mon_of_nf(R)::FacElemMon{AnticNumberField}
+    if has_attribute(R, :fac_elem_mon)
+      F = get_attribute(R, :fac_elem_mon)::FacElemMon{AnticNumberField}
       return F
-    catch e
-      if !isa(e, AccessorNotSetError)
-        rethrow(e)
-      end
     end
-    z = new()::FacElemMon{AnticNumberField}
+    z = new{AnticNumberField}()
     z.base_ring = R
     z.basis_conjugates_log = Dict{RingElem, Vector{arb}}()
     z.basis_conjugates = Dict{RingElem, Vector{arb}}()
     z.conj_log_cache = Dict{Int, Dict{nf_elem, arb}}()
     if cached
-      _set_fac_elem_mon_of_nf(R, z)
+      set_attribute!(R, :fac_elem_mon => z)
     end
     return z
   end


### PR DESCRIPTION
This `FacElemMon{AnticNumberField}` constructor is a bit weird. It seems to override the default caching strategy (where `FacElemMonDict` is used to store the cached object) by one where the data is instead stored as an attribute of the given `AnticNumberField`. But it still *also* checks if the required object already exists in `AnticNumberField`...

But the key used is the ring itself, so how could `haskey(FacElemMonDict, R)` ever return `true`? I am tempted to just remove that check

Independently, I wonder: why bother overriding the cache at all in this special case? My guess: because the global `FacElemMonDict` really is a leak. But then perhaps this special case should be extended to all rings that support attribute storage (which we nowadays can check using `_is_attribute_storing_type`. Moreover, perhaps `FacElemMonDict` (and all its relatives) should be changed to use `AbstractAlgebra.CacheDictType`
