### PR TITLE
Replace subgroup by sub

### DIFF
--- a/src/NumFieldOrd/NfOrd/Ideal/Prime.jl
+++ b/src/NumFieldOrd/NfOrd/Ideal/Prime.jl
@@ -1704,7 +1704,7 @@ the domain of `m`.
 """
 function decomposition_group(K::AnticNumberField, P::NfOrdIdl, mG::Map)
   iner = decomposition_group(P)
-  return subgroup(domain(mG), [mG\a for a in iner])
+  return sub(domain(mG), [mG\a for a in iner])
 end
 
 ################################################################################


### PR DESCRIPTION
Completely untested, but `subgroup` does not seem to be defined anywhere? Perhaps I missed something, or perhaps these functions are simply not covered by CI?

Motivated by https://github.com/oscar-system/Oscar.jl/issues/667﻿