### PR TITLE
minor fixes for galois group over number field

### DIFF
--- a/src/NumField/NfAbs/Elem.jl
+++ b/src/NumField/NfAbs/Elem.jl
@@ -845,9 +845,9 @@ function _height(a::nf_elem)
   return h
 end
 
-issquare(a::nf_elem) = ispower(a, 2)
+issquare(a::nf_elem) = ispower(a, 2)[1]
 
-issquare_with_sqrt(a::NumFieldElem) = issquare(a)
+issquare_with_sqrt(a::NumFieldElem) = ispower(a, 2)
 
 sqrt(a::nf_elem) = root(a, 2)
 

--- a/src/NumField/NfAbs/PolyFact.jl
+++ b/src/NumField/NfAbs/PolyFact.jl
@@ -70,15 +70,16 @@ function lift(C::HenselCtxQadic, mx::Int = minimum(precision, coefficients(C.f))
       else
         f = setprecision(C.lf[i], N2)
       end
+      
       #formulae and names from the Flint doc
       h = C.lf[j]
       g = C.lf[j-1]
       b = C.la[j]
       a = C.la[j-1]
-      setprecision!(h, N2)
-      setprecision!(g, N2)
-      setprecision!(a, N2)
-      setprecision!(b, N2)
+      h = setprecision(h, N2)
+      g = setprecision(g, N2)
+      a = setprecision(a, N2)
+      b = setprecision(b, N2)
 
       fgh = (f-g*h)*inv(p)
       G = rem(fgh*b, g)*p+g

--- a/src/NumField/SimpleNumField/Subfields.jl
+++ b/src/NumField/SimpleNumField/Subfields.jl
@@ -78,10 +78,14 @@ and an embedding $k \to L$.
 """
 function principal_subfields(K::SimpleNumField)
   ba = _principal_subfields_basis(K)
-  elts = Vector{Vector{nf_elem}}(undef, length(ba))
+  elts = Vector{Vector{elem_type(K)}}(undef, length(ba))
   for i in 1:length(ba)
-    baf = FakeFmpqMat(ba[i])
-    elts[i] = elem_type(K)[elem_from_mat_row(K, baf.num, j, baf.den) for j in 1:nrows(ba[i])]
+    if K isa NumField{fmpq}
+      baf = FakeFmpqMat(ba[i])
+      elts[i] = [elem_from_mat_row(K, baf.num, j, baf.den) for j=1:nrows(baf)]
+    else
+      elts[i] = [elem_from_mat_row(K, ba[i], j) for j=1:nrows(ba[i])]
+    end
   end
   T = typeof(K)
   return Tuple{T, morphism_type(T)}[ subfield(K, elts[i], isbasis = true) for i in 1:length(elts)]

--- a/test/NfAbs/Subfields.jl
+++ b/test/NfAbs/Subfields.jl
@@ -442,7 +442,7 @@ end
     kt, t = PolynomialRing(k, "t")
     K, b = NumberField(t^6+a)
 
-    @test length(subfields(K) == 4
+    @test length(subfields(K)) == 4
     @test length(principal_subfields(K)) == 4
   end  
 end

--- a/test/NfAbs/Subfields.jl
+++ b/test/NfAbs/Subfields.jl
@@ -443,6 +443,6 @@ end
     K, b = NumberField(t^6+a)
 
     @test length(subfields(K)) == 4
-    @test length(principal_subfields(K)) == 4
+    @test length(Hecke.principal_subfields(K)) == 4
   end  
 end

--- a/test/NfAbs/Subfields.jl
+++ b/test/NfAbs/Subfields.jl
@@ -435,3 +435,14 @@ end
   @test isone(denominator(defining_polynomial(L)))
   @test mL(gen(L))^2 == mL(gen(L)^2)
 end
+@testset "Subfields" begin
+  @testset "Relative_Subfields" begin
+    Qx,x = PolynomialRing(QQ,"x")
+    k,a = NumberField(x^3 + x + 1)
+    kt, t = PolynomialRing(k, "t")
+    K, b = NumberField(t^6+a)
+
+    @test length(subfields(K) == 4
+    @test length(principal_subfields(K)) == 4
+  end  
+end

--- a/test/NumField/Elem.jl
+++ b/test/NumField/Elem.jl
@@ -175,7 +175,7 @@ end
     for m in 1:100
       b = rand(K, -10:10)//rand(rangee)
       c = b^2
-      fl, d = issquare(c)
+      fl, d = issquare_with_sqrt(c)
       @test fl
       @test d^2 == c
       b = rand(K, -10:10)

--- a/test/NumField/Elem.jl
+++ b/test/NumField/Elem.jl
@@ -163,7 +163,7 @@
 end
 
 @testset "issquare" begin
-  #Enable one issquaer is working for non-monic defining polynomials
+  #Enable one issquare is working for non-monic defining polynomials
   Qx, x = QQ["x"]
   rangee = deleteat!(collect(-10:10), 11) # remove 0
   for d in [2,3,4,6,8,10]
@@ -180,20 +180,20 @@ end
       @test d^2 == c
       b = rand(K, -10:10)
       KK, m = simplify(K)
-      @test issquare(b)[1] == issquare(m\b)[1]
+      @test issquare(b) == issquare(m\b)
     end
   end
 
   f = -6//7*x + 1//9
   K, a = number_field(f, cached = false)
   c = 49//4
-  fl, b = issquare(K(c))
+  fl, b = issquare_with_sqrt(K(c))
   @test fl
   @test b^2 == c
 
   K, a = number_field(1//4*x^3 + 3*x^2 + 2*x - 1, cached = false)
   b = -1//10*a^2 - 2//5*a - 3//5
-  fl, c = issquare(b^2)
+  fl, c = issquare_with_sqrt(b^2)
   @test fl
   @test c^2 == b^2
 end


### PR DESCRIPTION
 - inplace setprec! for qadics (or polys over qadic) was no longer
   working. (HenselCtxQadic)
   Unnotices as this is not used (any more) in factoring
   but is used in galois
 - princial_subfields in relative extension was broken