### PR TITLE
Sparse linear system solving

### DIFF
--- a/src/NumField/NfAbs/NonSimple.jl
+++ b/src/NumField/NfAbs/NonSimple.jl
@@ -521,21 +521,15 @@ function minpoly_sparse(a::NfAbsNSElem)
   n = degree(K)
   M = sparse_matrix(FlintQQ)
   z = a^0
-  sz = SRow(z)
-  i = 0
-  push!(sz.values, FlintQQ(1))
-  push!(sz.pos, n+i+1)
-  push!(M, sz)
+  push!(M, SRow(z))
   z *= a
   sz = SRow(z)
   i = 1
   Qt, t = PolynomialRing(FlintQQ, "x", cached = false)
   while true
     if n % i == 0
-      echelon!(M)
-      fl, so = can_solve_ut(sub(M, 1:i, 1:n), sz)
+      fl, so = can_solve_with_solution(M, sz)
       if fl
-        so = mul(so, sub(M, 1:i, n+1:ncols(M)))
         # TH: If so is the zero vector, we cannot use the iteration,
         # so we do it by hand.
         if length(so.pos) == 0
@@ -546,8 +540,6 @@ function minpoly_sparse(a::NfAbsNSElem)
         return f
       end
     end
-    push!(sz.values, FlintQQ(1))
-    push!(sz.pos, n+i+1)
     push!(M, sz)
     z *= a
     sz = SRow(z)

--- a/src/NumField/NfRel/NfRelNS.jl
+++ b/src/NumField/NfRel/NfRelNS.jl
@@ -511,11 +511,7 @@ function minpoly_sparse(a::NfRelNSElem)
   k = base_field(K)
   M = sparse_matrix(k)
   z = one(K)
-  sz = SRow(z)
-  i = 0
-  push!(sz.values, k(1))
-  push!(sz.pos, n+i+1)
-  push!(M, sz)
+  push!(M, SRow(z))
   z *= a
   sz = SRow(z)
   i = 1
@@ -523,10 +519,8 @@ function minpoly_sparse(a::NfRelNSElem)
   f = kt()
   while true
     if n % i == 0
-      echelon!(M)
-      fl, so = can_solve_ut(sub(M, 1:i, 1:n), sz)
+      fl, so = can_solve_with_solution(M, sz)
       if fl
-        so = mul(so, sub(M, 1:i, n+1:ncols(M)))
         # TH: If so is the zero vector, we cannot use the iteration,
         # so we do it by hand.
         if length(so.pos) == 0
@@ -537,8 +531,6 @@ function minpoly_sparse(a::NfRelNSElem)
         return f
       end
     end
-    push!(sz.values, k(1))
-    push!(sz.pos, n+i+1)
     push!(M, sz)
     z *= a
     sz = SRow(z)

--- a/src/Sparse/Matrix.jl
+++ b/src/Sparse/Matrix.jl
@@ -919,6 +919,7 @@ end
 #  Append sparse row to sparse matrix
 #
 ################################################################################
+
 @doc Markdown.doc"""
     push!(A::SMat{T}, B::SRow{T}) where T
 
@@ -932,6 +933,23 @@ function push!(A::SMat{T}, B::SRow{T}) where T
   if length(B.pos) > 0
     A.c = max(A.c, B.pos[end])
   end
+  return A
+end
+
+@doc Markdown.doc"""
+    insert!(A::SMat{T}, i::Integer, B::SRow{T}) where T
+
+Insert the sparse row ```B``` at position ```i``` of the rows of ```A```.
+"""
+function Base.insert!(A::SMat{T}, i::Integer, B::SRow{T}) where T
+  insert!(A.rows, i, B)
+  A.r += 1
+  @assert length(A.rows) == A.r
+  A.nnz += length(B.pos)
+  if length(B.pos) > 0
+    A.c = max(A.c, B.pos[end])
+  end
+  return A
 end
 
 ################################################################################

--- a/src/Sparse/Rref.jl
+++ b/src/Sparse/Rref.jl
@@ -55,16 +55,20 @@ end
 function insert_row!(A::SMat{T}, i::Int, r::SRow{T}) where T
   insert!(A.rows, i, r)
   A.r += 1
-  A.nnz += length(r)
-  A.c = max(A.c, r.pos[end])
+  if !iszero(length(r))
+    A.nnz += length(r)
+    A.c = max(A.c, r.pos[end])
+  end
   return A
 end
 
 function push_row!(A::SMat{T}, r::SRow{T}) where T
   push!(A.rows, r)
   A.r += 1
-  A.nnz += length(r)
-  A.c = max(A.c, r.pos[end])
+  if !iszero(length(r))
+    A.nnz += length(r)
+    A.c = max(A.c, r.pos[end])
+  end
   return A
 end
 
@@ -109,11 +113,13 @@ function _add_row_to_rref!(M::SMat{T}, v::SRow{T}) where { T <: FieldElem }
   end
 
   # Multiply v by inv(v.values[1])
-  t = inv(v.values[1])
-  for j = 2:length(v)
-    v.values[j] = mul!(v.values[j], v.values[j], t)
+  if !isone(v.values[1])
+    t = inv(v.values[1])
+    for j = 2:length(v)
+      v.values[j] = mul!(v.values[j], v.values[j], t)
+    end
+    v.values[1] = one(base_ring(M))
   end
-  v.values[1] = one(base_ring(M))
   insert_row!(M, new_row, v)
 
   # Reduce the rows above the newly inserted one

--- a/src/Sparse/Rref.jl
+++ b/src/Sparse/Rref.jl
@@ -52,26 +52,6 @@ function rref!(A::SMat{T}; truncate::Bool = false) where {T <: FieldElement}
   return rankA
 end
 
-function insert_row!(A::SMat{T}, i::Int, r::SRow{T}) where T
-  insert!(A.rows, i, r)
-  A.r += 1
-  if !iszero(length(r))
-    A.nnz += length(r)
-    A.c = max(A.c, r.pos[end])
-  end
-  return A
-end
-
-function push_row!(A::SMat{T}, r::SRow{T}) where T
-  push!(A.rows, r)
-  A.r += 1
-  if !iszero(length(r))
-    A.nnz += length(r)
-    A.c = max(A.c, r.pos[end])
-  end
-  return A
-end
-
 # Reduce v by M and if the result is not zero add it as a row (and then reduce
 # M to maintain the rref).
 # Return true iff v is not in the span of the rows of M.
@@ -120,7 +100,7 @@ function _add_row_to_rref!(M::SMat{T}, v::SRow{T}) where { T <: FieldElem }
     end
     v.values[1] = one(base_ring(M))
   end
-  insert_row!(M, new_row, v)
+  insert!(M, new_row, v)
 
   # Reduce the rows above the newly inserted one
   for i = 1:new_row - 1

--- a/src/Sparse/Solve.jl
+++ b/src/Sparse/Solve.jl
@@ -410,7 +410,7 @@ end
 
 function can_solve_with_solution(a::SMat{T}, b::SRow{T}) where T <: FieldElem
   c = sparse_matrix(base_ring(b))
-  push_row!(c, b)
+  push!(c, b)
 
   # b is a row, so this is always from the left
   fl, sol = can_solve_with_solution(a, c, side = :left)
@@ -444,7 +444,7 @@ function _can_solve_with_solution(a::SMat{T}, b::SMat{T}; side::Symbol = :right)
     if !fl
       return fl, sparse_matrix(K)
     end
-    push_row!(sol, mul(s, c2))
+    push!(sol, mul(s, c2))
   end
   return true, sol
 end

--- a/test/Sparse.jl
+++ b/test/Sparse.jl
@@ -4,4 +4,5 @@
   include("Sparse/Trafo.jl")
   include("Sparse/HNF.jl")
   include("Sparse/Rref.jl")
+  include("Sparse/Solve.jl")
 end

--- a/test/Sparse/Solve.jl
+++ b/test/Sparse/Solve.jl
@@ -1,0 +1,35 @@
+@testset "Sparse solving" begin
+  M = sparse_matrix(QQ, [ 1 0 0; 0 0 0; 0 0 1 ])
+  b = sparse_matrix(QQ, [ 1 0 3 ])
+
+  fl, sol = can_solve_with_solution(M, b, side = :left)
+  @test fl
+  @test matrix(sol)*matrix(M) == matrix(b)
+  sol = solve(M, b, side = :left)
+  @test matrix(sol)*matrix(M) == matrix(b)
+
+  fl, sol = can_solve_with_solution(M, transpose(b), side = :right)
+  @test fl
+  @test matrix(M)*matrix(sol) == matrix(transpose(b))
+  sol = solve(M, transpose(b), side = :right)
+  @test matrix(M)*matrix(sol) == matrix(transpose(b))
+
+  fl, sol = can_solve_with_solution(M, b.rows[1])
+  @test fl
+  @test mul(sol, M) == b.rows[1]
+
+  for i in 1:10
+    r = 10
+    c = 20
+    M = matrix(FlintQQ, rand([0,0,0,0,0,0,0,0,0,0,1], r, c))
+    Ms = sparse_matrix(M)
+    N = matrix(FlintQQ, rand([0,0,0,0,0,0,0,0,0,0,1], r, 2))
+    Ns = sparse_matrix(N)
+    fl, sol = can_solve_with_solution(Ms, Ns, side = :right)
+    fl2, sol2 = can_solve_with_solution(M, N, side = :right)
+    @test fl == fl2
+    if fl
+      @test M*matrix(sol) == N
+    end
+  end
+end


### PR DESCRIPTION
Implements `can_solve_with_solution(::SMat, SMat)` by basically copying the function for dense matrices from AbstractAlgebra.
I noticed that there already is a `can_solve_with_solution(::SMat, ::SRow)` which uses `echelon!` for the row reduction instead of the new `rref`. I made this function also work with `SMat` in the second argument and renamed it to `_can_solve_with_solution`. I have the impression that my new functions are faster, see the timings below (this is also the case for my actual application in invariant theory).
```
julia> for i = 6:10
           r = 10*i
           c = r + 10
           M = matrix(GF(5), rand([0,0,0,0,0,0,0,0,0,0,1], r, c))
           Ms = sparse_matrix(M)
           N = matrix(GF(5), rand([0,0,0,0,0,0,0,0,0,0,1], r, 1))
           Ns = sparse_matrix(N)
           @btime can_solve_with_solution(Ms, Ns, side = :right)
           @btime Hecke._can_solve_with_solution(Ms, Ns, side = :right)
           println()
         end
  403.471 μs (1542 allocations: 157.36 KiB)
  2.661 ms (71013 allocations: 6.07 MiB)

  838.780 μs (2354 allocations: 302.67 KiB)
  5.349 ms (140976 allocations: 11.66 MiB)

  1.271 ms (2906 allocations: 437.25 KiB)
  8.308 ms (212179 allocations: 18.02 MiB)

  2.193 ms (3478 allocations: 589.53 KiB)
  13.444 ms (336529 allocations: 30.14 MiB)

  3.378 ms (4130 allocations: 707.55 KiB)
  20.401 ms (499430 allocations: 44.46 MiB)

julia> for i = 6:10
           r = 10*i
           c = r + 10
           M = matrix(GF(5), rand([0,0,0,0,0,0,0,0,0,0,1], r, c))
           Ms = sparse_matrix(M)
           N = matrix(GF(5), rand([0,0,0,0,0,0,0,0,0,0,1], r, 1))
           Ns = sparse_matrix(N)
           @btime can_solve_with_solution(Ms, Ns, side = :right)
           @btime Hecke._can_solve_with_solution(Ms, Ns, side = :right)
           println()
         end
  403.471 μs (1542 allocations: 157.36 KiB)
  2.661 ms (71013 allocations: 6.07 MiB)

  838.780 μs (2354 allocations: 302.67 KiB)
  5.349 ms (140976 allocations: 11.66 MiB)

  1.271 ms (2906 allocations: 437.25 KiB)
  8.308 ms (212179 allocations: 18.02 MiB)

  2.193 ms (3478 allocations: 589.53 KiB)
  13.444 ms (336529 allocations: 30.14 MiB)

  3.378 ms (4130 allocations: 707.55 KiB)
  20.401 ms (499430 allocations: 44.46 MiB)
```
I would hence remove the `_can_solve_...` functions or is there anything against this?