### PR TITLE
Implement `iterate(::FmpzModRing)`

### DIFF
--- a/src/Misc/UnitsModM.jl
+++ b/src/Misc/UnitsModM.jl
@@ -677,7 +677,7 @@ unit_group(A::Nemo.FmpzModRing) = UnitGroup(A)
 unit_group(A::Nemo.NmodRing) = UnitGroup(A)
 
 
-## Make Nmod iteratible
+## Make NmodRing iteratible
 
 Base.iterate(R::NmodRing) = (zero(R), zero(UInt))
 
@@ -689,11 +689,31 @@ function Base.iterate(R::NmodRing, st::UInt)
   return R(st + 1), st + 1
 end
 
+Base.IteratorEltype(::Type{NmodRing}) = Base.HasEltype()
 Base.eltype(::Type{NmodRing}) = nmod
 
 Base.IteratorSize(::Type{NmodRing}) = Base.HasLength()
-
 Base.length(R::NmodRing) = R.n
+
+## Make FmpzModRing iteratible
+
+Base.iterate(R::Nemo.FmpzModRing) = (zero(R), zero(fmpz))
+
+function Base.iterate(R::Nemo.FmpzModRing, st::fmpz)
+  if st == R.n - 1
+    return nothing
+  end
+
+  return R(st + 1), st + 1
+end
+
+Base.IteratorEltype(::Type{Nemo.FmpzModRing}) = Base.HasEltype()
+Base.eltype(::Type{Nemo.FmpzModRing}) = fmpz_mod
+
+Base.IteratorSize(::Type{Nemo.FmpzModRing}) = Base.HasLength()
+Base.length(R::Nemo.FmpzModRing) = Integer(R.n)
+
+## Make GaloisField iteratible
 
 Base.iterate(R::GaloisField) = (zero(R), zero(UInt))
 
@@ -705,8 +725,8 @@ function Base.iterate(R::GaloisField, st::UInt)
   return R(st + 1), st + 1
 end
 
+Base.IteratorEltype(::Type{GaloisField}) = Base.HasEltype()
 Base.eltype(::Type{GaloisField}) = gfp_elem
 
 Base.IteratorSize(::Type{GaloisField}) = Base.HasLength()
-
 Base.length(R::GaloisField) = R.n

--- a/test/Misc/UnitsModM.jl
+++ b/test/Misc/UnitsModM.jl
@@ -1,3 +1,11 @@
+@testset "collect" begin
+  ZZ7 = ResidueRing(ZZ, 7)
+  @test collect(ZZ7) == ZZ7.(0:6)
+  ZZ7_fmpz = ResidueRing(ZZ, ZZ(7))
+  @test collect(ZZ7_fmpz) == ZZ7_fmpz.(0:6)
+  F7 = GF(7)
+  @test collect(F7) == F7.(0:6)
+end
 @testset "#465" begin
   G, mG = unit_group(quo(ZZ, 8)[1]);
   H = collect(G)


### PR DESCRIPTION
Currently, iterating over `ResidueRing(ZZ, ZZ(7))` produces an error. That is unexpected. So I propose an `iterate(::FfmpzModRing)` method and some related methods here. These methods get tested via `collect(ResidueRing(ZZ, ZZ(7)))` which now works fine.