### PR TITLE
Some improvments for the Mordell-Weil group things

### DIFF
--- a/src/EllCrv/EllCrv.jl
+++ b/src/EllCrv/EllCrv.jl
@@ -47,7 +47,7 @@ export base_field, division_polynomial, division_polynomial_univariate, Elliptic
 ################################################################################
 
 mutable struct EllCrv{T}
-  base_field::Field
+  base_field::Ring
   short::Bool
   a_invars::Tuple{T, T, T, T, T}
   b_invars::Tuple{T, T, T, T}


### PR DESCRIPTION
- Speedup the computation in the hot loop using inplace operations
- Avoid rational arithmetic (everything is integral)

@JHanselman Can you have a look and confirm that this makes sense?

P.S.: For `E1` the time goes down from 15s to 0.4s on my machine.