### PR TITLE
add `relative_residue_field` for `NfRel`

### DIFF
--- a/docs/Build.jl
+++ b/docs/Build.jl
@@ -24,6 +24,11 @@ pages = [
                        "orders/ideals.md",
                        "orders/frac_ideals.md"
                      ],
+	 "Quadratic and hermitian forms" => [ "quad_forms/introduction.md",
+					      "quad_forms/basics.md",
+					      "quad_forms/lattices.md",
+					      "quad_forms/genusherm.md"
+					    ],
          "Abelian groups" => "abelian/introduction.md",
          "Class field theory" => "class_fields/intro.md",
          "Misc" =>  ["FacElem.md",

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -85,10 +85,11 @@ nav:
       - Elements:         orders/elements.md
       - Ideals:           orders/ideals.md
       - Fractional Ideals: orders/frac_ideals.md
-    - Quadratic and Hermitian forms:
+    - Quadratic and hermitian forms:
       - Introduction: 'quad_forms/introduction.md'
-      - Quadratic and hermitian spaces: 'quad_forms/basics.md'
+      - Spaces: 'quad_forms/basics.md'
       - Lattices: 'quad_forms/lattices.md'
+      - Genera for hermitian lattices: 'quad_forms/genusherm.md'
     - Abelian groups:
       - Introduction:     abelian/introduction.md
       - Elements:     abelian/elements.md

--- a/docs/src/quad_forms/basics.md
+++ b/docs/src/quad_forms/basics.md
@@ -1,26 +1,111 @@
-# Quadratic and hermitian spaces
+# Spaces
 ```@meta
 CurrentModule = Hecke
+DocTestSetup = quote
+    using Hecke
+  end
 ```
 
 ## Creation of spaces
 
 ```@docs
 quadratic_space(::NumField, ::Int)
+hermitian_space(::NumField, ::Int)
 quadratic_space(::NumField, ::MatElem)
+hermitian_space(::NumField, ::MatElem)
 ```
 
+### Examples
+Here are easy examples to see how these constructors work. We will keep the two 
+following spaces for the rest of this section:
+
+```@repl 2
+using Hecke # hide
+K, a = CyclotomicRealSubfield(7);
+Kt, t = K["t"];
+E, b = number_field(t^2-a*t+1, "b");
+Q = quadratic_space(K, K[0 1; 1 0])
+H = hermitian_space(E, 3)
+```
+---
+
 ## Attributes
+Let $(V, \Phi)$ be a space over $E/K$. We define its *dimension* to be its dimension
+as a vector space over its base ring $E$ and its *rank* to be the rank of its Gram 
+matrix. If these two invariants agree, the space is said to be *regular*. 
+
+While dealing with lattices, one always works with regular ambient spaces.
+
+The *determinant* $\textnormal{det}(V, \Phi)$ of $(V, \Phi)$ is defined to be the 
+class of the determinant of its Gram matrix in $K^{\times}/N(E^{\times})$ (which 
+is similar to $K^{\times}/(K^{\times})^2$ in the quadratic case). 
+The *discriminant* $\textnormal{disc}(V, \Phi)$ of $(V, \Phi)$ is defined to be 
+$(-1)^{(m(m-1)/2)}\textnormal{det}(V, \Phi)$, where $m$ is the rank of $(V, \Phi)$.
 
 ```@docs
 rank(::AbsSpace)
 dim(::AbsSpace)
 gram_matrix(::AbsSpace)
 involution(::AbsSpace)
-isregular(::AbsSpace)
+base_ring(::AbsSpace)
+fixed_field(::AbsSpace)
 det(::AbsSpace)
 discriminant(::AbsSpace)
 ```
+
+### Examples 
+So for instance, one could get the following information about the hermitian 
+space $H$: 
+
+```@repl 2
+using Hecke # hide
+K, a = CyclotomicRealSubfield(7);
+Kt, t = K["t"];
+E, b = number_field(t^2-a*t+1, "b"); 
+H = hermitian_space(E, 3); 
+rank(H), dim(H)
+gram_matrix(H)
+involution(H)
+base_ring(H)
+fixed_field(H)
+det(H), discriminant(H)
+```
+---
+
+## Predicates
+Let $(V, \Phi)$ be a hermitian space over $E/K$ (resp. quadratic space $K$). 
+We say that $(V, \Phi)$ is *definite* if $E/K$ is CM (resp. $K$ is totally 
+real) and if there exists an orthogonal basis of $V$ for which the diagonal 
+elements of the associated Gram matrix of $(V, \Phi)$ are either all totally 
+positive or all totally negative. In the former case, $V$ is said to be 
+*positive definite*, while in the latter case it is *negative definite*. 
+In all the other cases, we say that $V$ is *indefinite*.
+
+```@docs
+isregular(::AbsSpace)
+isquadratic(::AbsSpace)
+ishermitian(::AbsSpace)
+ispositive_definite(::AbsSpace)
+isnegative_definite(::AbsSpace)
+isdefinite(::AbsSpace)
+```
+
+Note that the `ishermitian` function tests whether the space is non-quadratic.
+
+### Examples 
+
+```@repl 2
+using Hecke # hide
+K, a = CyclotomicRealSubfield(7);
+Kt, t = K["t"];
+E, b = number_field(t^2-a*t+1, "b");
+Q = quadratic_space(K, K[0 1; 1 0]);
+H = hermitian_space(E, 3);
+isregular(Q), isregular(H)
+isquadratic(Q), ishermitian(H)
+isdefinite(Q), ispositive_definite(H)
+```
+---
 
 ## Inner products and diagonalization
 
@@ -32,11 +117,170 @@ orthogonal_basis(::AbsSpace)
 diagonal(::AbsSpace)
 ```
 
+### Examples 
+
+```@repl 2
+using Hecke # hide
+K, a = CyclotomicRealSubfield(7);
+Kt, t = K["t"];
+E, b = number_field(t^2-a*t+1, "b");
+Q = quadratic_space(K, K[0 1; 1 0]);
+H = hermitian_space(E, 3);
+gram_matrix(Q, K[1 1; 2 0])
+gram_matrix(H, E[1 0 0; 0 1 0; 0 0 1])
+inner_product(Q, [1, 1], [0, 2])
+orthogonal_basis(H)
+diagonal(Q), diagonal(H)
+```
+---
+
 ## Equivalence
+Let $(V, \Phi)$ and $(V', \Phi')$ be spaces over the same extension $E/K$. 
+A *homomorphism of spaces* from $V$ to $V'$ is a $E$-linear mapping 
+$f \colon V \to V'$ such that for all $x,y \in V$, one has
+```math
+   \Phi'(f(x), f(y)) = \Phi(x,y).
+```
+An automorphism of spaces is called an *isometry* and a monomorphism is 
+called an *embedding*.
+
 ```@docs
 hasse_invariant(::QuadSpace, p)
 witt_invariant(::QuadSpace, p)
+isisometric(::AbsSpace, ::AbsSpace)
 isisometric(::AbsSpace, ::AbsSpace, p)
 invariants(::QuadSpace)
-isisometric(::QuadSpace, ::QuadSpace)
 ```
+
+### Examples 
+For instance, for the case of $Q$ and the totally ramified prime $\mathfrak 
+p$ of $O_K$ above $7$, one can get:
+
+```@repl 2
+using Hecke # hide
+K, a = CyclotomicRealSubfield(7);
+Q = quadratic_space(K, K[0 1; 1 0]);
+OK = maximal_order(K);
+p = prime_decomposition(OK, 7)[1][1];
+hasse_invariant(Q, p), witt_invariant(Q, p)
+Q2 = quadratic_space(K, K[-1 0; 0 1]);
+isisometric(Q, Q2, p)
+isisometric(Q, Q2)
+invariants(Q2)
+```
+---
+
+## Embeddings
+Let $(V, \Phi)$ and $(V', \Phi')$ be two spaces over the same extension $E/K$, 
+and let $\sigma \colon V \to V'$ be an $E$-linear morphism. $\sigma$ is called 
+a *representation* of $V$ into $V'$ if for all $x \in V$
+```math 
+   \Phi'(\sigma(x), \sigma(x)) = \Phi(x,x).
+```
+In such a case, $V$ is said to be *represented* by $V'$ and $\sigma$ can be seen 
+as an embedding of $V$ into $V'$. This representation property can be also tested 
+locally with respect to the completions at some finite places. Note that in both 
+quadratic and hermitian cases, completions are taken at finite places of the fixed 
+field $K$.
+
+```@docs
+islocally_represented_by(::AbsSpace, ::AbsSpace, p)
+isrepresented_by(::AbsSpace, ::AbsSpace)
+```
+
+### Examples 
+Still using the spaces $Q$ and $H$, we can decide whether some other spaces
+embed respectively locally or globally into $Q$ or $H$:
+ 
+```@repl 2
+using Hecke # hide
+K, a = CyclotomicRealSubfield(7);
+Kt, t = K["t"];
+E, b = number_field(t^2-a*t+1, "b");
+Q = quadratic_space(K, K[0 1; 1 0]);
+H = hermitian_space(E, 3);
+OK = maximal_order(K);
+p = prime_decomposition(OK, 7)[1][1];
+Q2 = quadratic_space(K, K[-1 0; 0 1]);
+H2 = hermitian_space(E, E[-1 0 0; 0 1 0; 0 0 -1]);
+islocally_represented_by(Q2, Q, p)
+isrepresented_by(Q2, Q)
+islocally_represented_by(H2, H, p)
+isrepresented_by(H2, H)
+```
+---
+
+## Orthogonality operations
+
+```@docs
+orthogonal_complement(::AbsSpace, ::MatElem)
+orthogonal_sum(::AbsSpace, ::AbsSpace)
+```
+
+### Example 
+
+```@repl 2
+using Hecke # hide
+K, a = CyclotomicRealSubfield(7);
+Kt, t = K["t"];
+E, b = number_field(t^2-a*t+1, "b");
+Q = quadratic_space(K, K[0 1; 1 0]);
+H = hermitian_space(E, 3);
+H2 = hermitian_space(E, E[-1 0 0; 0 1 0; 0 0 -1]);
+orthogonal_complement(Q, matrix(K, 1, 2, [1 0]))
+H3, map1, map2 = orthogonal_sum(H, H2);
+H3
+map1
+map2
+```
+---
+
+## Isotropic spaces
+Let $(V, \Phi)$ be a space over $E/K$ and let $\mathfrak p$ be a place in $K$. 
+$V$ is said to be *isotropic* locally at $\mathfrak p$ if
+there exists an element $x \in V_{\mathfrak p}$ such that 
+$\Phi_{\mathfrak p}(x,x) = 0$, where $\Phi_{\mathfrak p}$ is the continuous 
+extension of $\Phi$ to $V_{\mathfrak p} \times V_{\mathfrak p}$.
+
+```@docs
+isisotropic(::AbsSpace, p)
+```
+### Example 
+
+```@repl 2
+using Hecke # hide
+K, a = CyclotomicRealSubfield(7);
+Kt, t = K["t"];
+E, b = number_field(t^2-a*t+1, "b");
+H = hermitian_space(E, 3);
+OK = maximal_order(K);
+p = prime_decomposition(OK, 7)[1][1];
+isisotropic(H, p)
+```
+---
+
+## Hyperbolic spaces
+
+Let $(V, \Phi)$ be a space over $E/K$ and let $\mathfrak p$ be a prime ideal 
+of $\mathcal O_K$. $V$ is said to be *hyperbolic* locally at $\mathfrak p$ if
+the completion $V_{\mathfrak p}$ of $V$ can be decomposed as an orthogonal sum 
+of dimension 2 spaces with Gram matrices of the form 
+$\begin{pmatrix}0&1\\1&0\end{pmatrix}$.
+
+```@docs
+islocally_hyperbolic(::HermSpace, ::NfOrdIdl)
+```
+
+### Example 
+
+```@repl 2
+using Hecke # hide
+K, a = CyclotomicRealSubfield(7);
+Kt, t = K["t"];
+E, b = number_field(t^2-a*t+1, "b");
+H = hermitian_space(E, 3);
+OK = maximal_order(K);
+p = prime_decomposition(OK, 7)[1][1];
+islocally_hyperbolic(H, p)
+```
+

--- a/docs/src/quad_forms/genusherm.md
+++ b/docs/src/quad_forms/genusherm.md
@@ -1,0 +1,481 @@
+# Genera for hermitian lattices
+```@meta
+CurrentModule = Hecke
+DocTestSetup = quote
+    using Hecke
+  end
+```
+
+## Local genus symbols
+
+_Definition 8.3.1 ([Kir16])_
+Let $L$ be a hermitian lattice over $E/K$ and let $\mathfrak p$ be a prime
+ideal of $\mathcal O_K$. Let $\mathfrak P$ be the largest ideal of $\mathcal O_E$ 
+over $\mathfrak p$ being invariant under the involution of $E$. We suppose that 
+
+```math
+   L_{\mathfrak p} = \perp_{i=1}^tL_i
+```
+with for all $1 \leq i \leq t$, $\mathfrak s(L_i) = \mathfrak P^{s_i}$ for a strictly 
+increasing sequence of integers $s_1 < \ldots < s_t$. Then, the *local genus symbol* 
+$g(L, \mathfrak p)$ of $L_{\mathfrak p}$ is defined to be:
+  - if $\mathfrak p$ is _good_, i.e. non ramified and non dyadic, 
+  
+```math
+   g(L, \mathfrak p) := [(s_1, r_1, d_1), \ldots, (s_t, r_t, d_t)]
+```
+  
+  where $d_i = 1$ if the determinant (resp. discriminant) of $L_i$ is a norm 
+  in $K_{\mathfrak p}^{\times}$, and $d_i = -1$ otherwise, and 
+  $r_i := \textnormal{rank}(L_i)$ for all i;
+  - if $\mathfrak p$ is _bad_,
+  
+```math
+   g(L, \mathfrak p) := [(s_1, r_1, d_1, n_1), \ldots, (s_t, r_t, d_t, n_t)]
+```
+  
+  where for all i, $n_i := \textnormal{ord}_{\mathfrak p}(\mathfrak n(L_i))$
+
+Note that we define the scale and the norm of the lattice $L_i$ ($1 \leq i \leq n$)
+defined over the extension of local fields $E_{\mathfrak P}/K_{\mathfrak p}$ 
+similarly to the ones of $L$, by extending by continuity the sesquilinear form 
+of the ambient space of $L$ to the completion. Regarding the determinant (resp. 
+discriminant), it is defined as the determinant of the Gram matrix associated 
+to a basis of $L_i$ relatively to the extension of the sesquilinear form 
+(resp. $(-1)^{(m(m-1)/2}$ times the determinant, where $m$ is the rank of $L_i$).
+
+We call any tuple in $g := g(L, \mathfrak p) = [g_1, \ldots, g_t]$ a *Jordan block* 
+of $g$ since it corresponds to invariants of a Jordan block of the completion of 
+the lattice $L$ at $\mathfrak p$. For any such block $g_i$, we call respectively 
+$s_i, r_i, d_i, n_i$ the *scale*, the *rank*, the *determinant class* (resp. 
+*discriminant class*) and the *norm* of $g_i$. Note that the norm is necessary 
+only when the prime ideal is bad.
+
+We say that two hermitian lattices $L$ and $L'$ over $E/K$ are in the same local 
+genus at $\mathfrak p$ if $g(L, \mathfrak p) = g(L', \mathfrak p)$.
+  
+### Creation of local genus symbols
+
+There are two ways of creating a local genus symbol for hermitian lattices:
+  - either abstractly, by choosing the extension $E/K$, the prime ideal $\mathfrak p$ 
+    of $\mathcal O_K$, the Jordan blocks `data` and the type of the $d_i$'s (either 
+    determinant class `:det` or discriminant class `:disc`);
+
+```julia
+   genus(HermLat, E::NumField, p::NfOrdIdl, data::Vector; type::Symbol = :det, 
+                                                          check::Bool = false)
+                                                             -> LocalGenusHerm
+```    
+  - or by constructing the local genus symbol of the completion of a hermitian
+    lattice $L$ over $E/K$ at a prime ideal $\mathfrak p$ of $\mathcal O_K$.
+  
+```julia
+   genus(L::HermLat, p::NfOrdIdl) -> LocalGenusHerm
+```
+
+#### Examples
+We will construct two examples for the rest of this section. Note that the prime 
+chosen here is bad.
+
+```@repl 2
+using Hecke # hide
+Qx, x = QQ["x"];
+K, a = NumberField(x^2 - 2, "a");
+Kt, t  = K["t"];
+E, b = NumberField(t^2 - a, "b");
+OK = maximal_order(K);
+p = prime_decomposition(OK, 2)[1][1];
+g1 = genus(HermLat, E, p, [(0, 1, 1, 0), (2, 2, -1, 1)], type = :det)
+D = matrix(E, 3, 3, [5//2*a - 4, 0, 0, 0, a, a, 0, a, -4*a + 8]);
+gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [1, 0, 0]), map(E, [a, 0, 0]), map(E, [b, 0, 0]), map(E, [a*b, 0, 0]), map(E, [0, 1, 0]), map(E, [0, a, 0]), map(E, [0, b, 0]), map(E, [0, a*b, 0]), map(E, [0, 0, 1]), map(E, [0, 0, a]), map(E, [0, 0, b]), map(E, [0, 0, a*b])];
+L = hermitian_lattice(E, gens, gram = D);
+g2 = genus(L, p)
+```
+
+---
+
+### Attributes
+
+```@docs
+length(::LocalGenusHerm)
+base_field(::LocalGenusHerm)
+prime(::LocalGenusHerm)
+```
+
+#### Examples
+
+```@repl 2
+using Hecke # hide
+Qx, x = QQ["x"];
+K, a = NumberField(x^2 - 2, "a");
+Kt, t  = K["t"];
+E, b = NumberField(t^2 - a, "b");
+OK = maximal_order(K);
+p = prime_decomposition(OK, 2)[1][1];
+g1 = genus(HermLat, E, p, [(0, 1, 1, 0), (2, 2, -1, 1)], type = :det);
+length(g1)
+base_field(g1)
+prime(g1)
+```
+
+---
+
+### Invariants
+
+```@docs
+scale(::LocalGenusHerm, ::Int)
+scales(::LocalGenusHerm)
+rank(::LocalGenusHerm, ::Int)
+rank(::LocalGenusHerm)
+ranks(::LocalGenusHerm)
+det(::LocalGenusHerm, ::Int)
+det(::LocalGenusHerm)
+dets(::LocalGenusHerm)
+discriminant(::LocalGenusHerm, ::Int)
+discriminant(::LocalGenusHerm)
+norm(::LocalGenusHerm, ::Int)
+norms(::LocalGenusHerm)
+```
+
+#### Examples
+
+```@repl 2 
+using Hecke # hide
+Qx, x = QQ["x"];
+K, a = NumberField(x^2 - 2, "a");
+Kt, t  = K["t"];
+E, b = NumberField(t^2 - a, "b");
+OK = maximal_order(K);
+p = prime_decomposition(OK, 2)[1][1];
+D = matrix(E, 3, 3, [5//2*a - 4, 0, 0, 0, a, a, 0, a, -4*a + 8]);
+gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [1, 0, 0]), map(E, [a, 0, 0]), map(E, [b, 0, 0]), map(E, [a*b, 0, 0]), map(E, [0, 1, 0]), map(E, [0, a, 0]), map(E, [0, b, 0]), map(E, [0, a*b, 0]), map(E, [0, 0, 1]), map(E, [0, 0, a]), map(E, [0, 0, b]), map(E, [0, 0, a*b])];
+L = hermitian_lattice(E, gens, gram = D);
+g2 = genus(L, p);
+scales(g2)
+ranks(g2)
+dets(g2)
+norms(g2)
+rank(g2), det(g2), discriminant(g2)
+```
+
+---
+
+### Predicates
+
+```@docs
+isramified(::LocalGenusHerm)
+issplit(::LocalGenusHerm)
+isinert(::LocalGenusHerm)
+isdyadic(::LocalGenusHerm)
+```
+
+#### Examples
+
+```@repl 2
+using Hecke # hide
+Qx, x = QQ["x"];
+K, a = NumberField(x^2 - 2, "a");
+Kt, t  = K["t"];
+E, b = NumberField(t^2 - a, "b");
+OK = maximal_order(K);
+p = prime_decomposition(OK, 2)[1][1];
+g1 = genus(HermLat, E, p, [(0, 1, 1, 0), (2, 2, -1, 1)], type = :det);
+isramified(g1), issplit(g1), isinert(g1), isdyadic(g1)
+```
+
+---
+
+### Local uniformizer
+
+```@docs
+uniformizer(::LocalGenusHerm)
+```
+
+#### Example
+
+```@repl 2
+using Hecke # hide
+Qx, x = QQ["x"];
+K, a = NumberField(x^2 - 2, "a");
+Kt, t  = K["t"];
+E, b = NumberField(t^2 - a, "b");
+OK = maximal_order(K);
+p = prime_decomposition(OK, 2)[1][1];
+g1 = genus(HermLat, E, p, [(0, 1, 1, 0), (2, 2, -1, 1)], type = :det);
+uniformizer(g1)
+```
+
+---
+
+### Determinant representatives
+Let $g$ be a local genus symbol for hermitian lattices. Its determinant class, or the
+determinant class of its Jordan blocks, are given by $\pm 1$, depending on whether the 
+determinants are local norms or not. It is possible to get a representative of this
+determinant class in terms of powers of the uniformizer of $g$.
+
+```@docs
+det_representative(::LocalGenusHerm, ::Int)
+det_representative(::LocalGenusHerm)
+```
+
+#### Examples
+
+```@repl 2
+using Hecke # hide
+Qx, x = QQ["x"];
+K, a = NumberField(x^2 - 2, "a");
+Kt, t  = K["t"];
+E, b = NumberField(t^2 - a, "b");
+OK = maximal_order(K);
+p = prime_decomposition(OK, 2)[1][1];
+g1 = genus(HermLat, E, p, [(0, 1, 1, 0), (2, 2, -1, 1)], type = :det);
+det_representative(g1)
+det_representative(g1,2)
+```
+
+---
+
+### Gram matrices
+
+```@docs
+gram_matrix(::LocalGenusHerm, ::Int)
+gram_matrix(::LocalGenusHerm)
+```
+
+#### Examples
+
+```@repl 2
+using Hecke # hide
+Qx, x = QQ["x"];
+K, a = NumberField(x^2 - 2, "a");
+Kt, t  = K["t"];
+E, b = NumberField(t^2 - a, "b");
+OK = maximal_order(K);
+p = prime_decomposition(OK, 2)[1][1];
+D = matrix(E, 3, 3, [5//2*a - 4, 0, 0, 0, a, a, 0, a, -4*a + 8]);
+gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [1, 0, 0]), map(E, [a, 0, 0]), map(E, [b, 0, 0]), map(E, [a*b, 0, 0]), map(E, [0, 1, 0]), map(E, [0, a, 0]), map(E, [0, b, 0]), map(E, [0, a*b, 0]), map(E, [0, 0, 1]), map(E, [0, 0, a]), map(E, [0, 0, b]), map(E, [0, 0, a*b])];
+L = hermitian_lattice(E, gens, gram = D);
+g2 = genus(L, p);
+gram_matrix(g2)
+gram_matrix(g2,1)
+```
+
+---
+---
+
+## Global genus symbols
+Let $L$ be a hermitian lattice over $E/K$. Let $P(L)$ be the set of all prime 
+ideals of $\mathcal O_K$ which are bad (ramified or dyadic), which are dividing 
+the scale of $L$ or which are dividing the volume of $L$. Let $S(E/K)$ be the 
+set of real infinite places of $K$ which split into complex places in $E$. We 
+define the *global genus symbol* $G(L)$ of $L$ to be the datum consisting of the 
+local genus symbols of $L$ at each prime of $P(L)$ and the signatures (i.e. the 
+negative index of inertia) of the Gram matrix of the rational span of $L$ at 
+each place in $S(E/K)$.
+
+Note that prime ideals in $P(L)$ which don't ramify correspond to those for which 
+the corresponding completions of $L$ are not unimodular.
+
+We say that two lattice $L$ and $L'$ over $E/K$ are in the same genus, if 
+$G(L) = G(L')$.
+ 
+### Creation of global genus symbols
+Similarly, there are two ways of constructing a global genus symbol for hermitian
+lattices:
+  - either abstractly, by choosing the extension $E/K$, the set of local genus 
+    symbols `S` and the signatures `signatures` at the places in $S(E/K)$. Note 
+    that this requires the given invariants to satisfy the product formula for Hilbert 
+    symbols.
+```julia 
+   genus(S::Vector{LocalGenusHerm}, signatures) -> GenusHerm
+```
+  Here `signatures` can be a dictionary with keys the infinite places and values 
+  the corresponding signatures, or a collection of tuples of the type 
+  `(::InfPlc, ::Int)`;
+  
+  - or by constructing the global genus symbol of a given hermitian lattice $L$.
+```julia
+   genus(L::HermLat) -> GenusHerm
+```
+
+#### Examples
+As before, we will construct two different global genus symbols for hermitian 
+lattices, which we will use for the rest of this section.
+
+```@repl 2
+using Hecke # hide
+Qx, x = QQ["x"];
+K, a = NumberField(x^2 - 2, "a");
+Kt, t  = K["t"];
+E, b = NumberField(t^2 - a, "b");
+OK = maximal_order(K);
+p = prime_decomposition(OK, 2)[1][1];
+g1 = genus(HermLat, E, p, [(0, 1, 1, 0), (2, 2, -1, 1)], type = :det);
+infp = infinite_places(E)
+SEK = unique([r.base_field_place for r in infp if isreal(r.base_field_place) && !isreal(r)]);
+length(SEK)
+G1 = genus([g1], [(SEK[1], 1)])
+D = matrix(E, 3, 3, [5//2*a - 4, 0, 0, 0, a, a, 0, a, -4*a + 8]);
+gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [1, 0, 0]), map(E, [a, 0, 0]), map(E, [b, 0, 0]), map(E, [a*b, 0, 0]), map(E, [0, 1, 0]), map(E, [0, a, 0]), map(E, [0, b, 0]), map(E, [0, a*b, 0]), map(E, [0, 0, 1]), map(E, [0, 0, a]), map(E, [0, 0, b]), map(E, [0, 0, a*b])];
+L = hermitian_lattice(E, gens, gram = D);
+G2 = genus(L)
+```
+
+---
+
+### Attributes
+
+```@docs
+base_field(::GenusHerm)
+primes(::GenusHerm)
+signatures(::GenusHerm)
+rank(::GenusHerm)
+```
+
+#### Examples
+
+```@repl 2
+using Hecke # hide
+Qx, x = QQ["x"];
+K, a = NumberField(x^2 - 2, "a");
+Kt, t  = K["t"];
+E, b = NumberField(t^2 - a, "b");
+OK = maximal_order(K);
+p = prime_decomposition(OK, 2)[1][1];
+D = matrix(E, 3, 3, [5//2*a - 4, 0, 0, 0, a, a, 0, a, -4*a + 8]);
+gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [1, 0, 0]), map(E, [a, 0, 0]), map(E, [b, 0, 0]), map(E, [a*b, 0, 0]), map(E, [0, 1, 0]), map(E, [0, a, 0]), map(E, [0, b, 0]), map(E, [0, a*b, 0]), map(E, [0, 0, 1]), map(E, [0, 0, a]), map(E, [0, 0, b]), map(E, [0, 0, a*b])];
+L = hermitian_lattice(E, gens, gram = D);
+G2 = genus(L);
+base_field(G2)
+primes(G2)
+signatures(G2)
+rank(G2)
+```
+
+---
+
+### Mass
+_Definition 4.2.1 [Kir16]_
+Let $L$ be a hermitian lattice over $E/K$, and suppose that $L$ is definite. In
+particular, the automorphism group of $L$ is finite. Let $L_1, \ldots, L_n$ be 
+a set of representatives of isometry classes in the genus of $L$. This means that 
+if $L'$ is a lattice over $E/K$ in the genus of $L$ (i.e. they are in the same genus), 
+then $L'$ is isometric to one of the $L_i$'s, and these representatives are pairwise 
+non-isometric. Then we define the *mass* of the genus $G(L)$ of $L$ to be
+```math
+   \textnormal{mass}(G(L)) := \sum_{i=1}^n\frac{1}{\#\textnormal{Aut}(L_i)}.
+```
+Note that since $L$ is definite, any lattice in the genus of $L$ is also definite, and the 
+definition makes sense.
+
+```@docs
+mass(::HermLat)
+```
+
+#### Example
+
+```@repl 2
+using Hecke # hide
+Qx, x = PolynomialRing(FlintQQ, "x");
+f = x^2 - 2;
+K, a = NumberField(f, "a", cached = false);
+Kt, t = PolynomialRing(K, "t");
+g = t^2 + 1;
+E, b = NumberField(g, "b", cached = false);
+D = matrix(E, 3, 3, [1, 0, 0, 0, 1, 0, 0, 0, 1]);
+gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [(-3*a + 7)*b + 3*a, (5//2*a - 1)*b - 3//2*a + 4, 0]), map(E, [(3004*a - 4197)*b - 3088*a + 4348, (-1047//2*a + 765)*b + 5313//2*a - 3780, (-a - 1)*b + 3*a - 1]), map(E, [(728381*a - 998259)*b + 3345554*a - 4653462, (-1507194*a + 2168244)*b - 1507194*a + 2168244, (-5917//2*a - 915)*b - 4331//2*a - 488])];
+L = hermitian_lattice(E, gens, gram = D);
+mass(L)
+```
+
+---
+---
+
+## Representatives of a genus
+
+```@docs
+representative(::LocalGenusHerm)
+Base.in(::HermLat, ::LocalGenusHerm)
+representative(::GenusHerm)
+Base.in(::HermLat, ::GenusHerm)
+representatives(::GenusHerm)
+genus_representatives(::HermLat)
+```
+
+### Examples
+
+```@repl 2
+using Hecke # hide
+Qx, x = QQ["x"];
+K, a = NumberField(x^2 - 2, "a");
+Kt, t  = K["t"];
+E, b = NumberField(t^2 - a, "b");
+OK = maximal_order(K);
+p = prime_decomposition(OK, 2)[1][1];
+g1 = genus(HermLat, E, p, [(0, 1, 1, 0), (2, 2, -1, 1)], type = :det);
+infp = infinite_places(E);
+SEK = unique([r.base_field_place for r in infp if isreal(r.base_field_place) && !isreal(r)]);
+G1 = genus([g1], [(SEK[1], 1)]);
+L1 = representative(g1)
+L1 in g1
+L2 = representative(G1)
+L2 in G1, L2 in g1
+length(genus_representatives(L1))
+length(representatives(G1))
+```
+
+---
+
+## Sum of genera
+
+```@docs
+orthogonal_sum(::LocalGenusHerm, ::LocalGenusHerm)
+orthogonal_sum(::GenusHerm, ::GenusHerm)
+```
+
+### Examples
+
+```@repl 2
+using Hecke # hide
+Qx, x = QQ["x"];
+K, a = NumberField(x^2 - 2, "a");
+Kt, t  = K["t"];
+E, b = NumberField(t^2 - a, "b");
+OK = maximal_order(K);
+p = prime_decomposition(OK, 2)[1][1];
+g1 = genus(HermLat, E, p, [(0, 1, 1, 0), (2, 2, -1, 1)], type = :det);
+infp = infinite_places(E);
+SEK = unique([r.base_field_place for r in infp if isreal(r.base_field_place) && !isreal(r)]);
+G1 = genus([g1], [(SEK[1], 1)]);
+D = matrix(E, 3, 3, [5//2*a - 4, 0, 0, 0, a, a, 0, a, -4*a + 8]);
+gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [1, 0, 0]), map(E, [a, 0, 0]), map(E, [b, 0, 0]), map(E, [a*b, 0, 0]), map(E, [0, 1, 0]), map(E, [0, a, 0]), map(E, [0, b, 0]), map(E, [0, a*b, 0]), map(E, [0, 0, 1]), map(E, [0, 0, a]), map(E, [0, 0, b]), map(E, [0, 0, a*b])];
+L = hermitian_lattice(E, gens, gram = D);
+g2 = genus(L, p);
+G2 = genus(L);
+orthogonal_sum(g1, g2)
+orthogonal_sum(G1, G2)
+```
+
+---
+
+## Enumeration of genera
+
+```@docs
+local_genera_hermitian(E, p, ::Int, ::Int, ::Int)
+genera_hermitian(E, rank, signatures, determinant, max_scale = nothing)
+```
+
+### Examples
+
+```@repl 2
+using Hecke # hide
+K, a = CyclotomicRealSubfield(8, "a");
+Kt, t = K["t"];
+E, b = number_field(t^2 - a * t + 1);
+p = prime_decomposition(maximal_order(K), 2)[1][1];
+local_genera_hermitian(E, p, 4, 2, 4)
+infp = infinite_places(E);
+SEK = unique([r.base_field_place for r in infp if isreal(r.base_field_place) && !isreal(r)]);
+genera_hermitian(E, 3, Dict(SEK[1] => 1, SEK[2] => 1), 30 * maximal_order(E))
+```
+

--- a/docs/src/quad_forms/introduction.md
+++ b/docs/src/quad_forms/introduction.md
@@ -4,48 +4,82 @@ CurrentModule = Hecke
 ```
 
 
-This chapter deals with quadratic and Hermitian spaces and lattices there of.
+This chapter deals with quadratic and hermitian spaces, and lattices there of. 
+Note that even though quadratic spaces/lattices are theoretically a special 
+case of hermitian spaces/lattices, a particular disctinction is made here. As 
+a note for knowledgeable users, only methods regarding hermitian spaces/lattices 
+over _degree 1 and degree 2 extensions of number fields_ are implemented up to now.
 
 ## Definitions and vocabulary
 
 We begin by collecting the necessary definitions and vocabulary.
 The terminology follows mainly [Kir16]
 
-### Quadratic and Hermitian spaces
+### Quadratic and hermitian spaces
 
-Let $E$ be a number field. A quadratic space is a finite-dimensional vector space
-$V$ over $E$ together with a bilinear morphism $\Phi \colon V \times V \to E$.
-We will always work with an implicit canonical basis $e_1,\dotsc,e_n$ of $V$.
-In view of this, quadratic spaces are in bijection with symmetric matrices over $E$.
-If $V$ is a quadratic space, we call the matrix $G = (\Phi(e_i, e_j))_{1 \leq i, j \leq n} \in E^{n \times n}$
-the *Gram matrix* of $V$.
+Let $K$ be a number field and let $E$ be a finitely generated etale algebra over 
+$K$ of dimension 1 or 2, i.e. $E=K$ or $E$ is a separable extension of $K$ of 
+degree 2. In both cases, $E/K$ is endowed with an $K$-linear involution 
+$\overline{\phantom{x}} \colon E \to E$ for which $K$ is the fixed field (in the 
+case $E=K$, this is simply the identity of $K$).
 
-Let $E/K$ be an extension of number fields of degree two with non-trivial automorphism $\overline{\phantom{x}} E \to E$. A *Hermitian space* is a finite-dimensional vector space
-$V$ over $E$ together with a sesquilinear (with respect to the involution $\overline{\phantom{x}}$) morphism $\Phi \colon V \times V \to K$.
-We will always work with an implicit canonical basis $e_1,\dotsc,e_n$ of $V$.
-In view of this, Hermitian spaces are in bijection with Hermitian matrices over $E$.
-If $V$ is a Hermitian space, we call the matrix $G = (\Phi(e_i, e_j))_{1 \leq i, j \leq n} \in E^{n \times n}$
-the *Gram matrix* of $V$. We call $\overline{\phantom{x}}$ the *involution* of $V$.
+A *hermitian space* $V$ over $E/K$ is a finite-dimensional $E$-vector space, 
+together with a sesquilinear (with respect to the involution of $E/K$) morphism 
+$\Phi \colon V \times V \to E$. In the trivial case $E=K$, $\Phi$ is therefore 
+a $K$-bilinear morphism and we called $(V, \Phi)$ a *quadratic hermitian space* 
+over $K$.
 
-In both cases we refer to the field $E$ as the *base ring* $V$. In this chapter
-we will refer to quadratic and Hermitian spaces also just as *spaces*.
-For Hermitian lattices, the field $K$ will be refered to as the *fixed field* of $V$.
+We will always work with an implicit canonical basis $e_1, \ldots, e_n$ of $V$. 
+In view of this, hermitian spaces over $E/K$ are in bijection with hermitian 
+matrices with entries in $E$, with respect to the involution $\overline{\phantom{x}}$. 
+In particular, there is a bijection between quadratic hermitian spaces over $K$ 
+and symmetric matrices with entries in $K$.
+For any basis $B = (v_1, \ldots, v_n)$ of $(V, \Phi)$, we call the matrix 
+$G_B = (\Phi(v_i, v_j))_{1 \leq i, j \leq n} \in E^{n \times n}$ the *Gram matrix* 
+of $(V, \Phi)$ associated to $B$. If $B$ is the implicit fixed canonical basis 
+of $(V, \Phi)$, we simply talk about the Gram matrix of $(V, \Phi)$.
 
-### Quadratic and Hermitian lattices
+For a hermitian space $V$, we refer to the field $E$ as the *base ring* of $V$ and 
+to $\overline{\phantom{x}}$ as the *involution* of $V$. Meanwhile, the field $K$ 
+is refered to as the *fixed field* of $V$.
 
-Let $V$ be a space (either quadratic or Hermitian) with base field $E$.
-A finitely generated $\mathcal O_E$-submodule $L$ of $V$ is called a *quadratic lattice* or *Hermitian lattice* respectively.
-We call $V$ the *ambient space* of $L$ and $L\otimes_{\mathcal O_E} E$ the *rational span* of $L$.
-The ring $\mathcal O_E$ will be referred to as the *base ring* of $L$.
+By abuse of language, non-quadratic hermitian spaces are sometimes simply called 
+_hermitian spaces_ and, in contrast, quadratic hermitian spaces are called 
+_quadratic spaces_. In a general context, an arbitrary space (quadratic or 
+hermitian) is refered to as a _space_ throughout this chapter.
+
+### Quadratic and hermitian lattices
+
+Let $V$ be a space over $E/K$. A finitely generated $\mathcal O_E$-submodule $L$ 
+of $V$ is called a *hermitian lattice*. By extension of vocabulary if $V$ is 
+quadratic (i.e. $E=K$), $L$ is called a *quadratic hermitian lattice*. We call 
+$V$ the *ambient space* of $L$ and $L\otimes_{\mathcal O_E} E$ the *rational span* 
+of $L$.
+
+For a hermitian lattice $L$, we refer to $E$ as the *base field* of $L$ and to 
+the ring $\mathcal O_E$ as the *base ring* of $L$. We also call 
+$\overline{\phantom{x}} \colon E \to E$ the *involution* of $L$. Finally, we 
+refer to the field $K$ fixed by this involution as the *fixed field* of $L$ and 
+to $\mathcal O_K$ as the *fixed ring* of $L$.
+
+Once again by abuse of language, non-quadratic hermitian lattices are sometimes 
+simply called _hermitian lattices_ and _quadratic lattices_ refer to quadratic
+hermitian lattices. Therefore, in a general context, an arbitrary lattice is 
+refered to as a _lattice_ in this chapter.
 
 ## References
 
-Many of the implemented algorithms for computing with quadratic and hermitian lattices
-over number fields are based on the Magma implementation of Markus Kirschmer, which can
-be found [here](http://www.math.rwth-aachen.de/~Markus.Kirschmer/magma/lat.html).
+Many of the implemented algorithms for computing with quadratic and hermitian 
+lattices over number fields are based on the Magma implementation of Markus 
+Kirschmer, which can be found [here](http://www.math.rwth-aachen.de/~Markus.Kirschmer/magma/lat.html).
+
+Most of the definitions and results are taken from:
 
 [Kir16]
-: Definite quadratic and hermitian forms with small class number. Habilitationsschrift. RWTH Aachen University, 2016, [pdf](http://www.math.rwth-aachen.de/~Markus.Kirschmer/papers/herm.pdf)
+: Definite quadratic and hermitian forms with small class number. Habilitationsschrift. RWTH Aachen University, 2016. 
+[pdf](http://www.math.rwth-aachen.de/~Markus.Kirschmer/papers/herm.pdf)
 
 [Kir19]
-: Determinant groups of hermitian lattices over local fields, Archiv der Mathematik, 113 (2019), no. 4, 337--347. [pdf](https://math.uni-paderborn.de/fileadmin/mathematik/AG-Computeralgebra/Publications-kirschmer/DETERMINANT_GROUPS_OF_HERMITIAN_LATTICES_OVER.pdf)
+: Determinant groups of hermitian lattices over local fields, Archiv der Mathematik, 113 (2019), no. 4, 337--347. 
+[pdf](https://math.uni-paderborn.de/fileadmin/mathematik/AG-Computeralgebra/Publications-kirschmer/DETERMINANT_GROUPS_OF_HERMITIAN_LATTICES_OVER.pdf)
+

--- a/docs/src/quad_forms/lattices.md
+++ b/docs/src/quad_forms/lattices.md
@@ -1,75 +1,334 @@
-# Quadratic and hermitian lattices
+# Lattices
 ```@meta
 CurrentModule = Hecke
+DocTestSetup = quote
+    using Hecke
+  end
 ```
 
 ## Creation of lattices
 
+### Inside a given ambient space
+
 ```@docs
-quadratic_lattice(::Field, ::MatElem; gram = nothing)
-quadratic_lattice(::Field, ::PMat; gram = nothing)
-hermitian_lattice(::NumField, ::MatElem; gram = nothing)
-hermitian_lattice(::NumField, ::PMat; gram = nothing)
+lattice(::AbsSpace)
+lattice(::AbsSpace, ::PMat)
+lattice(::AbsSpace, ::MatElem)
+lattice(::AbsSpace, ::Vector)
 ```
+
+### Quadratic lattice over a number field
+
+```@docs
+quadratic_lattice(::Field)
+quadratic_lattice(::Field, ::PMat)
+quadratic_lattice(::Field, ::MatElem)
+quadratic_lattice(::Field, ::Vector)
+```
+
+### Hermitian lattice over a degree 2 extension
+
+```@docs
+hermitian_lattice(::NumField)
+hermitian_lattice(::NumField, ::PMat)
+hermitian_lattice(::NumField, ::MatElem)
+hermitian_lattice(::NumField, ::Vector)
+```
+
+#### Examples
+The two following examples will be used all along this section:
+
+```@repl 2 
+using Hecke # hide
+K, a = rationals_as_number_field();
+Kt, t = K["t"];
+g = t^2 + 7;
+E, b = NumberField(g, "b"); 
+D = matrix(K, 3, 3, [2, 0, 0, 0, 2, 0, 0, 0, 2]);
+gens = Vector{nf_elem}[map(K, [1, 1, 0]), map(K, [1, 0, 1]), map(K, [2, 0, 0])];
+Lquad = quadratic_lattice(K, gens, gram = D)
+D = matrix(E, 4, 4, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [2, -1, 0, 0]), map(E, [-3, 0, -1, 0]), map(E, [0, 0, 0, -1]), map(E, [b, 0, 0, 0])];
+Lherm = hermitian_lattice(E, gens, gram = D) 
+```
+
+Note that the format used here is the one given by the internal function 
+`Hecke.to_hecke()` which prints REPL commands to get back the input lattice.
+
+```@repl 2
+using Hecke # hide
+K, a = rationals_as_number_field();
+Kt, t = K["t"];
+g = t^2 + 7;
+E, b = NumberField(g, "b");
+D = matrix(E, 4, 4, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [2, -1, 0, 0]), map(E, [-3, 0, -1, 0]), map(E, [0, 0, 0, -1]), map(E, [b, 0, 0, 0])];
+Lherm = hermitian_lattice(E, gens, gram = D);
+Hecke.to_hecke(Lherm)
+```
+
+Finally, one can access some databases in which are stored several quadratic and
+hermitian lattices. Up to now, these are not automatically available while running 
+Hecke. It can nonethelss be used in the following way:
+
+```@repl 2
+using Hecke # hide
+qld = Hecke.quadratic_lattice_database()
+lattice(qld, 1)
+hlb = Hecke.hermitian_lattice_database()
+lattice(hlb, 426)
+```
+
 ---
 
-## Basic invariants
+## Ambient space and rational span
 
 ```@docs
-ambient_space(L::AbsLat)
+ambient_space(::AbsLat)
 rational_span(::AbsLat)
-fixed_field(L::AbsLat)
-involution(::AbsLat)
-rank(L::AbsLat)
-degree(L::AbsLat)
-generators(L::AbsLat; minimal::Bool = false)
-discriminant(L::AbsLat)
-pseudo_matrix(L::AbsLat)
-coefficient_ideals(L::AbsLat)
-absolute_basis(L::AbsLat)
-absolute_basis_matrix(L::AbsLat)
+basis_matrix_of_rational_span(::AbsLat)
+gram_matrix_of_rational_span(::AbsLat)
+diagonal_of_rational_span(::AbsLat)
 ```
+
+### Examples
+
+```@repl 2
+using Hecke # hide
+K, a = rationals_as_number_field();
+Kt, t = K["t"];
+g = t^2 + 7;
+E, b = NumberField(g, "b");
+D = matrix(K, 3, 3, [2, 0, 0, 0, 2, 0, 0, 0, 2]);
+gens = Vector{nf_elem}[map(K, [1, 1, 0]), map(K, [1, 0, 1]), map(K, [2, 0, 0])];
+Lquad = quadratic_lattice(K, gens, gram = D);
+D = matrix(E, 4, 4, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [2, -1, 0, 0]), map(E, [-3, 0, -1, 0]), map(E, [0, 0, 0, -1]), map(E, [b, 0, 0, 0])];
+Lherm = hermitian_lattice(E, gens, gram = D);
+ambient_space(Lherm)
+rational_span(Lquad)
+basis_matrix_of_rational_span(Lherm)
+gram_matrix_of_rational_span(Lherm)
+diagonal_of_rational_span(Lquad)
+```
+
 ---
 
-## Rational invariants
+## Rational equivalence
 
 ```@docs
 hasse_invariant(L::QuadLat, p)
-witt_invariant(L::QuadLat, p::NfAbsOrdIdl)
+witt_invariant(L::QuadLat, p)
 isrationally_isometric(::AbsLat, ::AbsLat, ::NfAbsOrdIdl)
 isrationally_isometric(L::AbsLat, M::AbsLat)
 ```
+
+### Examples
+For now and for the rest of this section, the examples will include the new lattice 
+`Lquad2` which is quadratic. Moreover, all the completions are going to be done at 
+the prime ideal $p = 7*\mathcal O_K$.
+
+```@repl hecke
+using Hecke # hide
+K, a = rationals_as_number_field();
+D = matrix(K, 3, 3, [2, 0, 0, 0, 2, 0, 0, 0, 2]);
+gens = Vector{nf_elem}[map(K, [1, 1, 0]), map(K, [1, 0, 1]), map(K, [2, 0, 0])];
+Lquad = quadratic_lattice(K, gens, gram = D);
+D = matrix(K, 3, 3, [2, 0, 0, 0, 2, 0, 0, 0, 2]);
+gens = Vector{nf_elem}[map(K, [-35, 25, 0]), map(K, [30, 40, -20]), map(K, [5, 10, -5])];
+Lquad2 = quadratic_lattice(K, gens, gram = D) 
+OK = maximal_order(K);
+p = prime_decomposition(OK, 7)[1][1]
+hasse_invariant(Lquad, p), witt_invariant(Lquad, p)
+isrationally_isometric(Lquad, Lquad2, p)
+isrationally_isometric(Lquad, Lquad2)
+```
+
 ---
 
-## Definiteness
+## Attributes
+Let $L$ be a lattice over $E/K$. We call a *pseudo-basis* of $L$ any sequence
+of pairs $(\mathfrak A_i, x_i)_{1 \leq i \leq n}$ where the $\mathfrak A_i$'s 
+are fractional (left) ideals of $\mathcal O_E$ and $(x_i)_{1 \leq i \leq n}$ 
+is a basis of the rational span of $L$, and such that
+
+```math
+   L = \bigoplus_{i = 1}^n \mathfrak A_ix_i.
+```
+
+Note that a pseudo-basis is not unique. Given a pseudo-basis 
+$(\mathfrak A_i, x_i)_{1 \leq i \leq n}$ of $L$, we define the corresponding 
+*pseudo-matrix* of $L$ to be the datum consisting of a list of  *coefficient ideals* 
+corresponding to the ideals $\mathfrak A_i$'s and a matrix whose _rows_ are the 
+coordinates of the $x_i$'s in the canonical basis of the ambient space of $L$ 
+(conversely, given any such pseudo-matrix, one can define the corresponding pseudo-basis).
 
 ```@docs
+rank(L::AbsLat)
+degree(L::AbsLat)
+discriminant(::AbsLat)
+base_field(::AbsLat)
+base_ring(::AbsLat)
+fixed_field(::AbsLat)
+fixed_ring(::AbsLat)
+involution(::AbsLat)
+pseudo_matrix(::AbsLat)
+pseudo_basis(::AbsLat)
+coefficient_ideals(::AbsLat)
+absolute_basis_matrix(::AbsLat)
+absolute_basis(::AbsLat)
+generators(L::AbsLat; minimal::Bool = false)
+gram_matrix_of_generators(::AbsLat; minimal::Bool = false)
+```
+
+### Examples
+
+```@repl 2
+using Hecke # hide
+K, a = rationals_as_number_field();
+Kt, t = K["t"];
+g = t^2 + 7;
+E, b = NumberField(g, "b");
+D = matrix(E, 4, 4, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [2, -1, 0, 0]), map(E, [-3, 0, -1, 0]), map(E, [0, 0, 0, -1]), map(E, [b, 0, 0, 0])];
+Lherm = hermitian_lattice(E, gens, gram = D);
+rank(Lherm), degree(Lherm)
+discriminant(Lherm)
+base_field(Lherm)
+base_ring(Lherm)
+fixed_field(Lherm)
+fixed_ring(Lherm)
+involution(Lherm)
+pseudo_matrix(Lherm)
+pseudo_basis(Lherm)
+coefficient_ideals(Lherm)
+absolute_basis_matrix(Lherm)
+absolute_basis(Lherm)
+generators(Lherm)
+gram_matrix_of_generators(Lherm)
+```
+---
+
+## Module operations
+Let $L$ be a lattice over $E/K$ inside the space $(V, \Phi)$. The *dual lattice*
+of $L$ is defined to be the following lattice over $E/K$ in $(V, \Phi)$:
+
+```math
+   L^{\#} = \left\{ x \in V \mid \Phi(x,L) \subseteq \mathcal O_E \right\}.
+```
+
+For any fractional (left) ideal $\mathfrak a$ of $\mathcal O_E$, one can define
+the lattice $\mathfrak aL$ to be the lattice over $E/K$, in the same space $(V, \Phi)$,  
+obtained by rescaling the coefficient ideals of a pseudo-basis of $L$ by $\mathfrak a$. 
+In another flavour, for any non-zero element $a \in K$, one defines the *rescaled lattice* 
+$L^a$ to be the lattice over $E/K$ with the same underlying module as $L$ (i.e. the same
+pseudo-bases) but in space $(V, a\Phi)$.
+
+```@docs
+Base.:(+)(::AbsLat, ::AbsLat)
+intersect(::AbsLat, ::AbsLat)
+Base.:(*)(::NumFieldElem, ::AbsLat)
+Base.:(*)(::NumFieldOrdIdl, ::AbsLat)
+Base.:(*)(::NumFieldOrdFracIdl, ::AbsLat)
+rescale(::AbsLat, ::NumFieldElem)
+dual(::AbsLat)
+```
+
+### Examples
+
+```@repl 2
+using Hecke # hide
+K, a = rationals_as_number_field();
+D = matrix(K, 3, 3, [2, 0, 0, 0, 2, 0, 0, 0, 2]);
+gens = Vector{nf_elem}[map(K, [1, 1, 0]), map(K, [1, 0, 1]), map(K, [2, 0, 0])];
+Lquad = quadratic_lattice(K, gens, gram = D);
+D = matrix(K, 3, 3, [2, 0, 0, 0, 2, 0, 0, 0, 2]);
+gens = Vector{nf_elem}[map(K, [-35, 25, 0]), map(K, [30, 40, -20]), map(K, [5, 10, -5])];
+Lquad2 = quadratic_lattice(K, gens, gram = D);
+OK = maximal_order(K);
+p = prime_decomposition(OK, 7)[1][1];
+pseudo_matrix(Lquad + Lquad2)
+pseudo_matrix(intersect(Lquad, Lquad2))
+pseudo_matrix(p*Lquad)
+ambient_space(rescale(Lquad,3*a))
+pseudo_matrix(Lquad)
+```
+
+---
+
+## Invariants
+Let $L$ be a lattice over $E/K$, in the space $(V, \Phi)$. We define:
+- the *norm* $\mathfrak n(L)$ of $L$ to be the ideal of $\mathfrak O_K$ generated 
+  by the squares $\left\{\Phi(x,x) \mid x \in L \right\}$;
+- the *scale* $\mathfrak s(L)$ of $L$ to be the set 
+  $\Phi(L,L) = \left\{\Phi(x,y) \mid x,y \in L \right\}$;
+- the *volume* $\mathfrak v(L)$ of $L$ to be the index ideal
+
+```math
+   \lbrack L^{\#} \colon L \rbrack_{\mathcal O_E} := \langle \left\{ \sigma \mid \sigma \in \textnormal{Hom}_{\mathcal O_E}(L^{\#}, L) \right\} \rangle_{\mathcal O_E}.
+```
+
+Note that these are fractional ideals of $\mathcal O_E$.
+
+```@docs
+norm(::AbsLat)
+scale(L::AbsLat)
+volume(L::AbsLat)
+```
+
+### Examples 
+
+```@repl 2
+using Hecke # hide
+K, a = rationals_as_number_field();
+Kt, t = K["t"];
+g = t^2 + 7;
+E, b = NumberField(g, "b");
+D = matrix(E, 4, 4, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [2, -1, 0, 0]), map(E, [-3, 0, -1, 0]), map(E, [0, 0, 0, -1]), map(E, [b, 0, 0, 0])];
+Lherm = hermitian_lattice(E, gens, gram = D);
+norm(Lherm)
+scale(Lherm)
+volume(Lherm)
+```
+---
+
+## Predicates
+Let $L$ be a lattice over $E/K$. It is said to be *integral* if its scale is an 
+integral ideal, i.e. it is contained in $\mathcal O_E$. Moreover, if $\mathfrak p$ 
+is a prime ideal in $\mathcal O_K$, then $L$ is said to be *modular* (resp. 
+*locally modular at $\mathfrak p$*) if there exists a fractional ideal $\mathfrak a$ 
+of $\mathcal O_E$ (resp. an integer $v$) such that $\mathfrak aL^{\#} = L$ (resp. 
+$\mathfrak p^vL_{\mathfrak p}^{\#} = L_{\mathfrak p}$).
+
+```@docs
+isintegral(::AbsLat)
+ismodular(::AbsLat)
+ismodular(::AbsLat, p)
 ispositive_definite(L::AbsLat)
 isnegative_definite(L::AbsLat)
 isdefinite(L::AbsLat)
 can_scale_totally_positive(L::AbsLat)
 ```
----
 
-## Module operations
+### Examples 
 
-```@docs
-Base.:(*)(::NumFieldElem, ::AbsLat)
-Base.:(*)(::NfOrdIdl, ::AbsLat)
-Base.:(*)(::NfOrdFracIdl, ::AbsLat)
-rescale(::AbsLat, ::NumFieldElem)
-dual(::AbsLat)
-```
----
-
-## Invariants
-
-```@docs
-norm(::AbsLat)
-scale(L::AbsLat)
-isintegral(L::AbsLat)
-volume(L::AbsLat)
-ismodular(L::AbsLat)
+```@repl 2
+using Hecke # hide
+K, a = rationals_as_number_field();
+Kt, t = K["t"];
+g = t^2 + 7;
+E, b = NumberField(g, "b");
+D = matrix(E, 4, 4, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [2, -1, 0, 0]), map(E, [-3, 0, -1, 0]), map(E, [0, 0, 0, -1]), map(E, [b, 0, 0, 0])];
+Lherm = hermitian_lattice(E, gens, gram = D);
+OK = maximal_order(K);
+isintegral(Lherm)
+ismodular(Lherm)[1]
+p = prime_decomposition(OK, 7)[1][1];
+ismodular(Lherm, p)
+ispositive_definite(Lherm)
+can_scale_totally_positive(Lherm)
 ```
 ---
 
@@ -78,43 +337,118 @@ ismodular(L::AbsLat)
 ```@docs
 local_basis_matrix(L::AbsLat, p; type::Symbol = :any)
 jordan_decomposition(L::AbsLat, p::NfOrdIdl)
-islocally_isometric(::AbsLat, ::AbsLat, ::NfOrdIdl)
+isisotropic(::AbsLat, p)
 ```
+
+### Examples 
+
+```@repl 2
+using Hecke # hide
+K, a = rationals_as_number_field();
+D = matrix(K, 3, 3, [2, 0, 0, 0, 2, 0, 0, 0, 2]);
+gens = Vector{nf_elem}[map(K, [1, 1, 0]), map(K, [1, 0, 1]), map(K, [2, 0, 0])];
+Lquad = quadratic_lattice(K, gens, gram = D);
+OK = maximal_order(K);
+p = prime_decomposition(OK, 7)[1][1];
+local_basis_matrix(Lquad, p)
+jordan_decomposition(Lquad, p)
+isisotropic(Lquad, p)
+```
+
 ---
 
-## Genera
+## Automorphisms for definite lattices
+Let $L$ and $L'$ be two lattices over the same extension $E/K$, inside their 
+respective ambient spaces $(V, \Phi)$ and $(V', \Phi')$. Similarly to homomorphisms 
+of spaces, we define a *homomorphism of lattices* from $L$ to $L'$ to be an $E$-module 
+homomorphism $f \colon L \to L'$ such that for all $x,y \in L$, one has
 
-### Creation of genera from lattices
+```math
+   \Phi'(f(x), f(y)) = \Phi(x,y).
+```
+
+Again, any automorphism of lattices is called an *isometry* and any monomorphism is 
+called an *embedding*. We refer to the set of isometries from a lattice $L$ to itself 
+as the *automorphism group of $L$*.
 
 ```@docs
-genus(L::HermLat, p)
-genus(L::HermLat)
+automorphism_group_order(::AbsLat)
+automorphism_group_generators(::AbsLat)
 ```
+
+### Examples 
+
+```@repl 2
+using Hecke # hide
+K, a = rationals_as_number_field();
+Kt, t = K["t"];
+g = t^2 + 7;
+E, b = NumberField(g, "b");
+D = matrix(K, 3, 3, [2, 0, 0, 0, 2, 0, 0, 0, 2]);
+gens = Vector{nf_elem}[map(K, [1, 1, 0]), map(K, [1, 0, 1]), map(K, [2, 0, 0])];
+Lquad = quadratic_lattice(K, gens, gram = D);
+isdefinite(Lquad)
+automorphism_group_order(Lquad)
+automorphism_group_generators(Lquad)
+```
+
 ---
 
-### Properties of genera
+## Isometry
 
 ```@docs
-rank(G::LocalGenusHerm)
-rank(G::LocalGenusHerm, i::Int)
-ranks(G::LocalGenusHerm)
-det(G::LocalGenusHerm)
-det_representative(G::LocalGenusHerm)
-gram_matrix(G::LocalGenusHerm)
-primes(G::GenusHerm)
+isisometric(::AbsLat, ::AbsLat)
+islocally_isometric(::AbsLat, ::AbsLat, p::NfOrdIdl)
 ```
+
+### Examples 
+
+```@repl 2
+using Hecke # hide
+K, a = rationals_as_number_field();
+D = matrix(K, 3, 3, [2, 0, 0, 0, 2, 0, 0, 0, 2]);
+gens = Vector{nf_elem}[map(K, [1, 1, 0]), map(K, [1, 0, 1]), map(K, [2, 0, 0])];
+Lquad = quadratic_lattice(K, gens, gram = D);
+D = matrix(K, 3, 3, [2, 0, 0, 0, 2, 0, 0, 0, 2]);
+gens = Vector{nf_elem}[map(K, [-35, 25, 0]), map(K, [30, 40, -20]), map(K, [5, 10, -5])];
+Lquad2 = quadratic_lattice(K, gens, gram = D);
+OK = maximal_order(K);
+p = prime_decomposition(OK, 7)[1][1];
+isisometric(Lquad, Lquad2)
+islocally_isometric(Lquad, Lquad2, p)
+```
+
 ---
 
-### Check if lattice is contained in genus
+## Maximal integral lattices
 
 ```@docs
-Base.in(L::HermLat, G::LocalGenusHerm)
-Base.in(L::HermLat, G::GenusHerm)
+ismaximal_integral(::AbsLat, p)
+ismaximal_integral(::AbsLat)
+ismaximal(::AbsLat, p)
+maximal_integral_lattice(::AbsLat, p)
+maximal_integral_lattice(::AbsLat)
+maximal_integral_lattice(::AbsSpace)
 ```
----
 
-### Creating representatives
+### Examples
 
-```@docs
-representative(G::LocalGenusHerm)
+```@repl 2
+using Hecke # hide
+K, a = rationals_as_number_field();
+Kt, t = K["t"];
+g = t^2 + 7;
+E, b = NumberField(g, "b");
+D = matrix(E, 4, 4, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [2, -1, 0, 0]), map(E, [-3, 0, -1, 0]), map(E, [0, 0, 0, -1]), map(E, [b, 0, 0, 0])];
+Lherm = hermitian_lattice(E, gens, gram = D);
+OK = maximal_order(K);
+p = prime_decomposition(OK, 7)[1][1];
+ismaximal_integral(Lherm, p)
+ismaximal_integral(Lherm)
+ismaximal(Lherm, p)
+pseudo_basis(maximal_integral_lattice(Lherm, p))
+pseudo_basis(maximal_integral_lattice(Lherm))
+pseudo_basis(maximal_integral_lattice(ambient_space(Lherm)))
 ```
+

--- a/src/HeckeTypes.jl
+++ b/src/HeckeTypes.jl
@@ -869,7 +869,7 @@ const NfAbsOrdIdlSetID = Dict{NfAbsOrd, NfAbsOrdIdlSet}()
     No sanity checks. No data is copied, $x$ should not be used anymore.
 
 """
-mutable struct NfAbsOrdIdl{S, T} <: NumFieldOrdIdl
+@attributes mutable struct NfAbsOrdIdl{S, T} <: NumFieldOrdIdl
   order::NfAbsOrd{S, T}
   basis::Vector{NfAbsOrdElem{S, T}}
   basis_matrix::fmpz_mat

--- a/src/Map/Map.jl
+++ b/src/Map/Map.jl
@@ -25,8 +25,12 @@ end
 
 function preimage(M::Map{D, C}, a) where {D, C}
   if isdefined(M.header, :preimage)
-    p = M.header.preimage(a)::elem_type(D)
-    @assert parent(p) === domain(M)
+    if isdefined(M.header, :domain)
+      p = M.header.preimage(a)::elem_type(M.header.domain)
+      @assert parent(p) === domain(M)
+    else
+      error("No domain known")
+    end
     return p
   end
   error("No preimage function known")
@@ -35,7 +39,11 @@ end
 function image(M::Map{D, C}, a) where {D, C}
   if isdefined(M, :header)
     if isdefined(M.header, :image)
-      return M.header.image(a)::elem_type(C)
+      if isdefined(M.header, :codomain)
+        return M.header.image(a)::elem_type(M.header.codomain)
+      else
+        error("No codomain known")
+      end
     else
       error("No image function known")
     end

--- a/src/Map/NfRel.jl
+++ b/src/Map/NfRel.jl
@@ -117,3 +117,4 @@ function haspreimage(m::NfRelToAbsAlgAssMor, a::AbsAlgAssElem)
     return false, zero(domain(m))
   end
 end
+

--- a/src/Map/NfRelOrd.jl
+++ b/src/Map/NfRelOrd.jl
@@ -160,14 +160,14 @@ function RelOrdQuoMap(O::T1, Q::RelOrdQuoRing{T1, T2, T3}) where { T1, T2, T3 }
 end
 
 
-mutable struct NfRelOrdToRelFinFieldMor{T, S, U, W} <: Map{NfRelOrd{T, S, U}, RelFinField, HeckeMap, NfRelOrdToRelFinFieldMor}
-  header::MapHeader{NfRelOrd{T, S, U}, RelFinField{W}}
+mutable struct NfRelOrdToRelFinFieldMor{S, T} <: Map{S, RelFinField{T}, HeckeMap, NfRelOrdToRelFinFieldMor}
+  header::MapHeader{S, RelFinField{T}}
   poly_of_the_field
-  P::NfRelOrdIdl{T, S, U}
+  P
   map_subfield::Union{NfOrdToFqMor, NfRelOrdToRelFinFieldMor}
 
-    function NfRelOrdToRelFinFieldMor{T, S, U, W}(O::NfRelOrd{T, S, U}, P::NfRelOrdIdl{T, S, U}, mapsub::NfOrdToFqMor) where {T, S, U, W <: fq}
-    z = new{T, S, U, W}()
+    function NfRelOrdToRelFinFieldMor{S, T}(O::S, P, mapsub::NfOrdToFqMor) where {S, T <: fq}
+    z = new{S, T}()
     z.P = P
     z.map_subfield = mapsub
     p = minimum(P, copy = false)
@@ -259,8 +259,8 @@ mutable struct NfRelOrdToRelFinFieldMor{T, S, U, W} <: Map{NfRelOrd{T, S, U}, Re
     return z
   end
 
-  function NfRelOrdToRelFinFieldMor{T, S, U, W}(O::NfRelOrd{T, S, U}, P::NfRelOrdIdl{T, S, U}, mapsub::NfRelOrdToRelFinFieldMor) where {T, S, U, W <: RelFinFieldElem}
-    z = new{T, S, U, W}()
+  function NfRelOrdToRelFinFieldMor{S, T}(O::S, P, mapsub::NfRelOrdToRelFinFieldMor) where {S, T <: RelFinFieldElem}
+    z = new{S, T}()
     z.P = P
     z.map_subfield = mapsub
     p = minimum(P, copy = false)
@@ -363,20 +363,20 @@ mutable struct NfRelOrdToRelFinFieldMor{T, S, U, W} <: Map{NfRelOrd{T, S, U}, Re
 
 end
 
-mutable struct NfRelToRelFinFieldMor{T, W} <: Map{NfRel{T}, Hecke.RelFinField, HeckeMap, NfRelToRelFinFieldMor}
-  header::MapHeader{NfRel{T}, Hecke.RelFinField{W}}
+mutable struct NfRelToRelFinFieldMor{S, T} <: Map{S, Hecke.RelFinField{T}, HeckeMap, NfRelToRelFinFieldMor}
+  header::MapHeader{S, Hecke.RelFinField{T}}
 
-  function NfRelToRelFinFieldMor{T, W}() where {T, W <: FinFieldElem}
-    z = new{T, W}()
-    z.header = MapHeader{NfRel{T}, Hecke.RelFinField{W}}()
+  function NfRelToRelFinFieldMor{S, T}() where {S <: NfRel, T <: FinFieldElem}
+    z = new{S, T}()
+    z.header = MapHeader{S, Hecke.RelFinField{T}}()
     return z
   end
 end
 
-function extend(f::NfRelOrdToRelFinFieldMor{T, S, U, W}, E::NfRel{T}) where {T, S, U, W}
+function extend(f::NfRelOrdToRelFinFieldMor{S, T}, E::NfRel) where {S, T}
   nf(domain(f)) != E && error("Number field is not the number field of the order")
 
-  g = NfRelToRelFinFieldMor{T, W}()
+  g = NfRelToRelFinFieldMor{typeof(E), T}()
   g.header.domain = E
   g.header.codomain = f.header.codomain
 
@@ -384,7 +384,7 @@ function extend(f::NfRelOrdToRelFinFieldMor{T, S, U, W}, E::NfRel{T}) where {T, 
   P = f.P
   u = anti_uniformizer(P)
 
-  function _image(x::NfRelElem{T})
+  function _image(x::NfRelElem)
     m = denominator(x, OE)
     a = OE(m*x)
     b = OE(m)

--- a/src/Map/NfRelOrd.jl
+++ b/src/Map/NfRelOrd.jl
@@ -122,7 +122,7 @@ function extend(f::NfRelOrdToFqMor{T, S}, K::NfRel{T}) where {T, S}
 end
 
 mutable struct RelOrdToAlgAssMor{S, T} <: Map{S, AlgAss{T}, HeckeMap, RelOrdToAlgAssMor}
-  header::MapHeader
+  header::MapHeader{S, AlgAss{T}}
 
   function RelOrdToAlgAssMor{S, T}(O::S, A::AlgAss{T}, _image::Function, _preimage::Function) where { S <: Union{ NfRelOrd, AlgAssRelOrd }, T }
     z = new{S, T}()

--- a/src/Misc/Poly.jl
+++ b/src/Misc/Poly.jl
@@ -108,7 +108,7 @@ function rem!(z::fq_nmod_poly, x::fq_nmod_poly, y::fq_nmod_poly)
 end
 
 function rem!(z::fq_poly, x::fq_poly, y::fq_poly)
-  ccall((fq_poly_rem, libflint), Nothing, (fq_poly, fq_poly, fq_poly, FqPolyRing),
+  ccall((:fq_poly_rem, libflint), Nothing, (Ref{fq_poly}, Ref{fq_poly}, Ref{fq_poly}, Ref{FqPolyRing}),
        z, x, y, parent(x))
   return z
 end

--- a/src/Misc/RelFiniteField.jl
+++ b/src/Misc/RelFiniteField.jl
@@ -1,4 +1,4 @@
-################################################################################
+###############################################################################
 #
 #  Types
 #
@@ -491,6 +491,7 @@ end
 
 function absolute_basis(F::RelFinField{T}) where T <: FinFieldElem
   BK = absolute_basis(base_field(F))
+  BK = F.(BK)
   gF = gen(F)
   BF = Vector{elem_type(F)}(undef, absolute_degree(F))
   ind = 1
@@ -716,7 +717,7 @@ function absolute_field(F::RelFinField{T}; cached::Bool = true) where T <: FinFi
     el = F()
     for i = 1:degree(K)
       if !iszero(aux[1, i])
-        el += aux[1, i]*abs_basis[i]
+        el += F(aux[1, i])*abs_basis[i]
       end
     end
     return el
@@ -800,3 +801,5 @@ function fq_nmod_to_xy(f, Qxy::PolyRing, Qx::PolyRing)
   end
   return res
 end
+
+

--- a/src/NumField/NfRel/Types.jl
+++ b/src/NumField/NfRel/Types.jl
@@ -170,7 +170,7 @@ mutable struct NfRelOrdIdlSet{T, S, U}
   end
 end
 
-mutable struct NfRelOrdIdl{T, S, U} <: NumFieldOrdIdl
+@attributes mutable struct NfRelOrdIdl{T, S, U} <: NumFieldOrdIdl
   order::NfRelOrd{T, S, U}
   parent::NfRelOrdIdlSet{T, S, U}
   basis_pmatrix::PMat{T, S}

--- a/src/NumFieldOrd/NfOrd/ResidueField.jl
+++ b/src/NumFieldOrd/NfOrd/ResidueField.jl
@@ -229,26 +229,25 @@ function relative_residue_field(O::NfRelOrd{S, T, U}, P::NfRelOrdIdl{S, T, U}) w
   @req order(P) === O "P must be an ideal of O"
   E = nf(O)
   K = base_field(E)
-  projK = get_attribute(K, :rel_residue_field_map)
+  p = minimum(P)
+  projK = get_attribute(p, :rel_residue_field_map)
   if projK === nothing
     OK = maximal_order(K)
-    p = minimum(P, copy = false)
     if !(K isa Hecke.NfRel)
       _, projK = ResidueField(OK, p)
-      set_attribute!(K, :rel_residue_field_map, projK)
+      set_attribute!(p, :rel_residue_field_map, projK)
     else
       _, projK = relative_residue_field(OK, p)
-      set_attribute!(K, :rel_residue_field_map, projK)
+      set_attribute!(p, :rel_residue_field_map, projK)
     end
   end
   FK = codomain(projK)
-  types = collect(typeof(O).parameters)
   if base_field(K) isa FlintRationalField
-    projE = NfRelOrdToRelFinFieldMor{types[1], types[2], types[3], fq}(O, P, projK)
+    projE = NfRelOrdToRelFinFieldMor{typeof(O), fq}(O, P, projK)
   else
-    projE = NfRelOrdToRelFinFieldMor{types[1], types[2], types[3], Hecke.RelFinFieldElem{typeof(FK), typeof(FK.defining_polynomial)}}(O, P, projK)
+    projE = NfRelOrdToRelFinFieldMor{typeof(O), Hecke.RelFinFieldElem{typeof(FK), typeof(FK.defining_polynomial)}}(O, P, projK)
   end
-  set_attribute!(E, :rel_residue_field_map, projE)
+  set_attribute!(P, :rel_residue_field_map, projE)
   return codomain(projE), projE
 end
 

--- a/src/NumFieldOrd/NfOrd/ResidueField.jl
+++ b/src/NumFieldOrd/NfOrd/ResidueField.jl
@@ -220,9 +220,6 @@ residue field of a maximal order in `K` at $minimum(P)$.
 
 Note that if `K` is a relative number field, the latter will also be seen as a 
 relative residue field.
-
-The map from `O` to the residue field is stored in `E` under the attribute 
-`:rel_residue_field_map`.
 """
 function relative_residue_field(O::NfRelOrd{S, T, U}, P::NfRelOrdIdl{S, T, U}) where {S, T, U}
   @req ismaximal(O) "O must be maximal"

--- a/src/QuadForm/Herm/Genus.jl
+++ b/src/QuadForm/Herm/Genus.jl
@@ -94,8 +94,8 @@ end
     scale(g::LocalGenusHerm, i::Int) -> Int
 
 Given a local genus symbol `g` for hermitian lattices over $E/K$ at a prime $\mathfrak 
-p$ of $O_K$, return the $\mathfrak P$-valuation of the scale of the `i`th Jordan block of 
-`g`, where $\mathfrak P$ is a prime ideal of $O_E$ lying over $\mathfrak p$.
+p$ of $\mathcal O_K$, return the $\mathfrak P$-valuation of the scale of the `i`th 
+Jordan block of `g`, where $\mathfrak P$ is a prime ideal of $O_E$ lying over $\mathfrak p$.
 """
 scale(G::LocalGenusHerm, i::Int) = G.data[i][1]
 
@@ -103,8 +103,8 @@ scale(G::LocalGenusHerm, i::Int) = G.data[i][1]
     scales(g::LocalGenusHerm) -> Vector{Int}
 
 Given a local genus symbol `g` for hermitian lattices over $E/K$ at a prime $\mathfrak 
-p$ of $O_K$, return the $\mathfrak P$-valuation of the scales of the Jordan blocks of `g`, 
-where $\mathfrak P$ is a prime ideal of $O_E$ lying over $\mathfrak p$.
+p$ of $\mathcal O_K$, return the $\mathfrak P$-valuation of the scales of the Jordan 
+blocks of `g`, where $\mathfrak P$ is a prime ideal of $\mathcal O_E$ lying over $\mathfrak p$.
 """
 scales(G::LocalGenusHerm) = map(i -> scale(G, i), 1:length(G))::Vector{Int}
 
@@ -120,8 +120,8 @@ rank(G::LocalGenusHerm, i::Int) = G.data[i][2]
     rank(g::LocalGenusHerm) -> Int
 
 Given a local genus symbol `g` for hermitian lattices over $E/K$ at a prime ideal
-$\mathfrak p$ of $O_K$, return the rank of any hermitian lattice whose $\mathfrak p$-adic
-completion has local genus symbol `g`.
+$\mathfrak p$ of $\mathcal O_K$, return the rank of any hermitian lattice whose 
+$\mathfrak p$-adic completion has local genus symbol `g`.
 """
 function rank(G::LocalGenusHerm)
   return reduce(+, (rank(G, i) for i in 1:length(G)), init = Int(0))
@@ -149,10 +149,11 @@ det(G::LocalGenusHerm, i::Int) = G.data[i][3]
     det(g::LocalGenusHerm) -> Int
 
 Given a local genus symbol `g` for hermitian lattices over $E/K$ at a prime ideal
-$\mathfrak p$ of $O_K$, return the determinant of a hermitian lattice whose $\mathfrak p$-adic
-completion has local genus symbol `g`. 
+$\mathfrak p$ of $\mathcal O_K$, return the determinant of a hermitian lattice 
+whose $\mathfrak p$-adic completion has local genus symbol `g`. 
 
-The returned value is $1$ or $-1$ depending on whether the determinant is a local norm in `K`.
+The returned value is $1$ or $-1$ depending on whether the determinant is a local 
+norm in `K`.
 """
 function det(G::LocalGenusHerm)
   return reduce(*, (det(G, i) for i in 1:length(G)), init = Int(1))
@@ -196,10 +197,11 @@ end
     discriminant(g::LocalGenusHerm) -> Int
 
 Given a local genus symbol `g` for hermitian lattices over $E/K$ at a prime ideal
-$\mathfrak p$ of $O_K$, return the discriminant of a hermitian lattice whose $\mathfrak p$-adic
-completion has local genus symbol `g`. 
+$\mathfrak p$ of $\mathcal O_K$, return the discriminant of a hermitian lattice 
+whose $\mathfrak p$-adic completion has local genus symbol `g`. 
 
-The returned value is $1$ or $-1$ depending on whether the discriminant is a local norm in `K`.
+The returned value is $1$ or $-1$ depending on whether the discriminant is a local 
+norm in `K`.
 """
 function discriminant(G::LocalGenusHerm)
   d = det(G)
@@ -221,8 +223,8 @@ end
     norm(g::LocalGenusHerm, i::Int) -> Int
 
 Given a ramified dyadic local genus symbol `g` for hermitian lattices over $E/K$ at a 
-prime ideal $\mathfrak p$ of $O_K$, return the $\mathfrak p$-valuation of the norm of 
-the `i`th Jordan block of `g`.
+prime ideal $\mathfrak p$ of $\mathcal O_K$, return the $\mathfrak p$-valuation of 
+the norm of the `i`th Jordan block of `g`.
 """
 norm(G::LocalGenusHerm, i::Int) = begin @assert isdyadic(G) && isramified(G); G.norm_val[i] end
 
@@ -231,8 +233,8 @@ norm(G::LocalGenusHerm, i::Int) = begin @assert isdyadic(G) && isramified(G); G.
     norms(g::LocalGenusHerm) -> Vector{Int}
 
 Given a ramified dyadic local genus symbol `g` for hermitian lattices over $E/K$ at a 
-prime ideal $\mathfrak p$ of $O_K$, return the $\mathfrak p$-valuations of the norms 
-of the Jordan blocks of `g`.
+prime ideal $\mathfrak p$ of $\mathcal O_K$, return the $\mathfrak p$-valuations of the 
+norms of the Jordan blocks of `g`.
 """
 norms(G::LocalGenusHerm) = begin @assert isdyadic(G) && isramified(G); G.norm_val end
 
@@ -240,7 +242,8 @@ norms(G::LocalGenusHerm) = begin @assert isdyadic(G) && isramified(G); G.norm_va
     isramified(g::LocalLenusHerm) -> Bool
 
 Given a local genus symbol `g` for hermitian lattices over $E/K$ at a prime ideal 
-$\mathfrak p$ of $O_K$, return whether $\mathfrak p$ is ramified in $O_E$.
+$\mathfrak p$ of $\mathcal O_K$, return whether $\mathfrak p$ is ramified in 
+$\mathcal O_E$.
 """
 isramified(g::LocalGenusHerm) = g.isramified
 
@@ -248,7 +251,8 @@ isramified(g::LocalGenusHerm) = g.isramified
     issplit(g::LocalGenusHerm) -> Bool
 
 Given a local genus symbol `g` for hermitian lattices over $E/K$ at a prime ideal
-$\mathfrak p$ of $O_K$, return whether $\mathfrak p$ is split in $O_E$.
+$\mathfrak p$ of $\mathcal O_K$, return whether $\mathfrak p$ is split in 
+$\mathcal O_E$.
 """
 issplit(g::LocalGenusHerm) = g.issplit
 
@@ -256,7 +260,8 @@ issplit(g::LocalGenusHerm) = g.issplit
     isinert(g::LocalGenusHerm) -> Bool
 
 Given a local genus symbol `g` for hermitian lattices over $E/K$ at a prime ideal 
-$\mathfrak p$ of $O_K$, return whether $\mathfrak p$ is inert in $O_E$.
+$\mathfrak p$ of $\mathcal O_K$, return whether $\mathfrak p$ is inert in 
+$\mathcal O_E$.
 """
 isinert(g::LocalGenusHerm) = !g.isramified && !g.issplit
 
@@ -264,7 +269,7 @@ isinert(g::LocalGenusHerm) = !g.isramified && !g.issplit
     isdyadic(g::LocalGenusHerm) -> Bool
 
 Given a local genus symbol `g` for hermitian lattices over $E/K$ at a prime ideal 
-$\mathfrak p$ of $O_K$, return whether $\mathfrak p$ is dyadic.
+$\mathfrak p$ of $\mathcal O_K$, return whether $\mathfrak p$ is dyadic.
 """
 isdyadic(G::LocalGenusHerm) = G.isdyadic
 
@@ -287,7 +292,7 @@ base_field(G::LocalGenusHerm) = G.E
     prime(g::LocalGenusHerm) -> NfOrdIdl
 
 Given a local genus symbol `g` for hermitian lattices over $E/K$ at a prime ideal 
-$\mathfrak p$ of $O_K$, return $\mathfrak p$.
+$\mathfrak p$ of $\mathcal O_K$, return $\mathfrak p$.
 """
 prime(G::LocalGenusHerm) = G.p
 
@@ -318,9 +323,10 @@ end
 @doc Markdown.doc"""
     uniformizer(g::LocalGenusHerm) -> NumFieldElem
 
-Given a local genus symbol `g` of hermitian lattices over $E/K$ at a prime ideal 
-$\mathfrak p$ of $O_K$, return a generator for the largest ideal of $O_E$ containing 
-$\mathfrak p$ and invariant under the action of the non-trivial involution of `E`.
+Given a local genus symbol `g` for hermitian lattices over $E/K$ at a prime ideal 
+$\mathfrak p$ of $\mathcal O_K$, return a generator for the largest ideal of $\mathcal O_E$
+containing $\mathfrak p$ and invariant under the action of the non-trivial involution 
+of `E`.
 """
 function uniformizer(G::LocalGenusHerm)
   E = base_field(G)
@@ -432,8 +438,8 @@ end
     gram_matrix(g::LocalGenusHerm) -> MatElem
 
 Given a local genus symbol `g` for hermitian lattices over $E/K$ at a prime ideal
-$\mathfrak p$ of $O_K$, return a Gram matrix `M` of `g`, with coefficients in `E`.
-`M` is such that any hermitian lattice over $E/K$ with Gram matrix `M` satisfies 
+$\mathfrak p$ of $\mathcal O_K$, return a Gram matrix `M` of `g`, with coefficients 
+in `E`.`M` is such that any hermitian lattice over $E/K$ with Gram matrix `M` satisfies 
 that the local genus symbol of its completion at $\mathfrak p$ is `g`.
 """
 function gram_matrix(G::LocalGenusHerm)
@@ -444,13 +450,13 @@ function gram_matrix(G::LocalGenusHerm)
 end
 
 @doc Markdown.doc"""
-   gram_matrix(g::LocalGenusHerm, i::Int) -> MatElem
+    gram_matrix(g::LocalGenusHerm, i::Int) -> MatElem
 
 Given a local genus symbol `g` for hermitian lattices over $E/K$ at a prime ideal 
-$\mathfrak p$ of $O_K$, return a Gram matrix `M` of the `i`th Jordan block of `g`, 
-with coefficients in `E`. `M` is such that any hermitian lattice over $E/K$ with 
-Gram matrix `M` satisfies that the local genus symbol of its completion at $\mathfrak p$ 
-is equal to the `i`th Jordan block of `g`.
+$\mathfrak p$ of $\mathcal O_K$, return a Gram matrix `M` of the `i`th Jordan block 
+of `g`, with coefficients in `E`. `M` is such that any hermitian lattice over $E/K$ 
+with Gram matrix `M` satisfies that the local genus symbol of its completion at 
+$\mathfrak p$ is equal to the `i`th Jordan block of `g`.
 """
 function gram_matrix(G::LocalGenusHerm, l::Int)
   i = scale(G, l)
@@ -546,8 +552,8 @@ end
     representative(g::LocalGenusHerm) -> HermLat
 
 Given a local genus symbol `g` for hermitian lattices over $E/K$ at a prime ideal 
-$\mathfrak p$ of $O_K$, return a hermitian lattice over $E/K$ whose completion at 
-$\mathfrak p$ admits `g` as local genus symbol.
+$\mathfrak p$ of $\mathcal O_K$, return a hermitian lattice over $E/K$ whose 
+completion at $\mathfrak p$ admits `g` as local genus symbol.
 """
 function representative(G::LocalGenusHerm)
   E = base_field(G)
@@ -570,17 +576,18 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    genus(HermLat, E::NumField, p::Idl, data::Vector; type = :det, check = false)
-                                                              -> LocalGenusHerm
+    genus(HermLat, E::NumField, p::NfOrdIdl, data::Vector; type::Symbol = :det, 
+		                                           check::Bool = true)
+                                                                 -> LocalGenusHerm
 
 Construct the local genus symbol `g` for hermitian lattices over the algebra `E`, 
-with base field $K$, at the prime ideal `p` of $O_K$. Its invariants are specified 
-by `data`.
+with base field $K$, at the prime ideal `p` of $\mathcal O_K$. Its invariants are 
+specified by `data`.
 
 - If the prime ideal is good (not ramified-and-dyadic), the elements of `data` must 
   be `(s, r, d)::Tuple{Int, Int, Int}` where `s` refers to the scale $\mathfrak P$-valuation, 
   `r` the rank and `d` the determinant/discriminant class of a Jordan block of `g`, where
-  $\mathfrak P$ is a prime ideal of $O_E$ lying over `p`.
+  $\mathfrak P$ is a prime ideal of $\mathcal O_E$ lying over `p`.
 
   In the unramified case, `d` is determined by `s` and `r` and can be omitted.
   Hence also `(s, r)::Tuple{Int, Int}` is allowed.
@@ -846,9 +853,7 @@ end
     genus(L::HermLat, p::NfOrdIdl) -> LocalGenusHerm
 
 Return the local genus symbol `g` for hermitian lattices over $E/K$ of the completion 
-of the hermitian lattice `L` at the prime ideal `p` of $O_K$.
-
-See [Kir16, Definition 8.3.1].
+of the hermitian lattice `L` at the prime ideal `p` of $\mathcal O_K$.
 """
 function genus(L::HermLat, q)
   if typeof(q) === ideal_type(base_ring(base_ring(L)))
@@ -906,7 +911,7 @@ end
     in(L::HermLat, g::LocalGenusHerm) -> Bool
 
 Return whether `g` and the local genus symbol of the completion of the hermitian
-lattice `L` at $prime(g)$ agree. Note that `L` being in `g` requires both `L` and 
+lattice `L` at `prime(g)` agree. Note that `L` being in `g` requires both `L` and 
 `g` to be defined over the same extension $E/K$.
 """
 Base.in(L::HermLat, G::LocalGenusHerm) = base_field(L) === base_field(G) && genus(L, prime(G)) == G
@@ -923,7 +928,7 @@ Base.in(L::HermLat, G::LocalGenusHerm) = base_field(L) === base_field(G) && genu
 Given two local genus symbols `g1` and `g2`, return whether their respective Jordan
 decompositions are of the same Jordan type. Note that equality requires `g1` and `g2`
 to be defined over the same extension $E/K$ and at the same prime ideal $\mathfrak p$
-of $O_K$.
+of $\mathcal O_K$.
 """
 function ==(G1::LocalGenusHerm, G2::LocalGenusHerm)
   if base_field(G1) != base_field(G2)
@@ -1050,9 +1055,9 @@ end
     orthogonal_sum(g1::LocalGenusHerm, g2::LocalGenusHerm) -> LocalGenusHerm
  
 Given two local genus symbols `g1` and `g2` for hermitian lattices over $E/K$ 
-at the same prime ideal $\mathfrak p$ of $O_K$, return their orthogonal sum. It
-corresponds to the local genus symbol of the $\mathfrak p$-adic completion of 
-the orthogonal sum of respective representatives of `g1` and `g2`.
+at the same prime ideal $\mathfrak p$ of $\mathcal O_K$, return their orthogonal 
+sum. It corresponds to the local genus symbol of the $\mathfrak p$-adic completion 
+of the orthogonal sum of respective representatives of `g1` and `g2`.
 """
 function orthogonal_sum(G1::LocalGenusHerm, G2::LocalGenusHerm)
   @req prime(G1) == prime(G2) "Local genera must have the same prime ideal"
@@ -1191,7 +1196,7 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-   base_field(G::GenusHerm) -> NumField
+    base_field(G::GenusHerm) -> NumField
  
 Given a global genus symbol `G` for hermitian lattices over $E/K$, return `E`.
 """
@@ -1201,7 +1206,7 @@ base_field(G::GenusHerm) = G.E
     primes(G::GenusHerm) -> Vector{NfOrdIdl}
 
 Given a global genus symbol `G` for hermitian lattices over $E/K$, return
-the list of prime ideals of $O_K$ at which `G` has a local genus symbol.
+the list of prime ideals of $\mathcal O_K$ at which `G` has a local genus symbol.
 """
 primes(G::GenusHerm) = G.primes
 
@@ -1289,7 +1294,7 @@ function orthogonal_sum(G1::GenusHerm, G2::GenusHerm)
       g1 = G1.LGS[i]
     else
       @assert !isramified(maximal_order(E), p)
-      g1 = genus(HermLat, p, [(0, rank(G1), 1)])
+      g1 = genus(HermLat,E , p, [(0, rank(G1), 1)])
     end
 
     if p in P2
@@ -1297,7 +1302,7 @@ function orthogonal_sum(G1::GenusHerm, G2::GenusHerm)
       g2 = G2.LGS[i]
     else
       @assert !isramified(maximal_order(E), p)
-      g2 = genus(HermLat, p, [(0, rank(G2), 1)])
+      g2 = genus(HermLat, E, p, [(0, rank(G2), 1)])
     end
 
     g3 = orthogonal_sum(g1, g2)
@@ -1371,9 +1376,10 @@ end
 Return the global genus symbol `G` of the hermitian lattice `L`. `G` satisfies:
 - its local genus symbols correspond to those of the completions of `L` at the bad 
   prime ideals of `L`, i.e. the prime ideals dividing either the scale of `L`, or the 
-  volume of `L`, or the discriminant of $O_E$, and also the dyadic prime ideals of $O_K$;
+  volume of `L`, or the discriminant of $\mathcal O_E$, and also the dyadic prime 
+  ideals of $\mathcal O_K$;
 - signatures are those of the Gram matrix of the rational span of `L`. They are given 
-  at the real infinite places of `K` which splits into complex places of `E`.
+  at the real infinite places of `K` which split into complex places of `E`.
 """
 function genus(L::HermLat)
   c = get_attribute(L, :genus)
@@ -1524,7 +1530,7 @@ function _hermitian_form_invariants(M)
 end
 
 @doc Markdown.doc"""
-   representative(G::GenusHerm) -> HermLat
+    representative(G::GenusHerm) -> HermLat
 
 Given a global genus symbol `G` for hermitian lattices over $E/K$, return a hermitian 
 lattice over $E/K$ which admits `G` as global genus symbol.
@@ -1558,9 +1564,10 @@ end
                            det_val::Int, max_scale::Int) -> Vector{LocalGenusHerm}
 
 Return all local genus symbols for hermitian lattices over the algebra `E`, with base
-field $K$, at the prime ideal`p` of $O_K$. Each of them has rank equal to `rank`, scale 
-$\mathfrak P$-valuations bounded by `max_scale` and determinant `p`-valuations equal 
-to `det_val`, where $\mathfrak P$ is a prime ideal of $O_E$ lying above `p`.
+field $K$, at the prime ideal`p` of $\mathcal O_K$. Each of them has rank equal to 
+`rank`, scale $\mathfrak P$-valuations bounded by `max_scale` and determinant 
+`p`-valuations equal to `det_val`, where $\mathfrak P$ is a prime ideal of $\mathcal O_E$ 
+lying above `p`.
 """
 function local_genera_hermitian(E, p, rank::Int, det_val::Int, max_scale::Int)
   is_ramified = isramified(maximal_order(E), p)

--- a/src/QuadForm/Herm/Lattices.jl
+++ b/src/QuadForm/Herm/Lattices.jl
@@ -273,9 +273,9 @@ end
 @doc Markdown.doc"""
     bad_primes(L::HermLat; discriminant = false) -> Vector{NfOrdIdl}
 
-Given a hermitian lattice `L` over $E/K$, return the prime ideals of $O_K$ dividing 
-the scale or the volume of `L`. If `discriminant == true`, also the prime ideals 
-dividing the discriminant of $O_E$ are returned.
+Given a hermitian lattice `L` over $E/K$, return the prime ideals of $\mathcal O_K$ 
+dividing the scale or the volume of `L`. If `discriminant == true`, also the prime 
+ideals dividing the discriminant of $\mathcal O_E$ are returned.
 """
 function bad_primes(L::HermLat; discriminant::Bool = false)
   s = scale(L)
@@ -670,25 +670,11 @@ function _maximal_integral_lattice(L::HermLat, p, minimal = true)
   end
 end
 
-@doc Markdown.doc"""
-    ismaximal_integral(L::HermLat, p::NfOrdIdl) -> Bool, HermLat
-
-Return whether the completion of the hermitian lattice `L` over $E/K$ at the prime ideal 
-`p` of $O_K$ is maximal integral. In case it is not, the second returned value is a 
-hermitian lattice over $E/K$ whose completion at `p` is a minimal integral overlattive
-of $L_p$.
-"""
 function ismaximal_integral(L::HermLat, p)
-  @req valuation(norm(L), p) >= 0 "The lattice must be integral at the prime"
+  valuation(norm(L), p) < 0 && return false, L
   return _maximal_integral_lattice(L, p, true)
 end
 
-@doc Markdown.doc"""
-    ismaximal_integral(L::HermLat) -> Bool, HermLat
-
-Return whether the hermitian lattice `L` is maximal integral. 
-In case it is not, the second returned value is a minimal integral overlattice of `L`.
-"""
 function ismaximal_integral(L::HermLat)
   !isintegral(norm(L)) && throw(error("The lattice is not integral"))
   S = base_ring(L)
@@ -707,14 +693,6 @@ function ismaximal_integral(L::HermLat)
   return true, L
 end
 
-@doc Markdown.doc"""
-    ismaximal(L::HermLat, p::NfOrdIdl) -> Bool, HermLat
-
-Given a hermitian lattice `L` over $E/K$ and a prime ideal `p` of $O_K$, check 
-whether the norm of $L_p$ is integral and return whether `L` is maximal. If the
-first condition holds but the second does not, then a proper overlattice of `L` with
-integral norm is also returned.
-"""
 function ismaximal(L::HermLat, p)
   #iszero(L) && error("The lattice must be non-zero")
   v = valuation(norm(L), p)
@@ -727,12 +705,6 @@ function ismaximal(L::HermLat, p)
   end
 end
 
-@doc Markdown.doc"""
-    maximal_integral_lattice(L::HermLat) -> HermLat
-
-Given a hermitian lattice `L`, return a maximal integral lattice contained 
-in the ambient space of `L` and containing `L`.
-"""
 function maximal_integral_lattice(L::HermLat)
   !isintegral(norm(L)) && throw(error("The lattice is not integral"))
   S = base_ring(L)
@@ -748,25 +720,12 @@ function maximal_integral_lattice(L::HermLat)
   return L
 end
 
-@doc Markdown.doc"""
-    maximal_integral_lattice(L::HermLat, p::NfOrdIdl) -> HermLat
-
-Given a hermitian lattice `L` over $E/K$ and a prime ideal `p` of $O_K$, return 
-a lattice `M` in the ambient space of `L` with `M` maximal integral at `p` and 
-which agrees locally with `L` at all places different from `p`.
-"""
 function maximal_integral_lattice(L::HermLat, p)
   valuation(norm(L), p) < 0 && throw(error("Lattice is not locally integral"))
   _, L = _maximal_integral_lattice(L, p, false)
   return L
 end
 
-@doc Markdown.doc"""
-    maximal_integral_lattice(V::HermSpace) -> HermLat
-
-Given a hermitian space `V`, return a hermitian lattice `L` in `V` such that the 
-norm of `L` is integral and `L` is maximal in `V` with respect to this property.
-"""
 function maximal_integral_lattice(V::HermSpace)
   L = lattice(V, identity_matrix(base_ring(V), rank(V)))
   fac = collect(factor(scale(L)))

--- a/src/QuadForm/Herm/LocallyIsometricSublattice.jl
+++ b/src/QuadForm/Herm/LocallyIsometricSublattice.jl
@@ -292,8 +292,8 @@ end
     locally_isometric_sublattice(M::HermLat, L::HermLat, p::NfOrdIdl) -> HermLat
 
 Given rationally isometric hermitian lattices `M` and `L` over $E/K$ and a prime ideal `p`
-of $O_K$, return a sublattice `N` of `M` with $N_q = M_q$ for $q \neq p$ and $N_p$ isometric to
-$L_p$.
+of $\mathcal O_K$, return a sublattice `N` of `M` with $N_q = M_q$ for $q \neq p$ and 
+$N_p$ isometric to $L_p$.
 """
 function locally_isometric_sublattice(M::HermLat, L::HermLat, p)
   @assert base_ring(M) == base_ring(L)

--- a/src/QuadForm/Herm/Spaces.jl
+++ b/src/QuadForm/Herm/Spaces.jl
@@ -1,3 +1,5 @@
+export isrepresented_by, islocally_represented_by, islocally_hyperbolic
+
 ################################################################################
 #
 #  Constructors
@@ -230,12 +232,6 @@ end
 #
 ################################################################################
 
-@doc Markdown.doc"""
-    isisotropic(V::Hermspace, p::NfOrdIdl) -> Bool
-
-Return whether the completion of the hermitian space `V` over $E/K$ at the prime 
-ideal `p` of $O_K$ is isotropic.
-"""
 function isisotropic(V::HermSpace, q::T) where T <: NumFieldOrdIdl
   if nf(order(q)) == base_ring(V)
     p = minimum(q)
@@ -266,7 +262,7 @@ end
     islocally_hyperbolic(V::Hermspace, p::NfOrdIdl) -> Bool
 
 Return whether the completion of the hermitian space `V` over $E/K$ at the prime 
-ideal `p` of $O_K$ is hyperbolic.
+ideal `p` of $\mathcal O_K$ is hyperbolic.
 """
 function islocally_hyperbolic(V::HermSpace, p)
   rk = rank(V)
@@ -285,12 +281,6 @@ end
 # Hermitian forms are uniquely determined by their rank and determinant class
 # Thus there is no restriction to embeddings.
 
-@doc Markdown.doc"""
-    islocally_represented_by(U::HermSpace, V::HermSpace, p::NfOrdIdl) -> Bool
-
-Given two hermitian spaces `U` and `V` over $E/K$ and a prime ideal `p` of $O_K$, 
-return whether `U` is represented by `V` locally at `p`.
-"""
 function islocally_represented_by(U::HermSpace, V::HermSpace, p)
   if rank(U) > rank(V)
     return false
@@ -304,12 +294,6 @@ end
 # There are no restrictions, since spaces are uniquely determined by their
 # rank and determinant.
 
-@doc Markdown.doc"""
-    isrepresented_by(U::HermSpace, V::HermSpace) -> Bool
-
-Given two hermitian spaces `U` and `V`, return whether `U` is represented by `V`, 
-that is, whether `U` embeds into `V`.
-"""
 function isrepresented_by(U::HermSpace, V::HermSpace)
   v = rank(V) - rank(U)
   if v < 0

--- a/src/QuadForm/Lattices.jl
+++ b/src/QuadForm/Lattices.jl
@@ -1,13 +1,15 @@
-export *, +, absolute_basis, absolute_basis_matrix, ambient_space, bad_primes,
-       basis_matrix, can_scale_totally_positive, coefficient_ideal, degree, diagonal,
-       discriminant, dual, fixed_field, fixed_ring, generators, gram_matrix_of_rational_span,
-       hasse_invariant, hermitian_lattice, intersect, involution, isdefinite,
-       isintegral, islocally_isometric, ismodular, isnegative_definite,
-       ispositive_definite, isrationally_isometric, jordan_decomposition,
-       local_basis_matrix, norm, pseudo_matrix, quadratic_lattice, rank,
-       rational_span, rescale, scale, volume, witt_invariant, lattice,
-       Zlattice, automorphism_group_generators, automorphism_group_order,
-       isisometric, islocal_norm, normic_defect, issublattice, issublattice_with_relations
+export *, +, absolute_basis, absolute_basis_matrix, ambient_space, 
+       automorphism_group_generators, automorphism_group_order, bad_primes,
+       basis_matrix, basis_matrix_of_rational_span, can_scale_totally_positive, 
+       coefficient_ideals, degree, diagonal, diagonal_of_rational_span,
+       discriminant, dual, fixed_field, fixed_ring, generators, gram_matrix_of_generators, 
+       gram_matrix_of_rational_span, hasse_invariant, hermitian_lattice, intersect, 
+       involution, isdefinite, isintegral, isisometric, islocal_norm, islocally_isometric, 
+       ismodular, isnegative_definite, ispositive_definite, isrationally_isometric, 
+       issublattice, issublattice_with_relations, jordan_decomposition, lattice, 
+       local_basis_matrix, norm, normic_defect, pseudo_matrix, quadratic_lattice, 
+       rank, rational_span, rescale, scale, volume, witt_invariant, Zlattice 
+      
 
 export HermLat, QuadLat
 
@@ -81,7 +83,7 @@ rational_span(::AbsLat)
 ################################################################################
 
 @doc Markdown.doc"""
-    diagonal(L::AbsLat) -> Vector
+    diagonal_of_rational_span(L::AbsLat) -> Vector
 
 Return the diagonal of the rational span of the lattice `L`.
 """
@@ -490,7 +492,7 @@ witt_invariant(L::AbsLat, p)
 ################################################################################
 
 @doc Markdown.doc"""
-    isrationally_isometric(L::AbsLat, M::AbsLat, p::Union{InfPlc, NfOrdIdl})
+    isrationally_isometric(L::AbsLat, M::AbsLat, p::Union{InfPlc, NfAbsOrdIdl})
                                                                          -> Bool
 
 Return whether the rational spans of the lattices `L` and `M` are isometric over 
@@ -572,6 +574,8 @@ Return the sum of the lattices `L` and `M`.
 
 The lattices `L` and `M` must have the same ambient space.
 """
+Base.:(+)(::AbsLat, ::AbsLat)
+
 function Base.:(+)(L::T, M::T) where {T <: AbsLat}
   @assert has_ambient_space(L) && has_ambient_space(M)
   @assert ambient_space(L) === ambient_space(M)
@@ -594,6 +598,8 @@ Return the intersection of the lattices `L` and `M`.
 
 The lattices `L` and `M` must have the same ambient space.
 """
+intersect(::AbsLat, ::AbsLat)
+
 function intersect(L::T, M::T) where {T <: AbsLat}
   @assert has_ambient_space(L) && has_ambient_space(M)
   @assert ambient_space(L) === ambient_space(M)
@@ -619,7 +625,8 @@ Return the lattice $aL$ inside the ambient space of the lattice `L`.
 """
 function Base.:(*)(a::NumFieldElem, L::AbsLat)
   @assert has_ambient_space(L)
-  m = _module_scale_element(a, pseudo_matrix(L))
+  O = maximal_order(parent(a))
+  m = _module_scale_ideal(a*O, pseudo_matrix(L))
   return lattice_in_same_ambient_space(L, m)
 end
 
@@ -628,10 +635,12 @@ function Base.:(*)(L::QuadLat, a)
 end
 
 @doc Markdown.doc"""
-    *(a::NfRelOrdIdl, L::AbsLat) -> AbsLat
+    *(a::NumFieldOrdIdl, L::AbsLat) -> AbsLat
 
 Return the lattice $aL$ inside the ambient space of the lattice `L`.
 """
+Base.:(*)(::NumFieldOrdIdl, ::AbsLat)
+
 function Base.:(*)(a::Union{NfRelOrdIdl, NfAbsOrdIdl}, L::AbsLat)
   @assert has_ambient_space(L)
   m = _module_scale_ideal(a, pseudo_matrix(L))
@@ -639,10 +648,12 @@ function Base.:(*)(a::Union{NfRelOrdIdl, NfAbsOrdIdl}, L::AbsLat)
 end
 
 @doc Markdown.doc"""
-    *(a::NfOrdFracIdl, L::AbsLat) -> AbsLat
+    *(a::NumFieldOrdFracIdl, L::AbsLat) -> AbsLat
 
 Return the lattice $aL$ inside the ambient space of the lattice `L`.
 """
+Base.:(*)(::NumFieldOrdFracIdl, ::AbsLat)
+
 function Base.:(*)(a::Union{NfRelOrdFracIdl, NfAbsOrdFracIdl}, L::AbsLat)
   @assert has_ambient_space(L)
   m = _module_scale_ideal(a, pseudo_matrix(L))
@@ -797,7 +808,7 @@ end
 
 Return whether the lattice `L` is modular. In this case, the second returned value 
 is a fractional ideal $\mathfrak a$ of the base algebra of `L` such that 
-$\mathfrak a L^\# = L$, where $L^\#$ is the dual of 'L'.
+$\mathfrak a L^\# = L$, where $L^\#$ is the dual of `L`.
 """
 function ismodular(L::AbsLat)
   a = scale(L)
@@ -815,6 +826,8 @@ Return whether the completion $L_{p}$ of the lattice `L` at the prime ideal `p`
 is modular. If it is the case the second returned value is an integer `v` such 
 that $L_{p}$ is $p^v$-modular.
 """
+ismodular(::AbsLat, p)
+
 function ismodular(L::AbsLat{<: NumField}, p)
   a = scale(L)
   if base_ring(L) == order(p)
@@ -927,7 +940,7 @@ islocally_isometric(::AbsLat, ::AbsLat, ::NfOrdIdl)
 ################################################################################
 
 @doc Markdown.doc"""
-    isisotropic(L::AbsLat, p) -> Bool
+    isisotropic(L::AbsLat, p::Union{NfOrdIdl, InfPlc}) -> Bool
 
 Return whether the completion of the lattice `L` at the place `p` is 
 isotropic.
@@ -1455,4 +1468,64 @@ function _orthogonal_complement(v::Vector, L::AbsLat)
 
   return lattice(V, pm)
 end
+
+################################################################################
+#
+#  Maximal integral lattices
+#
+################################################################################
+
+@doc Markdown.doc"""
+    ismaximal_integral(L::AbsLat, p::NfOrdIdl) -> Bool, AbsLat
+
+Given a lattice `L` and a prime ideal `p` of the fixed ring $\mathcal O_K$ of
+`L`, return whether the completion of `L` at `p` is maximal integral. If it is
+not the case, the second returned value is a lattice in the ambient space of `L`
+whose completion at `p` is a minimal overlattice of $L_p$.
+"""
+ismaximal_integral(::AbsLat, p)
+
+@doc Markdown.doc"""
+    ismaximal_integral(L::AbsLat) -> Bool, AbsLat
+
+Given a lattice `L`, return whether `L` is maximal integral. If it is not,
+the second returned value is a minimal overlattice of `L` with integral norm.
+"""
+ismaximal_integral(::AbsLat)
+
+@doc Markdown.doc"""
+    ismaximal(L::AbsLat, p::NfOrdIdl) -> Bool, AbsLat
+
+Given a lattice `L` and a prime ideal `p` in the fixed ring $\mathcal O_K$ of
+`L`, check whether the norm of $L_p$ is integral and return whether `L` is maximal 
+at `p`. If it is locally integral but not locally maximal, the second returned value 
+is a lattice in the same ambient space of `L` whose completion at `p` has integral norm
+and is a proper overlattice of $L_p$.
+"""
+ismaximal(::AbsLat, p)
+
+@doc Markdown.doc"""
+    maximal_integral_lattice(L::AbsLat, p::NfOrdIdl) -> AbsLat
+
+Given a lattice `L` and a prime ideal `p` of the fixed ring $\mathcal O_K$ of
+`L`, return a lattice `M` in the ambient space of `L` which is maximal integral 
+at `p` and which agrees with `L` locally at all the places different from `p`.
+"""
+maximal_integral_lattice(::AbsLat, p)
+
+@doc Markdown.doc"""
+    maximal_integral_lattice(L::AbsLat) -> AbsLat
+
+Given a lattice `L`, return a lattice `M` in the ambient space of `L` which
+is maximal integral and which contains `L`.
+"""
+maximal_integral_lattice(::AbsLat)
+
+@doc Markdown.doc"""
+    maximal_integral_lattice(V::AbsSpace) -> AbsLat
+
+Given a space `V`, return a lattice in `V` with integral norm
+and which is maximal in `V` satisfying this property.
+"""
+maximal_integral_lattice(::AbsSpace)
 

--- a/src/QuadForm/Quad/Lattices.jl
+++ b/src/QuadForm/Quad/Lattices.jl
@@ -111,9 +111,9 @@ function quadratic_lattice(K::Field, gens::Vector ; gram = nothing)
 end
 
 @doc Markdown.doc"""
-    quadratic_lattice(K::Field, gram::MatElem) -> QuadLat
+    quadratic_lattice(K::Field ; gram::MatElem) -> QuadLat
 
-Given a matrix 'gram` and a field `K`, return the free quadratic
+Given a matrix `gram` and a field `K`, return the free quadratic
 lattice inside the quadratic space over `K` with Gram matrix `gram`.
 """
 function quadratic_lattice(K::Field ; gram::MatElem)
@@ -411,14 +411,8 @@ function guess_max_det(L::QuadLat, p)
   return v
 end
 
-@doc Markdown.doc"""
-    ismaximal_integral(L::QuadLat, p) -> Bool, QuadLat
-
-Checks whether L is maximal integral at $p$. If not, the second return value is
-a minimal integral overlattice at p.
-"""
 function ismaximal_integral(L::QuadLat, p)
-  @req order(p) == base_ring(L) "rings do not match"
+  @req order(p) == base_ring(L) "Rings do not match"
   #if iszero(L)
   #  return true, L
   #end
@@ -490,12 +484,6 @@ function ismaximal_integral(L::QuadLat, p)
   return false, LL
 end
 
-@doc Markdown.doc"""
-    ismaximal_integral(L::QuadLat) -> Bool, QuadLat
-
-Checks whether $L$ is maximal integral. If not, the second return valiue is a
-minimal integral overlattice.
-"""
 function ismaximal_integral(L::QuadLat)
   #if iszero(L)
   #  return true, L
@@ -527,13 +515,6 @@ function maximal_integral_lattice(L::QuadLat, p)
   return L
 end
 
-@doc Markdown.doc"""
-    ismaximal_integral(L::QuadLat, p) -> Bool, QuadLat
-
-Checks whether $L$ is maximal at $p$, that is, whether no overlattice has the
-same norm. If not, the second return value is a proper overlattice with the
-same norm.
-"""
 function ismaximal(L::QuadLat, p)
   @req order(p) == base_ring(L) "Asdsads"
   #if iszero(L)
@@ -549,12 +530,6 @@ function ismaximal(L::QuadLat, p)
   end
 end
 
-@doc Markdown.doc"""
-    maximal_integral_lattice(V::QuadSpace) -> QuadLat
-
-Return a lattice $L$ of $V$ such that the norm of $L$ is integral and $L$ is
-maximal with respect to this property.
-"""
 function maximal_integral_lattice(V::QuadSpace)
   K = base_ring(V)
   L = lattice(V, identity_matrix(K, rank(V)))
@@ -572,11 +547,6 @@ function maximal_integral_lattice(V::QuadSpace)
   return maximal_integral_lattice(L)
 end
 
-@doc Markdown.doc"""
-    maximal_integral_lattice(L::QuadLat) -> QuadLat
-
-Return a maximal integral lattice containing $L$.
-"""
 function maximal_integral_lattice(L::QuadLat)
   @req isintegral(norm(L)) "Lattice must be integral"
   for p in bad_primes(L, even = true)

--- a/src/QuadForm/Quad/Spaces.jl
+++ b/src/QuadForm/Quad/Spaces.jl
@@ -16,7 +16,7 @@ quadratic_space_type(K::S) where {S <: Field} =
 ################################################################################
 
 @doc Markdown.doc"""
-    quadratic_space(K::NumField, n::Int; cached = true) -> QuadSpace
+    quadratic_space(K::NumField, n::Int; cached::Bool = true) -> QuadSpace
 
 Create the quadratic space over `K` with dimension `n` and Gram matrix
 equals to the identity matrix.
@@ -28,7 +28,7 @@ function quadratic_space(K::Field, n::Int; cached::Bool = true)
 end
 
 @doc Markdown.doc"""
-    quadratic_space(K::NumField, G::MatElem; cached = true) -> QuadSpace
+    quadratic_space(K::NumField, G::MatElem; cached::Bool = true) -> QuadSpace
 
 Create the quadratic space over `K` with Gram matrix `G`.
 The matrix `G` must be square and symmetric.
@@ -782,11 +782,6 @@ function _can_locally_embed(n::Int, da, ha::Int, m::Int, db, hb::Int, p)
   end
 end
 
-@doc Markdown.doc"""
-    islocally_represented_by(U::QuadSpace, V::QuadSpace, p)
-
-Return whether $U$ is represented by $V$ locally at $\mathfrak p$.
-"""
 function islocally_represented_by(U::QuadSpace, V::QuadSpace, p)
   n, da, ha = rank(U), det(U), hasse_invariant(U, p)
   m, db, hb = rank(V), det(V), hasse_invariant(V, p)
@@ -805,11 +800,6 @@ end
 # characterization. But the Hasse invariant is zero outside the support
 # of the diagonal. Thus we get only finitely many conditions.
 
-@doc Markdown.doc"""
-    isrepresented_by(U::QuadSpace, V::QuadSpace)
-
-Return whether $U$ is represented by $V$, that is, whether $U$ embeds into $V$.
-"""
 function isrepresented_by(U::QuadSpace, V::QuadSpace)
   v = rank(V) - rank(U)
   if v < 0

--- a/src/QuadForm/Spaces.jl
+++ b/src/QuadForm/Spaces.jl
@@ -1,6 +1,7 @@
 export ambient_space, rank, gram_matrix, inner_product, involution, ishermitian, isquadratic, isregular,
-       islocal_square, isisometric, isrationally_isometric, quadratic_space,
-       hermitian_space, diagonal, invariants, hasse_invariant, witt_invariant, orthogonal_basis, fixed_field
+       islocal_square, isisometric, isrationally_isometric, isisotropic, quadratic_space,
+       hermitian_space, diagonal, invariants, hasse_invariant, witt_invariant, orthogonal_basis, fixed_field,
+       restrict_scalars, orthogonal_complement
 
 ################################################################################
 #
@@ -445,6 +446,14 @@ end
 #
 ################################################################################
 
+@doc Markdown.doc"""
+    isisotropic(V::AbsSpace, p::Union{NfOrdIdl, InfPlc}) -> Bool
+
+Given a space `V` and a place `p` in the fixed field `K` of `V`, return
+whether the completion of `V` at `p` is isotropic.
+"""
+isisotropic(::AbsSpace, p)
+
 isisotropic(V::AbsSpace, p::InfPlc) = _isisotropic(V, p)
 
 # this is badly written, no need to compute d
@@ -579,10 +588,10 @@ function _orthogonal_sum(V::AbsSpace, W::AbsSpace)
 end
 
 @doc Markdown.doc"""
-   orthogonal_sum(V::AbsSpace, W::AbsSpace) -> AbsSpace, AbsSpaceMor, AbsSpaceMor
+    orthogonal_sum(V::AbsSpace, W::AbsSpace) -> AbsSpace, AbsSpaceMor, AbsSpaceMor
 
 Given two spaces `V` and `W` of the same kind (either both hermitian or both quadratic)
-and defined over the same algebra, return their orthogonal sum $V \oplus W. It is given with
+and defined over the same algebra, return their orthogonal sum $V \oplus W$. It is given with
 the two natural embeddings $V \to V\oplus W$ and $W \to V\oplus W$.
 """
 orthogonal_sum(V::AbsSpace, W::AbsSpace)
@@ -605,3 +614,25 @@ function orthogonal_sum(V::HermSpace, W::HermSpace)
   return VplusW, f1, f2
 end
 
+################################################################################
+#
+#  Embeddings
+#
+################################################################################
+
+@doc Markdown.doc"""
+    islocally_represented_by(U::T, V::T, p::NfOrdIdl) where T <: AbsSpace -> Bool
+
+Given two spaces `U` and `V` over the same algebra `E`, and a prime ideal `p` in 
+the maximal order $\mathcal O_K$ of their fixed field `K`, return whether `U` is 
+represented by `V` locally at `p`, i.e. whether $U_p$ embeds in $V_p$.
+"""
+islocally_represented_by(::AbsSpace, ::AbsSpace, p)
+
+@doc Markdown.doc"""
+    isrepresented_by(U::T, V::T) where T <: AbsSpace -> Bool
+
+Given two spaces `U` and `V` over the same algebra `E`, return whether `U` is
+represented by `V`, i.e. whether `U` embeds in `V`.
+"""
+isrepresented_by(::AbsSpace, ::AbsSpace)

--- a/test/NumFieldOrd/NumFieldOrd.jl
+++ b/test/NumFieldOrd/NumFieldOrd.jl
@@ -58,6 +58,50 @@
   @test @inferred signature(OLns) == (0, 2)
   @test @inferred discriminant(OLns, FlintQQ) == absolute_discriminant(OLns)
 
+end
 
+@testset "RelResidueField" begin
+  Qs, s = QQ["s"]
+  K,a = number_field(s^4+s+1, "a")
+  Kt, t = K["t"]
+  E, b = number_field(t^2-a*t+1,"b")
+  Eu, u = E["u"]
+  L, c = number_field(u^3-7, "c")
+  OK = maximal_order(K)
+  OE = maximal_order(E)
+  OL = maximal_order(L)
+  p = prime_decomposition(OK, 11)[1][1]
+  P = prime_decomposition(OE,p)[1][1]
+  PP = prime_decomposition(OL, P)[1][1]
+  FL, projL = relative_residue_field(OL, PP)
+  mL = extend(projL, L)
+
+  e,f = PP.splitting_type
+  @test degree(defining_polynomial(FL)) == f
+  e,f = P.splitting_type
+  @test degree(defining_polynomial(base_field(FL))) == f
+  e, f = p.splitting_type
+  @test degree(defining_polynomial(base_field(base_field(FL)))) == f
+  
+  @test domain(projL.map_subfield) === OE
+  @test mL(gen(L)//2) == gen(FL)//2
+  @test degree(Hecke.absolute_field(FL)[1]) == 6
+  @test characteristic(Hecke.prime_field(FL)) == 11
+  
+  K,a = rationals_as_number_field()
+  Kt, t = K["t"]
+  E,b = number_field(t^4-5*t^3-6*t^2+5*t+1,"b")
+  OK = maximal_order(K)
+  OE = maximal_order(E)
+  p = prime_decomposition(OK, 2)[1][1]
+  P = prime_decomposition(OE, p)[1][1]
+  @test isindex_divisor(OE, p)
+  FE, projE = relative_residue_field(OE, P)
+  _, f = P.splitting_type
+  @test degree(defining_polynomial(FE)) == f
+  mE = extend(projE, E)
+  @test !iszero(mE(gen(E)))
+  @test get_attribute(E, :rel_residue_field_map) !== nothing
 
 end
+

--- a/test/NumFieldOrd/NumFieldOrd.jl
+++ b/test/NumFieldOrd/NumFieldOrd.jl
@@ -101,7 +101,7 @@ end
   @test degree(defining_polynomial(FE)) == f
   mE = extend(projE, E)
   @test !iszero(mE(gen(E)))
-  @test get_attribute(E, :rel_residue_field_map) !== nothing
+  @test get_attribute(P, :rel_residue_field_map) !== nothing
 
 end
 


### PR DESCRIPTION
This follows #639. I have adapted some similar codes written for absolute residue field. I had to modify some other methods, like the `(pre)image(::Map{C, D},a)` because for the map to residue fields, there are more than 2 parameters. I could only produce examples in tower of 3 extensions at most.