### PR TITLE
fixed `snf_with_transform`

### DIFF
--- a/src/Misc/Matrix.jl
+++ b/src/Misc/Matrix.jl
@@ -1297,7 +1297,7 @@ function snf_with_transform(A::fmpz_mat, l::Bool = true, r::Bool = true)
   for i in 1:min(nrows(S), ncols(S))
     if S[i, i] < 0
       if l
-        multiply_column!(L, fmpz(-1), i)
+        multiply_row!(L, fmpz(-1), i)
       end
       S[i, i] = -S[i, i]
     end

--- a/test/GrpAb/Elem.jl
+++ b/test/GrpAb/Elem.jl
@@ -220,6 +220,10 @@
       T,L,R = snf_with_transform(M, false, true)
       T,L,R = snf_with_transform(M, true, false)
       T,L,R = snf_with_transform(M, false, false)
+
+      M = diagonal_matrix(fmpz[-3, 5])
+      T,L,R = snf_with_transform(M, true, true)
+      @test L*M*R == T
     end
   end
 end


### PR DESCRIPTION
In the case of negative diagonal entries,
if one wants to change the signs by adjusting the left transformation matrix
then this must be done from the left, that is, by multiplying rows.