### PR TITLE
Rename `isisomorphic` -> `is_isomorphic`, add `is_isomorphic_with_map`

### DIFF
--- a/docs/src/number_fields/fields.md
+++ b/docs/src/number_fields/fields.md
@@ -116,6 +116,7 @@ simplified_simple_extension(::NonSimpleNumField)
 
 ```@docs
 is_isomorphic(::SimpleNumField, ::SimpleNumField)
+is_isomorphic_with_map(::SimpleNumField, ::SimpleNumField)
 isinvolution(::NfToNfMor)
 fixed_field(::NumFieldMor)
 automorphisms(::NumField)

--- a/src/AlgAss/AlgGrp.jl
+++ b/src/AlgAss/AlgGrp.jl
@@ -522,7 +522,7 @@ end
 function galois_module(K::AnticNumberField, A::AlgGrp; normal_basis_generator = normal_basis(K))
   G = group(A)
   Au, mAu = automorphism_group(K)
-  fl, f = is_isomorphic(G, Au)
+  fl, f = is_isomorphic_with_map(G, Au)
   @assert fl
   aut = Vector{NfToNfMor}(undef, order(G))
   for g in G

--- a/src/AlgAssAbsOrd/ICM.jl
+++ b/src/AlgAssAbsOrd/ICM.jl
@@ -2,7 +2,7 @@ export ideal_class_monoid, islocally_isomorphic, isconjugate
 
 ###############################################################################
 #
-#  ICM / is_isomorphic
+#  ICM / is_isomorphic_with_map
 #
 ###############################################################################
 
@@ -45,15 +45,15 @@ end
 
 # Stefano Marseglia "Computing the ideal class monoid of an order", Cor. 4.5
 @doc Markdown.doc"""
-    is_isomorphic(I::NfAbsOrdIdl, J::NfAbsOrdIdl) -> Bool, nf_elem
-    is_isomorphic(I::NfFracOrdIdl, J::NfFracOrdIdl) -> Bool, nf_elem
-    is_isomorphic(I::AlgAssAbsOrdIdl, J::AlgAssAbsOrdIdl) -> Bool, AbsAlgAssElem
+    is_isomorphic_with_map(I::NfAbsOrdIdl, J::NfAbsOrdIdl) -> Bool, nf_elem
+    is_isomorphic_with_map(I::NfFracOrdIdl, J::NfFracOrdIdl) -> Bool, nf_elem
+    is_isomorphic_with_map(I::AlgAssAbsOrdIdl, J::AlgAssAbsOrdIdl) -> Bool, AbsAlgAssElem
 
 Given two (fractional) ideals $I$ and $J$ of an order $R$ of an $Q$-étale
 algebra $A$, this function returns `true` and an element $a \in A$ such that
 $I = aJ$ if such an element exists and `false` and $0$ otherwise.
 """
-function is_isomorphic(I::T, J::T) where { T <: Union{ NfAbsOrdIdl, NfOrdFracIdl, AlgAssAbsOrdIdl}}
+function is_isomorphic_with_map(I::T, J::T) where { T <: Union{ NfAbsOrdIdl, NfOrdFracIdl, AlgAssAbsOrdIdl}}
   A = _algebra(order(I))
   if !islocally_isomorphic(I, J)
     return false, zero(A)
@@ -70,6 +70,19 @@ function is_isomorphic(I::T, J::T) where { T <: Union{ NfAbsOrdIdl, NfOrdFracIdl
   end
 
   return true, divexact(_elem_in_algebra(a, copy = false), A(denominator(IJ, copy = false)))
+end
+
+@doc Markdown.doc"""
+    is_isomorphic(I::NfAbsOrdIdl, J::NfAbsOrdIdl) -> Bool, nf_elem
+    is_isomorphic(I::NfFracOrdIdl, J::NfFracOrdIdl) -> Bool, nf_elem
+    is_isomorphic(I::AlgAssAbsOrdIdl, J::AlgAssAbsOrdIdl) -> Bool, AbsAlgAssElem
+
+Given two (fractional) ideals $I$ and $J$ of an order $R$ of an $Q$-étale
+algebra $A$, this function returns `true` if an element $a \in A$ exists such that
+$I = aJ$ and `false` otherwise.
+"""
+function is_isomorphic(I::T, J::T) where { T <: Union{ NfAbsOrdIdl, NfOrdFracIdl, AlgAssAbsOrdIdl}}
+  return is_isomorphic_with_map(I, J)[1]
 end
 
 function ring_of_multipliers(I::NfOrdFracIdl)
@@ -307,7 +320,7 @@ end
 function _isconjugate(O::Union{ NfAbsOrd, AlgAssAbsOrd }, M::fmpz_mat, N::fmpz_mat)
   I, basisI = matrix_to_ideal(O, M)
   J, basisJ = matrix_to_ideal(O, N)
-  t, a = is_isomorphic(J, I)
+  t, a = is_isomorphic_with_map(J, I)
   @assert J == a*I
   if !t
     return false, zero_matrix(FlintZZ, nrows(M), ncols(M))

--- a/src/AlgAssAbsOrd/PIP.jl
+++ b/src/AlgAssAbsOrd/PIP.jl
@@ -2017,7 +2017,7 @@ function _is_D16_subfield_free(K, KtoQG, QG::AlgGrp)
   else
     B = parent(_cache_tmp[1])
     GG = group(B)
-    fl, f = is_isomorphic(GG, group(D16))
+    fl, f = is_isomorphic_with_map(GG, group(D16))
     @assert fl
     ff = hom(B, D16, f)
     unitss = ff.(_cache_tmp)

--- a/src/Grp/Morphisms.jl
+++ b/src/Grp/Morphisms.jl
@@ -393,7 +393,7 @@ end
 
 multiples(n::Int64, b::Int64) =  [i * n for i in 1:Int64(floor(b/n))]
 
-function is_isomorphic(G::GrpGen, H::GrpGen)
+function is_isomorphic_with_map(G::GrpGen, H::GrpGen)
   idG, A, AtoG = find_small_group(G)
   idH, B, BtoH = find_small_group(H)
   if idG != idH

--- a/src/NumField/NfAbs/NfAbs.jl
+++ b/src/NumField/NfAbs/NfAbs.jl
@@ -535,12 +535,12 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    is_isomorphic(K::AnticNumberField, L::AnticNumberField) -> Bool, NfToNfMor
+    is_isomorphic_with_map(K::AnticNumberField, L::AnticNumberField) -> Bool, NfToNfMor
 
-Returns "true" and an isomorphism from $K$ to $L$ if $K$ and $L$ are isomorphic.
+Return `true` and an isomorphism from $K$ to $L$ if $K$ and $L$ are isomorphic.
 Otherwise the function returns "false" and a morphism mapping everything to 0.
 """
-function is_isomorphic(K::AnticNumberField, L::AnticNumberField)
+function is_isomorphic_with_map(K::AnticNumberField, L::AnticNumberField)
   f = K.pol
   g = L.pol
   if degree(f) != degree(g)
@@ -843,7 +843,7 @@ function splitting_field(fl::Vector{<:PolyElem{nf_elem}}; do_roots::Bool = false
   end
   lg = [k for k = fl if degree(k) > 1]
   if length(lg) == 0
-    if do_roots 
+    if do_roots
       return base_ring(fl[1]), r
     else
       return base_ring(fl[1])

--- a/src/NumField/NfRel/NfRel.jl
+++ b/src/NumField/NfRel/NfRel.jl
@@ -629,7 +629,7 @@ end
 
 ################################################################################
 #
-#  issubfield and is_isomorphic
+#  issubfield and is_isomorphic_with_map
 #
 ################################################################################
 
@@ -657,7 +657,7 @@ function issubfield(K::NfRel, L::NfRel)
   return false, hom(K, L, zero(L), check = false)
 end
 
-function is_isomorphic(K::NfRel, L::NfRel)
+function is_isomorphic_with_map(K::NfRel, L::NfRel)
   @assert base_field(K) == base_field(L)
   f = K.pol
   g = L.pol

--- a/src/NumField/NonSimpleNumField/Field.jl
+++ b/src/NumField/NonSimpleNumField/Field.jl
@@ -195,7 +195,7 @@ function non_simple_extension(K::SimpleNumField)
       res = v
     end
     L, = number_field(v)
-    @assert is_isomorphic(simple_extension(L)[1], K)[1]
+    @assert is_isomorphic(simple_extension(L)[1], K)
   end
 
   return res

--- a/src/NumField/SimpleNumField/Field.jl
+++ b/src/NumField/SimpleNumField/Field.jl
@@ -87,7 +87,7 @@ end
 @doc Markdown.doc"""
     basis(L::SimpleNumField) -> Vector{NumFieldElem}
 
-Returns the canonical basis of a simple extension $L/K$, that is, the elements
+Return the canonical basis of a simple extension $L/K$, that is, the elements
 $1,a,\dotsc,a^{d - 1}$, where $d$ is the degree of $K$ and $a$ the primitive
 element.
 
@@ -178,19 +178,26 @@ end
 @doc Markdown.doc"""
     issubfield(K::SimpleNumField, L::SimpleNumField) -> Bool, Map
 
-Returns `true` and an injection from $K$ to $L$ if $K$ is a subfield of $L$.
+Return `true` and an injection from $K$ to $L$ if $K$ is a subfield of $L$.
 Otherwise the function returns `false` and a morphism mapping everything to
 $0$.
 """
 issubfield(::SimpleNumField, ::SimpleNumField)
 
 @doc Markdown.doc"""
-    is_isomorphic(K::SimpleNumField, L::SimpleNumField) -> Bool, Map
+    is_isomorphic(K::SimpleNumField, L::SimpleNumField) -> Bool
 
-Returns `true` and an isomorphism from $K$ to $L$ if $K$ and $L$ are isomorphic.
+Return `true` if $K$ and $L$ are isomorphic, otherwise `false`.
+"""
+is_isomorphic(K::SimpleNumField, L::SimpleNumField) = is_isomorphic_with_map(K, L)[1]
+
+@doc Markdown.doc"""
+    is_isomorphic_with_map(K::SimpleNumField, L::SimpleNumField) -> Bool, Map
+
+Return `true` and an isomorphism from $K$ to $L$ if $K$ and $L$ are isomorphic.
 Otherwise the function returns `false` and a morphism mapping everything to $0$.
 """
-is_isomorphic(::SimpleNumField, ::SimpleNumField)
+is_isomorphic_with_map(::SimpleNumField, ::SimpleNumField)
 
 ################################################################################
 #

--- a/src/NumField/SimpleNumField/Field.jl
+++ b/src/NumField/SimpleNumField/Field.jl
@@ -199,6 +199,8 @@ Otherwise the function returns `false` and a morphism mapping everything to $0$.
 """
 is_isomorphic_with_map(::SimpleNumField, ::SimpleNumField)
 
+export is_isomorphic_with_map
+
 ################################################################################
 #
 #  Linear disjointness

--- a/test/AlgAss/AlgAss.jl
+++ b/test/AlgAss/AlgAss.jl
@@ -62,7 +62,7 @@ end
 
     # Extend to K again
     C, CtoB = Hecke._as_algebra_over_center(B)
-    @test is_isomorphic(K, base_ring(C))[1]
+    @test is_isomorphic(K, base_ring(C))
     @test dim(C) == dim(A)
 
     test_alg_morphism_char_0(C, B, CtoB)

--- a/test/AlgAssAbsOrd/ICM.jl
+++ b/test/AlgAssAbsOrd/ICM.jl
@@ -6,11 +6,11 @@
   O = equation_order(K)
   icm = ideal_class_monoid(O)
   @test length(icm) == 59
-  @test is_isomorphic(evaluate(icm[1]), evaluate(icm[2]))[1] == false
-  t, b = is_isomorphic(O(2)*O, O(3)*O)
+  @test !is_isomorphic(evaluate(icm[1]), evaluate(icm[2]))
+  t, b = is_isomorphic_with_map(O(2)*O, O(3)*O)
   @test t == true
   @test (O(3)*O)*(b*O) == K(2)*O
-  t, b = is_isomorphic(K(2)*O, K(3)*O)
+  t, b = is_isomorphic_with_map(K(2)*O, K(3)*O)
   @test t == true
   @test (O(3)*O)*(b*O) == K(2)*O
 
@@ -30,11 +30,11 @@ end
   O = Order(A, basis(A))
   icm = ideal_class_monoid(O)
   @test length(icm) == 59
-  @test is_isomorphic(evaluate(icm[1]), evaluate(icm[2]))[1] == false
-  t, b = is_isomorphic(O(2)*O, O(3)*O)
+  @test !is_isomorphic(evaluate(icm[1]), evaluate(icm[2]))
+  t, b = is_isomorphic_with_map(O(2)*O, O(3)*O)
   @test t == true
   @test (O(3)*O)*(b*O) == A(2)*O
-  t, b = is_isomorphic(A(2)*O, A(3)*O)
+  t, b = is_isomorphic_with_map(A(2)*O, A(3)*O)
   @test t == true
   @test (O(3)*O)*(b*O) == A(2)*O
 

--- a/test/FieldFactory/FrobeniusExtensions.jl
+++ b/test/FieldFactory/FrobeniusExtensions.jl
@@ -5,9 +5,9 @@
   @test length(flds) == 7
   flds = Hecke.primitive_frobenius_extensions(QQ, (6, 1), fmpz(10)^3, only_real = true)
   @test length(flds) == 22
-  @test all(count(L -> is_isomorphic(L, K)[1], flds) == 1 for K in flds)
+  @test all(count(L -> is_isomorphic(L, K), flds) == 1 for K in flds)
   flds = Hecke.primitive_frobenius_extensions(QQ, (6, 1), fmpz(10)^3, only_non_real = true)
-  @test length(flds) == 127 
+  @test length(flds) == 127
   flds = Hecke.primitive_frobenius_extensions(QQ, (6, 1), fmpz(10)^3)
   @test length(flds) == 149
 
@@ -18,13 +18,13 @@
   @test length(flds) == 0
   flds = Hecke.primitive_frobenius_extensions(QQ, (10, 1), fmpz(2209), only_non_real = true)
   @test length(flds) == 1
-  @test is_isomorphic(flds[1], number_field(x^5 - 2*x^4 + 2*x^3 - x^2 + 1)[1])[1]
+  @test is_isomorphic(flds[1], number_field(x^5 - 2*x^4 + 2*x^3 - x^2 + 1)[1])
 
   flds = Hecke.primitive_frobenius_extensions(QQ, (10, 1), fmpz(106800), only_real = true)
   @test length(flds) == 0
   flds = Hecke.primitive_frobenius_extensions(QQ, (10, 1), fmpz(160801), only_real = true)
   @test length(flds) == 1
-  @test is_isomorphic(flds[1], number_field(x^5 - x^4 - 5*x^3 + 4*x^2 + 3*x - 1)[1])[1]
+  @test is_isomorphic(flds[1], number_field(x^5 - x^4 - 5*x^3 + 4*x^2 + 3*x - 1)[1])
 
   @test_throws ArgumentError Hecke.primitive_frobenius_extensions(QQ, (1, 1), fmpz(10))
   @test_throws ArgumentError Hecke.primitive_frobenius_extensions(QQ, (10, 1), fmpz(160801), only_real = true, only_non_real = true)

--- a/test/Misc/NumberField.jl
+++ b/test/Misc/NumberField.jl
@@ -4,7 +4,7 @@
     K, a = NumberField(x^2 + 1, "a")
     L, b = NumberField(x^4 + 1, "b")
 
-    c, KtoL = Hecke.issubfield(K, L)
+    c, KtoL = issubfield(K, L)
     @test c == true
     @test parent(KtoL(a)) == L
 
@@ -14,7 +14,7 @@
 
     OK = maximal_order(K)
     OL = maximal_order(L)
-    c, KtoL = Hecke.issubfield(K, L)
+    c, KtoL = issubfield(K, L)
     @test c == true
     @test parent(KtoL(a)) == L
   end
@@ -27,19 +27,18 @@
     g = x^5 - 172x^4 + 7024x^3 + 8656448x^2 + 55735552x + 45796197888
     K2, a2 = NumberField(g, "a2")
 
-    c, KtoK2 = Hecke.is_isomorphic(K, K2)
+    c, KtoK2 = is_isomorphic_with_map(K, K2)
     @test c == true
     @test parent(KtoK2(a)) == K2
 
     OK = maximal_order(K)
     OK2 = maximal_order(K2)
-    c, KtoK2 = Hecke.is_isomorphic(K, K2)
+    c, KtoK2 = is_isomorphic_with_map(K, K2)
     @test c == true
     @test parent(KtoK2(a)) == K2
 
     h = f - 1
     K3, a3 = NumberField(h, "a3")
-    d, KtoK3 = Hecke.is_isomorphic(K, K3)
-    @test d == false
+    @test !is_isomorphic(K, K3)
   end
 end

--- a/test/NfAbs/NonSimple.jl
+++ b/test/NfAbs/NonSimple.jl
@@ -111,7 +111,7 @@
   @testset "Morphisms" begin
     L, m = @inferred simple_extension(K)
     LL,  = number_field(x^6-6*x^4-6*x^3+12*x^2-36*x+1)
-    @test is_isomorphic(L, LL)[1]
+    @test is_isomorphic(L, LL)
     for i in 1:100
       z = rand(L, -10:10)
       zz = rand(L, -10:10)
@@ -167,7 +167,7 @@
     lp = Hecke.non_simple_extension(K)
     Kns, gKns = number_field(lp)
     L, mL = simple_extension(Kns)
-    @test is_isomorphic(L, K)[1]
+    @test is_isomorphic(L, K)
   end
 
 end

--- a/test/NfAbs/Simplify.jl
+++ b/test/NfAbs/Simplify.jl
@@ -2,31 +2,31 @@
   Qx, x = PolynomialRing(FlintQQ, "x")
   K, a = NumberField(x^2 - 10, cached = false)
   L, mL = simplify(K)
-  @test is_isomorphic(K, L)[1]
+  @test is_isomorphic(K, L)
 
   K, a = NumberField(x^2 - 100000000000000000000000, cached = false)
   L, mL = simplify(K)
-  @test is_isomorphic(K, L)[1]
+  @test is_isomorphic(K, L)
 
   K, a = NumberField(x - 10, cached = false)
   L, mL = simplify(K)
-  @test is_isomorphic(K, L)[1]
+  @test is_isomorphic(K, L)
 
   K,a = NumberField(x^4-100020001*x^2+100040006000400010, cached = false)
   L, mL = simplify(K)
-  @test is_isomorphic(K, L)[1]
+  @test is_isomorphic(K, L)
 
   K, a = number_field(8*x^3 + 4*x^2 - 4*x - 1, cached = false)
   L, mL = simplify(K)
   @test Hecke.isdefining_polynomial_nice(L)
   L1, mL1 = simplify(K, canonical = true)
   @test Hecke.isdefining_polynomial_nice(L1)
-  @test is_isomorphic(L1, L)[1]
+  @test is_isomorphic(L1, L)
 
   f = -1//3*x^2 - x + 1
   K, a = number_field(f, cached = false)
   L, mL = simplify(K)
-  @test is_isomorphic(K, L)[1]
+  @test is_isomorphic(K, L)
 
   f = x - 1
   K, a = number_field(f, cached = false)

--- a/test/NfAbs/Subfields.jl
+++ b/test/NfAbs/Subfields.jl
@@ -135,8 +135,8 @@ end
   L2,_ = NumberField(x^2 + 6*x + 7, "l2");
 
   @testset "Fields [2^4]_4" begin
-    @test any(L -> is_isomorphic(L[1],L1)[1], K0)
-    @test any(L -> is_isomorphic(L[1],L2)[1], K0)
+    @test any(L -> is_isomorphic(L[1],L1), K0)
+    @test any(L -> is_isomorphic(L[1],L2), K0)
   end
 
   ###testing .degree of fields##
@@ -373,7 +373,7 @@ end
     l = subfields(K)
     @test length(l) == 1
     @test degree(l[1][1]) == 1
-    @test is_isomorphic(l[1][1], K)[1]
+    @test is_isomorphic(l[1][1], K)
   end
 
   @testset "relative fields" begin
@@ -444,5 +444,5 @@ end
 
     @test length(subfields(K)) == 4
     @test length(Hecke.principal_subfields(K)) == 4
-  end  
+  end
 end

--- a/test/NfOrd/NarrowPicardGroup.jl
+++ b/test/NfOrd/NarrowPicardGroup.jl
@@ -5,7 +5,7 @@
     OK = maximal_order(number_field(x^2 + d)[1])
     C = narrow_class_group(OK)[1]
     CC = Hecke.narrow_picard_group(OK)[1]
-    @test is_isomorphic(C, CC)[1]
+    @test is_isomorphic(C, CC)
   end
 
   K = number_field(x^4 + 2*x^3 - 35*x^2 - 36*x + 5, "a", cached = false)[1]

--- a/test/NfRel/NfRel.jl
+++ b/test/NfRel/NfRel.jl
@@ -28,13 +28,13 @@
     h = minpoly(bb)
     L2, b2 = NumberField(h, "b2")
 
-    c, LtoL2 = Hecke.is_isomorphic(L, L2)
+    c, LtoL2 = is_isomorphic_with_map(L, L2)
     @test c == true
     @test parent(LtoL2(b)) == L2
 
     #i = g - 1
     #L3, b3 = NumberField(i, "b3")
-    #d, LtoL3 = Hecke.is_isomorphic(L, L3)
+    #d, LtoL3 = is_isomorphic_with_map(L, L3)
     #@test d == false
   end
 

--- a/test/NfRel/NfRelOrd.jl
+++ b/test/NfRel/NfRelOrd.jl
@@ -128,7 +128,7 @@ end
     end
     push!(g, h)
     gg = monic_randpoly(Ky, 3, 3, 10) # Must be coprime to 2
-    while gg == g[1] || !is_irreducible(gg) || is_isomorphic(number_field(g[1], cached = false)[1], number_field(gg, cached = false)[1])[1]
+    while gg == g[1] || !is_irreducible(gg) || is_isomorphic(number_field(g[1], cached = false)[1], number_field(gg, cached = false)[1])
       gg = monic_randpoly(Ky, 3, 3, 10) # Must be coprime to 2
     end
     push!(g, gg)

--- a/test/NumField/CM.jl
+++ b/test/NumField/CM.jl
@@ -33,7 +33,7 @@
   fl, c = Hecke.iscm_field(k)
   @test c * C == cm_type(k, cembd[2:2])
   @test id_hom(k) * C == C
-  
+
   K, a = cyclotomic_field(7)
   ct = Hecke.cm_types(K)
   @test count(isprimitive, ct) == 6
@@ -43,6 +43,6 @@
   K, a = number_field(f)
   ct = Hecke.cm_types(K)
   KK = Hecke.reflex(ct[1]).field
-  @test is_isomorphic(KK, number_field(x^4 + 52*x^2 + 477)[1])[1]
-  @test is_isomorphic(Hecke.reflex(Hecke.reflex(ct[1])).field, K)[1] # since primitive
+  @test is_isomorphic(KK, number_field(x^4 + 52*x^2 + 477)[1])
+  @test is_isomorphic(Hecke.reflex(Hecke.reflex(ct[1])).field, K) # since primitive
 end

--- a/test/NumField/Elem.jl
+++ b/test/NumField/Elem.jl
@@ -43,14 +43,14 @@
     K3, a3 = NumberField(t^3 - 2)
     K4, (a4, ) = NumberField([t^3 - 2])
     K41, mK4 = component(K4, 1)
-    @test is_isomorphic(K41, K3)[1]
+    @test is_isomorphic(K41, K3)
     @test mK4(gen(K41)) == a4
 
 
     K1, a1 = NumberField(x^3 - 2)
     K2, (a2, ) = NumberField([x^3 - 2])
     K21, mK2 = component(K2, 1)
-    @test is_isomorphic(K21, K1)[1]
+    @test is_isomorphic(K21, K1)
     @test mK2(gen(K21)) == a2
   end
 

--- a/test/NumField/NfAbs/NfAbs.jl
+++ b/test/NumField/NfAbs/NfAbs.jl
@@ -25,7 +25,7 @@ end
   @test typeof(K) == AnticNumberField
   K1 = number_field([x^3-2, x^2+x+1])[1]
   K1abs = simple_extension(K1)[1]
-  @test is_isomorphic(K, K1abs)[1]
+  @test is_isomorphic(K, K1abs)
   K, R = splitting_field(f, do_roots = true)
   for r in R
     @test iszero(f(r))

--- a/test/NumField/NfRel/Simplify.jl
+++ b/test/NumField/NfRel/Simplify.jl
@@ -4,7 +4,7 @@
   Kt, t = K["t"]
   L, = number_field(t^2 - 5, cached = false)
   k, = @inferred Hecke.simplified_absolute_field(L, cached = false)
-  @test is_isomorphic(k, number_field(x^4 + 513*x^2 + 67081)[1])[1]
+  @test is_isomorphic(k, number_field(x^4 + 513*x^2 + 67081)[1])
 
   K, a = number_field(x^3 + 42*x - 192, "a", cached = false);
   Kt, t = K["t"]

--- a/test/RCF/rcf.jl
+++ b/test/RCF/rcf.jl
@@ -33,14 +33,14 @@
   H = hilbert_class_field(K)
   L1 = number_field(H)
   L2 = number_field(H, using_stark_units = true, redo = true)
-  @test is_isomorphic(Hecke.simplified_absolute_field(L1)[1], Hecke.simplified_absolute_field(L2)[1])[1]
+  @test is_isomorphic(Hecke.simplified_absolute_field(L1)[1], Hecke.simplified_absolute_field(L2)[1])
 
   f = x^2 - x - 100
   K, a = number_field(f, cached = false, check = false)
   H = hilbert_class_field(K)
   L1 = number_field(H)
   L2 = number_field(H, using_stark_units = true, redo = true)
-  @test is_isomorphic(Hecke.simplified_absolute_field(L1)[1], Hecke.simplified_absolute_field(L2)[1])[1]
+  @test is_isomorphic(Hecke.simplified_absolute_field(L1)[1], Hecke.simplified_absolute_field(L2)[1])
   @test length(closure(Hecke.absolute_automorphism_group(H), *)) == 10
 
   r, mr = Hecke.ray_class_groupQQ(Z, 32, true, 8);
@@ -147,7 +147,7 @@ end
   @test norm(conductor(C)[1]) == 21
 
   C = cyclotomic_field(ClassField, 1)
-  @test C == C*C 
+  @test C == C*C
 end
 
 


### PR DESCRIPTION
The function `is_isomorphic` just returns a `Bool`, while `is_isomorphic_with_map` also returns a map.

This brings us in line with what we do in Oscar now (modulo the underscore after `is`, but that's temporary). Also, before this PR, some `isisomorphic` methods had one return value, some had two, which was quite confusing.

Breaking change.

Contains PR #682 which ideally should be merged first.