### PR TITLE
Disable trim_trailing_whitespace in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ charset = utf-8
 end_of_line = lf
 indent_style = space
 insert_final_newline = true
-trim_trailing_whitespace = true
+trim_trailing_whitespace = false
 
 [*.jl]
 indent_size = 2


### PR DESCRIPTION
I like the option, but right now there are a ton of files in Hecke.jl
which have trailing whitespaces, and this results in lots of diffs for
me when I edit them, as my editor honors .editorconfig.

The alternative would be to remove all those trailing whitespaces, and
then possible ensure they stay away by adding a suitable check to pull
requests to prevent them from being added again. Also, convince all
contributors to configure their editor to honor these settings, assuming
they have one of the many editors listed on <https://editorconfig.org>.
