### PR TITLE
Iterator for `TorQuadMod`

### DIFF
--- a/src/QuadForm/Torsion.jl
+++ b/src/QuadForm/Torsion.jl
@@ -453,26 +453,19 @@ end
 
 Base.length(T::TorQuadMod) = Int(order(T))
 
-Base.IteratorSize(::TorQuadMod) = Base.HasLength()
+Base.IteratorSize(::Type{TorQuadMod}) = Base.HasLength()
+
+Base.eltype(::Type{TorQuadMod}) = TorQuadModElem
 
 function Base.iterate(T::TorQuadMod)
-  if order(T) > typemax(UInt)
-    error("Too large for iterator")
-  end
-
-  A = abelian_group(T)
-
-  return T(Hecke._elem_from_enum(A, UInt(0))), UInt(1)
+  a, st = iterate(abelian_group(T))
+  return T(a), st
 end
 
 function Base.iterate(T::TorQuadMod, st::UInt)
-  if st >= order(T)
-    return nothing
-  end
-
-  A = abelian_group(T)
-
-  return T(Hecke._elem_from_enum(A, st)), st + 1
+  st >= order(T) && return nothing
+  a, st = iterate(abelian_group(T), st)
+  return T(a), st
 end
 
 ################################################################################

--- a/src/QuadForm/Torsion.jl
+++ b/src/QuadForm/Torsion.jl
@@ -444,6 +444,37 @@ function lift(a::TorQuadModElem)
   return fmpq[z[1, i] for i in 1:ncols(z)]
 end
 
+
+################################################################################
+#
+#  Iterator
+#
+################################################################################
+
+Base.length(T::TorQuadMod) = Int(order(T))
+
+Base.IteratorSize(::TorQuadMod) = Base.HasLength()
+
+function Base.iterate(T::TorQuadMod)
+  if order(T) > typemax(UInt)
+    error("Too large for iterator")
+  end
+
+  A = abelian_group(T)
+
+  return T(Hecke._elem_from_enum(A, UInt(0))), UInt(1)
+end
+
+function Base.iterate(T::TorQuadMod, st::UInt)
+  if st >= order(T)
+    return nothing
+  end
+
+  A = abelian_group(T)
+
+  return T(Hecke._elem_from_enum(A, st)), st + 1
+end
+
 ################################################################################
 #
 #  Maps between torsion quadratic modules

--- a/test/QuadForm/Torsion.jl
+++ b/test/QuadForm/Torsion.jl
@@ -181,4 +181,9 @@
   @test N === normal_form(N)[1]
   j = inv(i)
   @test all(g == i(j(g)) for g in gens(N))
+
+  # iterator
+  gen = genera((0,6), 2^3*2^3*5^2)
+  disc = discriminant_group.(gen)
+  @test all(T -> length(collect(T)) == order(T), disc)
 end

--- a/test/QuadForm/Torsion.jl
+++ b/test/QuadForm/Torsion.jl
@@ -183,7 +183,7 @@
   @test all(g == i(j(g)) for g in gens(N))
 
   # iterator
-  gen = genera((0,6), 2^3*2^3*5^2)
+  gen = genera((0,6), 2^3*3^3*5^2)
   disc = discriminant_group.(gen)
   @test all(T -> length(collect(T)) == order(T), disc)
 end


### PR DESCRIPTION
Adding iterators for `TorQuadmod`, based on the iterator of the underlying abelian group.