### PR TITLE
Fix `mass` for `HermLat` and allow `use_auto`

### DIFF
--- a/src/QuadForm/Herm/Mass.jl
+++ b/src/QuadForm/Herm/Mass.jl
@@ -18,7 +18,6 @@ function _local_factor_dyadic(L::HermLat, p)
   @assert valscale >= 0
   val = div(valscale, 2)
   if !iszero(val)
-    println("line 21")
     s = elem_in_nf(uniformizer(p))
     L = rescale(L, s^(-val))
   end
@@ -44,7 +43,6 @@ function _local_factor_dyadic(L::HermLat, p)
   k1 = div(m1, 2)
 
   if isodd(m)
-    println("line 46")
     return fmpq(1, 2) * _gauss(k, k1, q^2)
   end
 
@@ -61,50 +59,39 @@ function _local_factor_dyadic(L::HermLat, p)
     h1 = m1 == 0 || G[end][4] == 2 * div(e + 1, 2)
     # L_p = H(0)^k0 \perp H(1)^k1
     if h0 && h1
-      println("line 64")
       t = iseven(e) ? k1 : k0
       return (q^t + 1) * lf
     end
 
     if !b
       if iseven(e)
-        println("line 71")
         return q^(m * (f2 - l) - k1) * (q^m1 - 1) * lf
       else
-        println("line 74")
         return q^(m * (f2 - l) + k0) * (q^m1 - 1) * lf
       end
     else
       if iseven(e)
-        println("line 79")
         return q^(m * (f2 - 1 - l) + k1) * (q^m0 - 1) * lf
       else
-        println("line 82")
         return q^(m * (f2 - l ) - k0)    * (q^m0 - 1) * lf
       end
     end
   else # non-hyperbolic case
     if isodd(e)
       if b && l == div(e - 1, 2)
-        println("line 89")
         return (q^k0 - 1) * lf
       elseif b
-        println("line 92")
         return q^(m * (f2 - l) - k0) * (q^m0 - 1) * lf
       else
-        println("line 95")
         return q^(m * (f2 - l) + k0) * (q^m1 - 1) * lf
       end
     end
 
     if b
-      println("line 101")
       return q^(m * (f2 - 1 - l) + k1) * (q^m0 - 1) * lf
     elseif l == div(e, 2) # e is even
-      println("line 104")
-      return q^(k1 - 1) * lf
+      return (q^k1 - 1) * lf
     else
-      println("line 107")
       return q^(m * (f2 - l) - k1) * (q^m1 - 1) * lf
     end
   end
@@ -132,14 +119,11 @@ function _local_factor_maximal(L::HermLat, p)
   if !islocal_norm(E, K(disc), p)
     q = norm(p)
     if ram
-      println("line 135")
       return fmpq(q^m - 1, 2*q + 2)
     else
-      println("line 138")
       return fmpq(q^m - (-1)^m, q + 1)
     end
   end
-  println("line 142")
   return fmpq(1)
 end
 
@@ -213,7 +197,14 @@ end
 #
 ################################################################################
 
+@doc Markdown.doc"""
+    local_factor(L::HermLat, p) -> fmpq
+
+Given a definite hermitian lattice $L$ and a bad prime $p$, return the local density
+of $L$ at $p$.
+"""
 function local_factor(L::HermLat, p)
+  @req isdefinite(L) "Lattice must be definite"
   S = base_ring(L)
   E = nf(S)
   K = base_field(E)
@@ -314,6 +305,11 @@ end
 #
 ################################################################################
 
+@doc Markdown.doc"""
+    mass(L::HermLat) -> fmpq
+
+Given a definite hermitian lattice $L$, return the mass of its genus.
+"""
 function mass(L::HermLat)
   @req isdefinite(L) "Lattice must be definite"
   m = rank(L)
@@ -338,7 +334,14 @@ function mass(L::HermLat)
   end
 end
 
+@doc Markdown.doc"""
+    local_mass(L::HermLat) -> fmpq
+
+Given a definite hermitian lattice $L$, return the product of its local
+densities at the bad primes.
+"""
 function local_mass(L::HermLat)
+  @req isdefinite(L) "Lattice must be definite"
   lf = fmpq(1)
 
   for p in bad_primes(L, discriminant = true)

--- a/src/QuadForm/Herm/Mass.jl
+++ b/src/QuadForm/Herm/Mass.jl
@@ -18,6 +18,7 @@ function _local_factor_dyadic(L::HermLat, p)
   @assert valscale >= 0
   val = div(valscale, 2)
   if !iszero(val)
+    println("line 21")
     s = elem_in_nf(uniformizer(p))
     L = rescale(L, s^(-val))
   end
@@ -43,6 +44,7 @@ function _local_factor_dyadic(L::HermLat, p)
   k1 = div(m1, 2)
 
   if isodd(m)
+    println("line 46")
     return fmpq(1, 2) * _gauss(k, k1, q^2)
   end
 
@@ -59,39 +61,50 @@ function _local_factor_dyadic(L::HermLat, p)
     h1 = m1 == 0 || G[end][4] == 2 * div(e + 1, 2)
     # L_p = H(0)^k0 \perp H(1)^k1
     if h0 && h1
+      println("line 64")
       t = iseven(e) ? k1 : k0
       return (q^t + 1) * lf
     end
 
     if !b
       if iseven(e)
+        println("line 71")
         return q^(m * (f2 - l) - k1) * (q^m1 - 1) * lf
       else
+        println("line 74")
         return q^(m * (f2 - l) + k0) * (q^m1 - 1) * lf
       end
     else
       if iseven(e)
+        println("line 79")
         return q^(m * (f2 - 1 - l) + k1) * (q^m0 - 1) * lf
       else
-        return q^(m * (f2 - 1 ) - k0)    * (q^m0 - 1) * lf
+        println("line 82")
+        return q^(m * (f2 - l ) - k0)    * (q^m0 - 1) * lf
       end
     end
   else # non-hyperbolic case
     if isodd(e)
       if b && l == div(e - 1, 2)
+        println("line 89")
         return (q^k0 - 1) * lf
       elseif b
+        println("line 92")
         return q^(m * (f2 - l) - k0) * (q^m0 - 1) * lf
       else
+        println("line 95")
         return q^(m * (f2 - l) + k0) * (q^m1 - 1) * lf
       end
     end
 
     if b
+      println("line 101")
       return q^(m * (f2 - 1 - l) + k1) * (q^m0 - 1) * lf
     elseif l == div(e, 2) # e is even
+      println("line 104")
       return q^(k1 - 1) * lf
     else
+      println("line 107")
       return q^(m * (f2 - l) - k1) * (q^m1 - 1) * lf
     end
   end
@@ -114,16 +127,19 @@ function _local_factor_maximal(L::HermLat, p)
   if isodd(m) && ram
     return fmpq(1, 2)
   end
-  G = gram_matrix_of_basis(L)
+  G = gram_matrix_of_rational_span(L)
   disc = _discriminant(G)
   if !islocal_norm(E, K(disc), p)
     q = norm(p)
     if ram
+      println("line 135")
       return fmpq(q^m - 1, 2*q + 2)
     else
+      println("line 138")
       return fmpq(q^m - (-1)^m, q + 1)
     end
   end
+  println("line 142")
   return fmpq(1)
 end
 
@@ -204,7 +220,10 @@ function local_factor(L::HermLat, p)
   q = norm(p)
   lp = prime_decomposition(S, p)
   ram = length(lp) == 1 && lp[1][2] == 2
-  if ram && isdyadic(p)
+  if ram && iseven(q)
+    if ismaximal(L,p)[1]
+      return _local_factor_maximal(L, p)
+    end
     lf = _local_factor_dyadic(L, p)
     # TODO: Use Cho's recipe if p unramified over Z.
     if iszero(lf)
@@ -213,7 +232,6 @@ function local_factor(L::HermLat, p)
     end
     return lf
   end
-  lp = prime_decomposition(S, p)
   split = length(lp) > 1 && !ram
   _, G, s = jordan_decomposition(L, p)
   if length(s) == 1 && !ram
@@ -258,7 +276,7 @@ function local_factor(L::HermLat, p)
     N = N + div(m ,2)
   end
 
-  return q^(Int(FlintZZ(N))) * f
+  return fmpq(q)^(Int(FlintZZ(N))) * f
 end
 
 function _standard_mass(L::HermLat, prec::Int = 10)

--- a/src/QuadForm/Herm/Mass.jl
+++ b/src/QuadForm/Herm/Mass.jl
@@ -149,7 +149,7 @@ function _local_factor_generic(L::HermLat, p)
   ss = elem_in_nf(uniformizer(p))^(-val)
 
   if def
-    R = maximal_order(K)
+    R = base_ring(base_ring(L))
     rlp = real_places(K)
     A::GrpAbFinGen, _exp, _log = infinite_primes_map(R, rlp, p)
     sa = ss * a
@@ -211,7 +211,7 @@ function local_factor(L::HermLat, p)
   q = norm(p)
   lp = prime_decomposition(S, p)
   ram = length(lp) == 1 && lp[1][2] == 2
-  if ram && iseven(q)
+  if ram && iseven(q) # p is dyadic and ramified
     if ismaximal(L,p)[1]
       return _local_factor_maximal(L, p)
     end

--- a/src/QuadForm/Herm/Mass.jl
+++ b/src/QuadForm/Herm/Mass.jl
@@ -5,19 +5,19 @@
 ################################################################################
 
 # Returns the local mass factor for dyadic primes
-# The local scales must be be 0 or 1
+# The local scales must be 0 or 1
 # Otherwise the function returns 0
 
 function _local_factor_dyadic(L::HermLat, p)
   @assert isdyadic(p)
   S = base_ring(L)
   E = nf(S)
-  K = base_field(nf(S))
+  K = base_field(E)
   P = prime_decomposition(S, p)[1][1]
   valscale = valuation(scale(L), P)
   @assert valscale >= 0
   val = div(valscale, 2)
-  if !iszero(val )
+  if !iszero(val)
     s = elem_in_nf(uniformizer(p))
     L = rescale(L, s^(-val))
   end
@@ -67,7 +67,7 @@ function _local_factor_dyadic(L::HermLat, p)
       if iseven(e)
         return q^(m * (f2 - l) - k1) * (q^m1 - 1) * lf
       else
-        return q^(m * (f2 - l) - k0) * (q^m1 - 1) * lf
+        return q^(m * (f2 - l) + k0) * (q^m1 - 1) * lf
       end
     else
       if iseven(e)
@@ -149,7 +149,7 @@ function _local_factor_generic(L::HermLat, p)
   ss = elem_in_nf(uniformizer(p))^(-val)
 
   if def
-    R = base_ring(base_ring(L))
+    R = maximal_order(K)
     rlp = real_places(K)
     A::GrpAbFinGen, _exp, _log = infinite_primes_map(R, rlp, p)
     sa = ss * a
@@ -168,9 +168,8 @@ function _local_factor_generic(L::HermLat, p)
   end
   f = _local_factor_maximal(L, p)
   for i in 1:(length(chain) - 1)
-    M, E = maximal_sublattices(chain[i + 1], P, use_auto = false)
+    M, E = maximal_sublattices(chain[i + 1], P, use_auto = def)
     lM = length(M)
-    # should be use_auto = def)
     _f = 0
     for j in 1:lM
       if islocally_isometric(chain[i], M[j], p)
@@ -179,8 +178,7 @@ function _local_factor_generic(L::HermLat, p)
     end
 
     f = f * _f
-    M, E = minimal_superlattices(chain[i], P, use_auto = false)
-    # should be use_auto = def)
+    M, E = minimal_superlattices(chain[i], P, use_auto = def)
     lM = length(M)
     _f = 0
     for j in 1:lM

--- a/src/QuadForm/Herm/Spaces.jl
+++ b/src/QuadForm/Herm/Spaces.jl
@@ -24,7 +24,7 @@ must be square and Hermitian with respect to the non-trivial automorphism of `E`
 The number field `E` must be a quadratic extension, that is, `degree(E) == 2` must hold.
 """
 function hermitian_space(E::NumField, gram::MatElem; cached::Bool = true)
-  @req (E isa NfRel && degree(E) == 2) "E must be a relative number field of degree 2"
+  @req degree(E) == 2 "E must be a quadratic extension"
   if dense_matrix_type(elem_type(typeof(E))) === typeof(gram)
     gramc = gram
   else
@@ -253,25 +253,6 @@ end
 #  Hyperbolic spaces
 #
 ################################################################################
-
-# function _islocally_hyperbolic_hermitian_detclass(rk, d, E, K, p)
-#   if isodd(rk)
-#     return false
-#   end
-#   if d == 1
-#     if iseven(div(rk, 2))
-#       return true
-#     else
-#       return islocal_norm(E, K(-1), p)
-#     end
-#   else
-#     if iseven(div(rk, 2))
-#       return false
-#     else
-#       return !islocal_norm(E, K(-1), p)
-#     end
-#   end
-# end
 
 @doc Markdown.doc"""
     islocally_hyperbolic(V::Hermspace, p) -> Bool

--- a/src/QuadForm/Herm/Spaces.jl
+++ b/src/QuadForm/Herm/Spaces.jl
@@ -150,7 +150,9 @@ end
 #
 ################################################################################
 
-function isisometric(L::HermSpace{AnticNumberField}, M::HermSpace{AnticNumberField}, p::fmpz)
+function isisometric(L::HermSpace, M::HermSpace, p::fmpz)
+  K = fixed_field(L)
+  p = p*maximal_order(K)
   return _isisometric(L, M, p)
 end
 
@@ -176,6 +178,10 @@ end
 function isisometric(L::HermSpace, M::HermSpace, P::InfPlc)
   if L == M
     return true
+  end
+  
+  if rank(L) != rank(M)
+    return false
   end
 
   if iscomplex(P)

--- a/src/QuadForm/Herm/Spaces.jl
+++ b/src/QuadForm/Herm/Spaces.jl
@@ -5,26 +5,26 @@
 ################################################################################
 
 @doc Markdown.doc"""
-    hermitian_space(K::NumField, n::Int; cached = true) -> HermSpace
+    hermitian_space(E::NumField, n::Int; cached = true) -> HermSpace
 
-Create the Hermitian space over `K` with dimension `n` and Gram matrix equal to
-the identity matrix. The number field `K` must be a quadratic extension, that
-is, `degree(K) == 2` must hold.
+Create the Hermitian space over `E` with dimension `n` and Gram matrix equals to
+the identity matrix. The number field `E` must be a quadratic extension, that
+is, `degree(E) == 2` must hold.
 """
-function hermitian_space(K::NumField, n::Int; cached::Bool = true)
-  G = identity_matrix(K, n)
-  return hermitian_space(K, G, cached = cached)
+function hermitian_space(E::NumField, n::Int; cached::Bool = true)
+  G = identity_matrix(E, n)
+  return hermitian_space(E, G, cached = cached)
 end
 
 @doc Markdown.doc"""
-    hermitian_space(E::NumField, G::MatElem; cached = true) -> HermSpace
+    hermitian_space(E::NumField, gram::MatElem; cached = true) -> HermSpace
 
-Create the Hermitian space over `K` with Gram matrix equal to the identity
-matrix. The matrix `G` must be square and Hermitian with respect to the non-trivial
-automorphism of `K`. The number field `K` must be a quadratic extension, that
-is, `degree(K) == 2` must hold.
+Create the Hermitian space over `E` with Gram matrix equals to `gram`. The matrix `gram` 
+must be square and Hermitian with respect to the non-trivial automorphism of `E`. 
+The number field `E` must be a quadratic extension, that is, `degree(E) == 2` must hold.
 """
 function hermitian_space(E::NumField, gram::MatElem; cached::Bool = true)
+  @req (E isa NfRel && degree(E) == 2) "E must be a relative number field of degree 2"
   if dense_matrix_type(elem_type(typeof(E))) === typeof(gram)
     gramc = gram
   else
@@ -223,9 +223,12 @@ end
 #
 ################################################################################
 
-isisotropic(V::HermSpace, p::InfPlc) = _isisotropic(V, p)
+@doc Markdown.doc"""
+    isisotropic(V::Hermspace, q::NumFieldOrdIdl) -> Bool
 
-function isisotropic(V::HermSpace, q)
+Return whether $V$ is locally isotropic at $\mathfrak q$.
+"""
+function isisotropic(V::HermSpace, q::T) where T <: NumFieldOrdIdl
   if nf(order(q)) == base_ring(V)
     p = minimum(q)
   else
@@ -251,25 +254,30 @@ end
 #
 ################################################################################
 
-function _islocally_hyperbolic_hermitian_detclass(rk, d, E, K, p)
-  if isodd(rk)
-    return false
-  end
-  if d == 1
-    if iseven(div(rk, 2))
-      return true
-    else
-      return islocal_norm(E, K(-1), p)
-    end
-  else
-    if iseven(div(rk, 2))
-      return false
-    else
-      return !islocal_norm(E, K(-1), p)
-    end
-  end
-end
+# function _islocally_hyperbolic_hermitian_detclass(rk, d, E, K, p)
+#   if isodd(rk)
+#     return false
+#   end
+#   if d == 1
+#     if iseven(div(rk, 2))
+#       return true
+#     else
+#       return islocal_norm(E, K(-1), p)
+#     end
+#   else
+#     if iseven(div(rk, 2))
+#       return false
+#     else
+#       return !islocal_norm(E, K(-1), p)
+#     end
+#   end
+# end
 
+@doc Markdown.doc"""
+    islocally_hyperbolic(V::Hermspace, p) -> Bool
+
+Return whether $V$ is hyperbolic locally at $\mathfrak p$.
+"""
 function islocally_hyperbolic(V::HermSpace, p)
   rk = rank(V)
   if isodd(rk)
@@ -288,7 +296,7 @@ end
 # Thus there is no restriction to embeddings.
 
 @doc Markdown.doc"""
-    islocally_represented_by(U::HermSpace, V::HermSpace, p)
+    islocally_represented_by(U::HermSpace, V::HermSpace, p) -> Bool
 
 Return whether $U$ is represented by $V$ locally at $\mathfrak p$.
 """
@@ -306,7 +314,7 @@ end
 # rank and determinant.
 
 @doc Markdown.doc"""
-    isrepresented_by(U::HermSpace, V::HermSpace)
+    isrepresented_by(U::HermSpace, V::HermSpace) -> Bool
 
 Return whether $U$ is represented by $V$, that is, whether $U$ embeds into $V$.
 """

--- a/src/QuadForm/Lattices.jl
+++ b/src/QuadForm/Lattices.jl
@@ -1184,12 +1184,13 @@ function maximal_sublattices(L::AbsLat, p; use_auto::Bool = false,
   @req base_ring(L) == order(p) "Incompatible arguments: p must be an ideal in the base ring of L"
 
   B = local_basis_matrix(L, p, type = :submodule)
+  full_rank = rank(matrix(L.pmat)) == Hecke.max(nrows(L.pmat), ncols(L.pmat))
   n = nrows(B)
   R = base_ring(L)
   K = nf(R)
   k, h = ResidueField(R, p)
   hext = extend(h, K)
-  use_auto = isdefinite(L) ? use_auto : false
+  use_auto = (isdefinite(L) && full_rank) ? use_auto : false
 
   if use_auto
     G = automorphism_group_generators(L)
@@ -1246,12 +1247,13 @@ function minimal_superlattices(L::AbsLat, p; use_auto::Bool = false,
   @req base_ring(L) == order(p) "Incompatible arguments: p must be an ideal in the base ring of L"
 
   B = local_basis_matrix(L, p, type = :submodule)
+  full_rank = rank(matrix(L.pmat)) == Hecke.max(nrows(L.pmat), ncols(L.pmat))
   n = nrows(B)
   R = base_ring(L)
   K = nf(R)
   k, h = ResidueField(R, p)
   hext = extend(h, K)
-  use_auto = isdefinite(L) ? use_auto : false
+  use_auto = (isdefinite(L) && full_rank) ? use_auto : false
 
   if use_auto
     G = automorphism_group_generators(L)

--- a/test/QuadForm.jl
+++ b/test/QuadForm.jl
@@ -5,7 +5,6 @@
   include("QuadForm/Morphism.jl")
   include("QuadForm/Enumeration.jl")
   include("QuadForm/MassQuad.jl")
-  include("QuadForm/MassHerm.jl")
   include("QuadForm/Quad.jl")
   include("QuadForm/QuadBin.jl")
   include("QuadForm/Herm.jl")

--- a/test/QuadForm/Genus.jl
+++ b/test/QuadForm/Genus.jl
@@ -2,7 +2,8 @@
 
   # TODO: move the remaining examples in the corresponding files in ~/test/QuadForm/Quad
   # Representatives
-
+  
+  Qx, x = FlintQQ["x"]
   K, a = NumberField(x^2 - 15)
   gens = [[a-1, 2*a-12, 0], [-471//70*a+881//14, 12*a-471, 1//70*a+39//14], [-7367*a+33891, 38904*a-212340, -194*a+1164], [2858191//5*a-1701731, -3700688*a+8438412, 103014//5*a-40352]]
   D = matrix(K, 3, 3, [38*a+150, 0, 0, 0, 2*a+8, 0, 0, 0, 302*a+1170])

--- a/test/QuadForm/Genus.jl
+++ b/test/QuadForm/Genus.jl
@@ -1,76 +1,7 @@
 @testset "Genera" begin
-  K, a = CyclotomicRealSubfield(8, "a")
-  Kt, t = PolynomialRing(K, "t")
-  L, b = number_field(t^2 - gen(K) * t + 1)
-  p = prime_decomposition(maximal_order(K), 2)[1][1]
-  G = @inferred local_genera_hermitian(L, p, 4, 2, 4)
-  @test length(G) == 15
-  for i in 1:length(G)
-    @test rank(G[i]) == 4
-    @test (@inferred representative(G[i])) in G[i]
-  end
 
-  GG = G[1]
-  u = @inferred uniformizer(GG)
-  @assert parent(u) == K
-
-  p = prime_decomposition(maximal_order(K), 17)[1][1]
-  G = @inferred local_genera_hermitian(L, p, 5, 5, 5)
-  @test length(G) == 7
-  for i in 1:length(G)
-    @test rank(G[i]) == 5
-    @test (@inferred representative(G[i])) in G[i]
-  end
-
-  K, a = CyclotomicRealSubfield(8, "a")
-  Kt, t = K["t"]
-  L, b = number_field(t^2 - gen(K) * t + 1)
-  p = prime_decomposition(maximal_order(K), 2)[1][1]
-  l =  Vector{Tuple{Int, Int, Int, Int}}[[(0, 3, 1, 0), (4, 1, 1, 2)],
-       [(0, 3, -1, 0), (4, 1, 1, 2)],
-       [(0, 3, 1, 0), (4, 1, -1, 2)],
-       [(0, 3, -1, 0), (4, 1, -1, 2)],
-       [(0, 2, 1, 0), (2, 2, 1, 1)],
-       [(0, 2, -1, 0), (2, 2, 1, 1)],
-       [(0, 2, 1, 1), (2, 2, 1, 1)],
-       [(0, 2, 1, 0), (2, 2, 1, 2)],
-       [(0, 2, 1, 1), (2, 2, -1, 1)],
-       [(0, 2, -1, 0), (2, 2, 1, 2)],
-       [(0, 2, 1, 1), (2, 2, 1, 2)],
-       [(0, 1, 1, 0), (1, 2, 1, 1), (2, 1, 1, 1)],
-       [(0, 1, -1, 0), (1, 2, 1, 1), (2, 1, 1, 1)],
-       [(1, 4, 1, 1)],
-       [(1, 4, -1, 1)]]
-  # The compiler does not like the following:
-  # Gs = map(x -> genus(HermLat, L, p, x), l)
-  Gs = Hecke.LocalGenusHerm{typeof(L), typeof(p)}[ genus(HermLat, L, p, x) for x in l ]
-  myG = @inferred local_genera_hermitian(L, p, 4, 2, 4)
-  @test length(Gs) == length(myG)
-  @test all(x -> x in Gs, myG)
-  @test all(x -> x in myG, Gs)
-
-  K, a = CyclotomicRealSubfield(8, "a")
-  Kt, t = K["t"]
-  L, b = number_field(t^2 - gen(K) * t + 1)
-  rlp = real_places(K)
-  G = @inferred genera_hermitian(L, 3, Dict(rlp[1] => 1, rlp[2] => 1), 100 * maximal_order(L))
-  for i in 1:10
-    g1 = rand(G)
-    g2 = rand(G)
-    M, = @inferred orthogonal_sum(representative(g1), representative(g2))
-    @test M in (g1 + g2)
-  end
-
+  # TODO: move the remaining examples in the corresponding files in ~/test/QuadForm/Quad
   # Representatives
-
-  Qx, x = FlintQQ["x"]
-  K, a = NumberField(x - 1, "a")
-  Kt, t = K["t"]
-  E, b = NumberField(t^2 + 1, "b")
-  p = prime_decomposition(maximal_order(K), 2)[1][1]
-  G = genus(HermLat, E, p, [(0, 3, -1, 0)])
-  L = @inferred representative(G)
-  @test length(@inferred Hecke.genus_representatives(L)) == 1
 
   K, a = NumberField(x^2 - 15)
   gens = [[a-1, 2*a-12, 0], [-471//70*a+881//14, 12*a-471, 1//70*a+39//14], [-7367*a+33891, 38904*a-212340, -194*a+1164], [2858191//5*a-1701731, -3700688*a+8438412, 103014//5*a-40352]]
@@ -109,28 +40,6 @@
 
   # Addition of genera
 
-  K, a = CyclotomicRealSubfield(8, "a")
-  Kt, t = PolynomialRing(K, "t")
-  L, b = number_field(t^2 - gen(K) * t + 1)
-
-  p = prime_decomposition(maximal_order(K), 2)[1][1]
-  G = local_genera_hermitian(L, p, 4, 2, 4)
-  for i in 1:10
-    g1 = rand(G)
-    g2 = rand(G)
-    g3 = @inferred orthogonal_sum(g1, g2)
-    @test genus(representative(g3), p) == genus(orthogonal_sum(representative(g1), representative(g2))[1], p)
-  end
-
-  p = prime_decomposition(maximal_order(K), 3)[1][1]
-  G = local_genera_hermitian(L, p, 4, 2, 4)
-  for i in 1:10
-    g1 = rand(G)
-    g2 = rand(G)
-    g3 = @inferred orthogonal_sum(g1, g2)
-    @test genus(representative(g3), p) == genus(orthogonal_sum(representative(g1), representative(g2))[1], p)
-  end
-
   Qx, x = PolynomialRing(FlintQQ, "x", cached = false)
   f = x - 1;
   K, a = number_field(f)
@@ -157,24 +66,5 @@
 
   @test @inferred !Hecke.isrepresented_by(W, V)
 
-  Qx, x = PolynomialRing(FlintQQ, "x")
-  f = x^2-3
-  K, a = NumberField(f, "a", cached = false)
-  Kt, t = PolynomialRing(K, "t")
-  g = t^2+(1)
-  E, b = NumberField(g, "b", cached = false)
-  D = matrix(E, 3, 3, [(a), 0, 0, 0, (2 * a), 0, 0, 0, (a + 5)])
-  V = hermitian_space(E, D)
-  DD = matrix(E, 2, 2, [a + 3, 0, 0, (a + 2)])
-  W = hermitian_space(E, DD)
-  @test @inferred Hecke.isrepresented_by(W, V)
-  @test @inferred Hecke.isrepresented_by(V, V)
-  DD = E(a) * identity_matrix(E, 5)
-  W = hermitian_space(E, DD)
-  @test @inferred Hecke.isrepresented_by(V, W)
-
-  # they are not isometric at some dyadic prime ideal:
-  DD = identity_matrix(E, 4)
-  W = hermitian_space(E, DD)
-  @test !(@inferred Hecke.isrepresented_by(W, V))
 end
+

--- a/test/QuadForm/Herm.jl
+++ b/test/QuadForm/Herm.jl
@@ -2,4 +2,7 @@
   include("Herm/Spaces.jl")
   include("Herm/Genus.jl")
   include("Herm/GenusRep.jl")
+  include("Herm/Lattices.jl")
+  include("Herm/LocallyIsometricSublattice.jl")
+  include("Herm/Mass.jl")
 end

--- a/test/QuadForm/Herm/Genus.jl
+++ b/test/QuadForm/Herm/Genus.jl
@@ -396,4 +396,89 @@
   G = genus([g], sig)
   @test G == genus([g], [(rlp[1], 2), (rlp[2], 2)])
 
+  ##############################################################################
+  #
+  #  Local genera hermitian
+  #
+  #############################################################################
+
+  K, a = CyclotomicRealSubfield(8, "a")
+  Kt, t = PolynomialRing(K, "t")
+  L, b = number_field(t^2 - a * t + 1)
+  
+  p = prime_decomposition(maximal_order(K), 2)[1][1]
+  G = @inferred local_genera_hermitian(L, p, 4, 2, 4)
+  @test length(G) == 15
+  for i in 1:length(G)
+    @test rank(G[i]) == 4
+    @test (@inferred representative(G[i])) in G[i]
+  end
+
+  for i in 1:10
+    g1 = rand(G)
+    g2 = rand(G)
+    g3 = @inferred orthogonal_sum(g1, g2)
+    @test genus(representative(g3), p) == genus(orthogonal_sum(representative(g1), representative(g2))[1], p)
+  end
+
+  GG = G[1]
+  u = @inferred uniformizer(GG)
+  @assert parent(u) == K
+
+  p = prime_decomposition(maximal_order(K), 3)[1][1]
+  G = local_genera_hermitian(L, p, 4, 2, 4)
+  for i in 1:10
+    g1 = rand(G)
+    g2 = rand(G)
+    g3 = @inferred orthogonal_sum(g1, g2)
+    @test genus(representative(g3), p) == genus(orthogonal_sum(representative(g1), representative(g2))[1], p)
+  end
+
+  p = prime_decomposition(maximal_order(K), 17)[1][1]
+  G = @inferred local_genera_hermitian(L, p, 5, 5, 5)
+  @test length(G) == 7
+  for i in 1:length(G)
+    @test rank(G[i]) == 5
+    @test (@inferred representative(G[i])) in G[i]
+  end
+
+  K, a = CyclotomicRealSubfield(8, "a")
+  Kt, t = K["t"]
+  L, b = number_field(t^2 - a * t + 1)
+  p = prime_decomposition(maximal_order(K), 2)[1][1]
+  l =  Vector{Tuple{Int, Int, Int, Int}}[[(0, 3, 1, 0), (4, 1, 1, 2)],
+       [(0, 3, -1, 0), (4, 1, 1, 2)],
+       [(0, 3, 1, 0), (4, 1, -1, 2)],
+       [(0, 3, -1, 0), (4, 1, -1, 2)],
+       [(0, 2, 1, 0), (2, 2, 1, 1)],
+       [(0, 2, -1, 0), (2, 2, 1, 1)],
+       [(0, 2, 1, 1), (2, 2, 1, 1)],
+       [(0, 2, 1, 0), (2, 2, 1, 2)],
+       [(0, 2, 1, 1), (2, 2, -1, 1)],
+       [(0, 2, -1, 0), (2, 2, 1, 2)],
+       [(0, 2, 1, 1), (2, 2, 1, 2)],
+       [(0, 1, 1, 0), (1, 2, 1, 1), (2, 1, 1, 1)],
+       [(0, 1, -1, 0), (1, 2, 1, 1), (2, 1, 1, 1)],
+       [(1, 4, 1, 1)],
+       [(1, 4, -1, 1)]]
+  Gs = Hecke.LocalGenusHerm{typeof(L), typeof(p)}[ genus(HermLat, L, p, x) for x in l ]
+  myG = @inferred local_genera_hermitian(L, p, 4, 2, 4)
+  @test length(Gs) == length(myG)
+  @test all(x -> x in Gs, myG)
+  @test all(x -> x in myG, Gs)
+
+  K, a = CyclotomicRealSubfield(8, "a")
+  Kt, t = K["t"]
+  L, b = number_field(t^2 - a * t + 1)
+  rlp = real_places(K)
+  G = @inferred genera_hermitian(L, 3, Dict(rlp[1] => 1, rlp[2] => 1), 100 * maximal_order(L))
+  for i in 1:10
+    g1 = rand(G)
+    g2 = rand(G)
+    M, = @inferred orthogonal_sum(representative(g1), representative(g2))
+    @test M in (g1 + g2)
+  end
+
+
+
 end

--- a/test/QuadForm/Herm/GenusRep.jl
+++ b/test/QuadForm/Herm/GenusRep.jl
@@ -101,5 +101,18 @@
   PB = [pseudo_basis(LL) for LL in gen_rep]
   @test all(i -> PB[i][1][2] == P^(i-1) && PB[i][2][2]^-1 == a(P)^(i-1), 1:length(PB))
 
+  #
+  # Another indefinite example
+  #
+
+  Qx, x = FlintQQ["x"]
+  K, a = NumberField(x - 1, "a")
+  Kt, t = K["t"]
+  E, b = NumberField(t^2 + 1, "b")
+  p = prime_decomposition(maximal_order(K), 2)[1][1]
+  G = genus(HermLat, E, p, [(0, 3, -1, 0)])
+  L = @inferred representative(G)
+  @test length(@inferred Hecke.genus_representatives(L)) == 1
+
 end
 

--- a/test/QuadForm/Herm/Mass.jl
+++ b/test/QuadForm/Herm/Mass.jl
@@ -1,28 +1,118 @@
 @testset "Mass" begin
 
+  #
+  # Examples from arguments checks: indefinite and rank 0 cases
+  #
+
   Qx, x = PolynomialRing(FlintQQ, "x")
-  f = x-1
+  f = x^2 - 2
   K, a = NumberField(f, "a", cached = false)
   Kt, t = PolynomialRing(K, "t")
-  g = t^2+(2)
+  g = t^2 - a*t + 1
   E, b = NumberField(g, "b", cached = false)
-  D = matrix(E, 3, 3, [(1), 0, 0, 0, (1), 0, 0, 0, (1)])
-  gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [(-2)*b+(-2), b+(6), 0]), map(E, [0, (1), (1)]), map(E, [b+(-6), (-6)*b+(6), 0])]
+  D = matrix(E, 3, 3, [-1, 0, 0, 0, 1, 0, 0, 0, 1])
+  gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [2, 0, 0]), map(E, [a, 0, 0]), map(E, [b + 1, 0, 0]), map(E, [a*b + a, 0, 0]), map(E, [0, 10, 0]), map(E, [0, 10*a, 0]), map(E, [0, 2*b + 6*a + 10, 0]), map(E, [0, a*b + 5*a + 6, 0]), map(E, [0, 5, 5]), map(E, [0, 5*a, 5*a]), map(E, [0, b + 3*a, b + 3*a]), map(E, [0, a*b + 6, a*b + 6])]
+  L = hermitian_lattice(E, generators = gens, gram_ambient_space = D)
+  @test !isdefinite(L)
+  @test_throws ArgumentError mass(L)
+
+  D = matrix(E, 0, 0, [])
+  gens = Vector{Hecke.NfRelElem{nf_elem}}[]
+  L = hermitian_lattice(E, generators = gens, gram_ambient_space = D)
+  @test isdefinite(L)
+  @test rank(L) == 0
+  @test @inferred mass(L) == 1
+
+  #
+  # Bunch of examples
+  #
+
+  K, a = rationals_as_number_field()
+  Kt, t = PolynomialRing(K, "t")
+  g = t^2 + 5
+  E, b = NumberField(g, "b", cached = false)
+  D = matrix(E, 3, 3, [1, 0, 0, 0, 1, 0, 0, 0, 2])
+  gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [b + 8, b + 9, 0]), map(E, [-25*b + 66, -51//2*b + 171//2, -5//2*b + 1]), map(E, [104*b + 150, 132*b + 145, 5//2*b + 35//2]), map(E, [529*b - 47, 1243//2*b - 437//2, 28*b + 95//2])]
+  L = hermitian_lattice(E, generators = gens, gram_ambient_space = D)
+  @test isdefinite(L)
+  m = @inferred mass(L)
+  @test m == sum([inv(fmpq(automorphism_group_order(LL))) for LL in genus_representatives(L)])
+  
+ 
+  K, a = rationals_as_number_field()
+  Kt, t = PolynomialRing(K, "t")
+  g = t^2 + 2
+  E, b = NumberField(g, "b", cached = false)
+  D = matrix(E, 4, 4, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1])
+  gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [-11*b - 18, 5*b - 8, 0, 0]), map(E, [-763//4*b - 373, 471//4*b - 279//2, -3//2*b + 5, 0]), map(E, [-205589//4*b - 45927, 54261//4*b - 71509//2, -13*b + 1018, -1//2*b + 2]), map(E, [-267023*b + 283211, -206429//2*b - 168273, 14671//4*b + 2083, 25//4*b + 15//2])]
+  L = hermitian_lattice(E, generators = gens, gram_ambient_space = D)
+  m = @inferred mass(L)
+  @test m == 1//512
+
+  D = matrix(E, 4, 4, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1])
+  gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [14*b - 18, 8*b - 10, 0, 0]), map(E, [85//2*b - 493//2, 25*b - 277//2, 1, 0]), map(E, [-399//4*b - 2843//2, -205//4*b - 803, 11//4*b + 8, -1//4*b + 3//2]), map(E, [13929//2*b - 6826, 3955*b - 3803, -121//4*b + 61, -35//4*b + 7//2])]
+  L = hermitian_lattice(E, generators = gens, gram_ambient_space = D)
+  m = @inferred mass(L)
+  @test m == 1//512
+
+  D = matrix(E, 4, 4, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1])
+  gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [-9*b - 38, 3*b + 8, 0, 0]), map(E, [-1//2*b - 5//2, -1//2, 1, 0]), map(E, [-716*b - 173, 329//2*b, -1//4*b + 1//2, -1//4*b]), map(E, [59*b - 84, -11*b + 22, 0, 0])]
+  L = hermitian_lattice(E, generators = gens, gram_ambient_space = D)
+  m = @inferred mass(L)
+  @test m == sum([inv(fmpq(automorphism_group_order(LL))) for LL in genus_representatives(L)])
+
+  D = matrix(E, 4, 4, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1])
+  gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [-6*b - 38, 4*b + 10, 0, 0]), map(E, [1321//4*b - 2323//2, -91//4*b + 369, -1//2*b, 0]), map(E, [-2089//2*b + 5256, -23*b - 1610, 5//4*b - 5//2, 5//4*b]), map(E, [6376*b + 13976, -2645*b - 3174, -3//2*b - 9, 5//2*b - 4])]
+  L = hermitian_lattice(E, generators = gens, gram_ambient_space = D)
+  m = @inferred mass(L)
+  @test m == sum([inv(fmpq(automorphism_group_order(LL))) for LL in genus_representatives(L)])
+
+  D = matrix(E, 3, 3, [1, 0, 0, 0, 1, 0, 0, 0, 1])
+  gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [-2*b-2, b+6, 0]), map(E, [0, 1, 1]), map(E, [b-6, -6*b+6, 0])]
   L = hermitian_lattice(E, generators = gens, gram_ambient_space = D)
   m = @inferred mass(L)
   @test m == 1//32
+  
+  g = t^2 + 1
+  E, b = NumberField(g, "b", cached = false)
+  D = matrix(E, 4, 4, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1])
+  gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [8*b + 14, 4*b + 10, 0, 0]), map(E, [57*b + 443//2, 17*b + 303//2, -3//2*b + 3//2, 0]), map(E, [5//2*b - 7//2, b - 2, -3//2*b + 1, 3//2*b]), map(E, [1//2*b - 3, -3//2, -1//2*b + 1, b - 1//2])]
+  L = hermitian_lattice(E, generators = gens, gram_ambient_space = D)
+  m = @inferred mass(L)
+  @test m == sum([inv(fmpq(automorphism_group_order(LL))) for LL in genus_representatives(L)])
+
+  D = matrix(E, 4, 4, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 3])
+  gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [1, 1, 0, 0]), map(E, [-3*b + 5, 0, 8, 0]), map(E, [-40*b - 24, 0, -129//2*b + 2, -3//2*b + 1]), map(E, [-312*b - 208, 0, -1037//2*b - 17//2, -25//2*b + 15//2])]
+  L = hermitian_lattice(E, generators = gens, gram_ambient_space = D)
+  m = @inferred mass(L)
+  @test m == sum([inv(fmpq(automorphism_group_order(LL))) for LL in genus_representatives(L)])
+
+  D = matrix(E, 4, 4, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 3])
+  gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [-b - 2, 1, 0, 0]), map(E, [-9*b - 9, 0, -8, 0]), map(E, [-30*b - 24, 0, -9//2*b - 31//2, -1//2*b - 3//2]), map(E, [-48*b - 96, 0, 13//2*b - 89//2, 1//2*b - 9//2])]
+  L = hermitian_lattice(E, generators = gens, gram_ambient_space = D)
+  @test isdefinite(L)
+  m = @inferred mass(L)
+  @test m == sum([inv(fmpq(automorphism_group_order(LL))) for LL in genus_representatives(L)])
+
+  D = matrix(E, 6, 6, [1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1])
+  gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [-11*b + 1, -3*b + 1, 0, 0, 0, 0]), map(E, [-42*b + 27//2, -4*b + 17//2, 3//2*b + 13//2, 0, 0, 0]), map(E, [-2074*b + 4314, 370*b + 952, 624*b + 368, 7*b - 1, 0, 0]), map(E, [-1//2, -1//2, 0, 1//2*b - 1//2, 1, 0]), map(E, [-64401//2*b - 379225, -127585//2*b - 50257, -57600*b, -440*b + 352, -1//2*b - 1, -1//2*b - 1]), map(E, [178435*b + 414553, 90613*b + 32617, 64800*b - 21600, 363*b - 561, b + 1, b + 1])]
+  L = hermitian_lattice(E, generators = gens, gram_ambient_space = D)
+  m = @inferred mass(L)
+  @test m == 1//147456
+
 
   Qx, x = PolynomialRing(FlintQQ, "x")
   f = x^2-3
   K, a = NumberField(f, "a", cached = false)
   Kt, t = PolynomialRing(K, "t")
-  g = t^2+(1)
+  g = t^2+1
   E, b = NumberField(g, "b", cached = false)
-  D = matrix(E, 3, 3, [(1), 0, 0, 0, (1), 0, 0, 0, (1)])
-  gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [(-1//2*a-1//2)*b+(1//2*a+5//2), (-1), 0]), map(E, [(a-9)*b+(15*a+3), 0, (-a)*b+(8*a+13)]), map(E, [(-1610*a+2990)*b+(2070*a-2990), 0, (-68*a+393)*b+(19*a+462)])]
+  D = matrix(E, 3, 3, [1, 0, 0, 0, 1, 0, 0, 0, 1])
+  gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [(-1//2*a-1//2)*b+(1//2*a+5//2), -1, 0]), map(E, [(a-9)*b+ 15*a+3, 0, -a*b+ 8*a+13]), map(E, [(-1610*a+2990)*b + 2070*a-2990, 0, (-68*a+393)*b + 19*a+462])]
   L = hermitian_lattice(E, generators = gens, gram_ambient_space = D)
   m = @inferred mass(L)
   @test m == 1//108
+
 
   Qx, x = PolynomialRing(FlintQQ, "x")
   f = x^4-x^3-4*x^2+4*x+1
@@ -30,8 +120,8 @@
   Kt, t = PolynomialRing(K, "t")
   g = t^2+(a^3 - 1*a^2 - 4*a + 5)
   E, b = NumberField(g, "b", cached = false)
-  D = matrix(E, 3, 3, [(1), 0, 0, 0, (1), 0, 0, 0, (1)])
-  gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [(1), 0, 0]), map(E, [0, (1), 0]), map(E, [0, 0, (1)])]
+  D = matrix(E, 3, 3, [1, 0, 0, 0, 1, 0, 0, 0, 1])
+  gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [1, 0, 0]), map(E, [0, 1, 0]), map(E, [0, 0, 1])]
   L = hermitian_lattice(E, generators = gens, gram_ambient_space = D)
   m = @inferred mass(L)
   @test m == 1//10125

--- a/test/QuadForm/Herm/Mass.jl
+++ b/test/QuadForm/Herm/Mass.jl
@@ -1,4 +1,5 @@
-@testset "Mass of hermitian lattices" begin
+@testset "Mass" begin
+
   Qx, x = PolynomialRing(FlintQQ, "x")
   f = x-1
   K, a = NumberField(f, "a", cached = false)
@@ -34,4 +35,6 @@
   L = hermitian_lattice(E, generators = gens, gram_ambient_space = D)
   m = @inferred mass(L)
   @test m == 1//10125
+
 end
+

--- a/test/QuadForm/Herm/Spaces.jl
+++ b/test/QuadForm/Herm/Spaces.jl
@@ -5,6 +5,8 @@
   p = 3*OK
   Kt, t = K["t"]
 
+  infp = infinite_places(K)
+
   E, b = NumberField(t^2 + 3)
   s = involution(E)
 
@@ -42,9 +44,33 @@
   @test !Hecke.isisotropic(U,p)
   @test Hecke.islocally_hyperbolic(V,p)
   @test Hecke.isisotropic(V,p)
+  @test all(v -> Hecke.isisotropic(V, v), infp)
   @test !Hecke.islocally_hyperbolic(W,p)
   @test Hecke.isisotropic(W,p)
   @test_throws AssertionError Hecke.islocally_hyperbolic(V, 2*OK)
+
+
+  Qx, x = PolynomialRing(FlintQQ, "x")
+  f = x^2-3
+  K, a = NumberField(f, "a", cached = false)
+  Kt, t = PolynomialRing(K, "t")
+  g = t^2+(1)
+  E, b = NumberField(g, "b", cached = false)
+  D = matrix(E, 3, 3, [(a), 0, 0, 0, (2 * a), 0, 0, 0, (a + 5)])
+  V = hermitian_space(E, D)
+  DD = matrix(E, 2, 2, [a + 3, 0, 0, (a + 2)])
+  W = hermitian_space(E, DD)
+  @test @inferred Hecke.isrepresented_by(W, V)
+  @test @inferred Hecke.isrepresented_by(V, V)
+  DD = E(a) * identity_matrix(E, 5)
+  W = hermitian_space(E, DD)
+  @test @inferred Hecke.isrepresented_by(V, W)
+
+  # they are not isometric at some dyadic prime ideal:
+  DD = identity_matrix(E, 4)
+  W = hermitian_space(E, DD)
+  @test !(@inferred Hecke.isrepresented_by(W, V))
+
 
   K, a = rationals_as_number_field()
   OK = maximal_order(K)
@@ -58,11 +84,36 @@
   V = hermitian_space(E, E[102 b; -b 0])
   H = hermitian_space(E, E[0 1; 1 0])
   W = hermitian_space(E, E[1 1 2; 1 2 3; 2 3 1])
+  
+  @test_throws ErrorException hasse_invariant(V, p)
+  @test_throws ErrorException witt_invariant(W, q)
+
   for r in [p,q]
     @test Hecke.islocally_represented_by(V,H,r)
   end
   @test Hecke.isrepresented_by(V,H)
   @test !Hecke.islocally_represented_by(W,V,p)
+  @test Hecke.islocally_represented_by(V, W, p)
   @test !Hecke.isrepresented_by(W,V)
+  
+  @test !isisometric(V, W, ZZ(2))
+  @test all(p -> isisometric(V, H, ZZ(p)), PrimesSet(1, 20))
+
+
+  Qx, x = QQ["x"]
+  K, a = number_field(x^3+3, "a")
+  Kt, t = K["t"]
+  E, b = number_field(t^2-2, "b")
+
+  V = hermitian_space(E, E[102 b; -b 0])
+  H = hermitian_space(E, E[0 1; 1 0])
+  W = hermitian_space(E, E[1 1 2; 1 2 3; 2 3 1])
+
+  infp = infinite_places(K)
+
+  @test isisometric(V, V, infp[1])
+  @test !isisometric(V, W, infp[2])
+  @test count(v -> isisometric(V, H), infp) == 2
+  @test isisometric(V, H)
 
 end

--- a/test/QuadForm/Lattices.jl
+++ b/test/QuadForm/Lattices.jl
@@ -85,9 +85,9 @@
   L, b = number_field(t^2 + 11, "b", check = true)
   p = prime_decomposition(maximal_order(K), 2)[1][1]
   P = prime_decomposition(maximal_order(L), p)[1][1]
-  H = @inferred Hecke.lattice(hermitian_space(K, 2 * identity_matrix(K, 3)), pseudo_matrix(identity_matrix(K, 3), [p, p, p]))
+  H = @inferred Hecke.lattice(quadratic_space(K, 2 * identity_matrix(K, 3)), pseudo_matrix(identity_matrix(K, 3), [p, p, p]))
   #@test Hecke._genus_symbol_kirschmer(H, fmpz(2)) == Any[(3, 4, true, 4, -64)]
-  @test @inferred islocally_isometric(H, H, fmpz(2))
+  @test @inferred islocally_isometric(H, H, p)
 
   H = Hecke.lattice(hermitian_space(L, L(elem_in_nf(uniformizer(p))) * identity_matrix(L, 3)), pseudo_matrix(identity_matrix(L, 3), [P, P, P]))
   #@test Hecke._genus_symbol_kirschmer(H, p) == Any[(3, 3, false)]

--- a/test/QuadForm/Lattices.jl
+++ b/test/QuadForm/Lattices.jl
@@ -113,8 +113,6 @@
   M = @inferred Hecke.maximal_integral_lattice(V)
   @test Hecke.genus(M, p) == genus(HermLat, L, p, [(-2, 2, 1, 0), (0, 1, 1, 0)])
 
-  Qx, x = QQ["x"]
-  f = x^3-39*x-65
   K, a = CyclotomicRealSubfield(8, "a")
   Kt, t = K["t"]
   E, b = number_field(t^2 - a * t + 1, "b")
@@ -152,8 +150,6 @@
   L = Hecke._to_number_field_lattice(E8)
   @test L == dual(L)
 
-  Qx, x = QQ["x"]
-  f = x^3-39*x-65
   K, a = CyclotomicRealSubfield(8, "a")
   Kt, t = K["t"]
   E, b = number_field(t^2 - a * t + 1, "b")


### PR DESCRIPTION
I have fixed the code for the mass of hermitian lattices and I have implemented the use of the automorphism group of definite lattices when it could be used. I have moved some tests to centralise as much as possible into the `~/test/QuadForm/Herm` directory. There were also few fixes to do in `~/Herm/Spaces.jl` that I have done. There is also more documentation where I could provide some.