### PR TITLE
`ZLat` to Magma/Sage

### DIFF
--- a/src/QuadForm/IO.jl
+++ b/src/QuadForm/IO.jl
@@ -43,7 +43,7 @@ function to_hecke(io::IO, L::QuadLat; target = "L", skip_field = false)
   println(io, target, " = quadratic_lattice(K, gens, gram = D)")
 end
 
-function to_hecke(io::IO, L::HermLat; target = "L", skip_field = skip_field)
+function to_hecke(io::IO, L::HermLat; target = "L", skip_field = false)
   E = nf(base_ring(L))
   K = base_field(E)
   println(io, "Qx, x = PolynomialRing(FlintQQ, \"x\")")
@@ -212,6 +212,12 @@ end
 
 function to_sage(L::AbsLat; target = "L")
   return to_sage(stdout, L, target = target)
+end
+
+function to_sage_string(L::AbsLat; target = "L")
+  b = IOBuffer()
+  to_sage(b, L, target = target)
+  return String(take!(b))
 end
 
 function to_sage(io::IO, L::ZLat; target = "L")

--- a/src/QuadForm/IO.jl
+++ b/src/QuadForm/IO.jl
@@ -188,7 +188,7 @@ end
 #
 ################################################################################
 
-function to_hecke(io::IO, L::ZLat; target = "L")
+function to_hecke(io::IO, L::ZLat; target = "L", skip_field = false)
   B = basis_matrix(L)
   G = gram_matrix(ambient_space(L))
   Bst = "[" * split(string([B[i, j] for i in 1:nrows(B) for j in 1:ncols(B)]), '[')[2]
@@ -196,5 +196,33 @@ function to_hecke(io::IO, L::ZLat; target = "L")
   println(io, "B = matrix(FlintQQ, ", nrows(B), ", ", ncols(B), " ,", Bst, ");")
   println(io, "G = matrix(FlintQQ, ", nrows(G), ", ", ncols(G), " ,", Gst, ");")
   println(io, target, " = ", "Zlattice(B, gram = G);")
+end
+
+function to_magma(io::IO, L::ZLat; target = "L")
+  B = basis_matrix(L)
+  G = gram_matrix(ambient_space(L))
+  Bst = "[" * split(string([B[i, j] for i in 1:nrows(B) for j in 1:ncols(B)]), '[')[2]
+  Gst = "[" * split(string([G[i, j] for i in 1:nrows(G) for j in 1:ncols(G)]), '[')[2]
+  Bst = replace(Bst, "//" => "/")
+  Gst = replace(Gst, "//" => "/")
+  println(io, "B := Matrix(Rationals(), ", nrows(B), ", ", ncols(B), " ,", Bst, ");")
+  println(io, "G := Matrix(Rationals(), ", nrows(G), ", ", ncols(G), " ,", Gst, ");")
+  println(io, target, " := ", "LatticeWithBasis(B, G);")
+end
+
+function to_sage(L::AbsLat; target = "L")
+  return to_sage(stdout, L, target = target)
+end
+
+function to_sage(io::IO, L::ZLat; target = "L")
+  B = basis_matrix(L)
+  G = gram_matrix(ambient_space(L))
+  Bst = "[" * split(string([B[i, j] for i in 1:nrows(B) for j in 1:ncols(B)]), '[')[2]
+  Gst = "[" * split(string([G[i, j] for i in 1:nrows(G) for j in 1:ncols(G)]), '[')[2]
+  Bst = replace(Bst, "//" => "/")
+  Gst = replace(Gst, "//" => "/")
+  println(io, "B = Matrix(QQ, ", nrows(B), ", ", ncols(B), " ,", Bst, ")")
+  println(io, "G = Matrix(QQ, ", nrows(G), ", ", ncols(G), " ,", Gst, ")")
+  println(io, target, " = ", "IntegralLattice(G, B)")
 end
 

--- a/src/QuadForm/IO.jl
+++ b/src/QuadForm/IO.jl
@@ -223,6 +223,11 @@ function to_sage(io::IO, L::ZLat; target = "L")
   Gst = replace(Gst, "//" => "/")
   println(io, "B = Matrix(QQ, ", nrows(B), ", ", ncols(B), " ,", Bst, ")")
   println(io, "G = Matrix(QQ, ", nrows(G), ", ", ncols(G), " ,", Gst, ")")
-  println(io, target, " = ", "IntegralLattice(G, B)")
+  if is_integral(L)
+    println(io, target, " = ", "IntegralLattice(G, B)")
+  else
+    println(io, "V = FreeQuadraticModule(ZZ, ", degree(L), ", ",  "inner_product_matrix = G)")
+    println(io, target, " = ", "V.span(B)")
+  end
 end
 

--- a/test/QuadForm/IO.jl
+++ b/test/QuadForm/IO.jl
@@ -19,4 +19,15 @@
   L = hermitian_lattice(E, gens, gram = D)
   @test Hecke.to_hecke_string(L) isa String
   @test Hecke.to_magma_string(L) isa String
+
+  # For Zlattices
+  B = matrix(FlintQQ, 6, 7 ,[1, -1, 0, 0, 0, 0, 0, 0, 1, -1, 0, 0, 0, 0, 0, 0, 1, -1, 0, 0, 0, 0, 0, 0, 1, -1, 0, 0, 0, 0, 0, 0, 1, -1, 0, 0, 0, 0, 0, 0, 1, -1]);
+  G = matrix(FlintQQ, 7, 7 ,[3, 2, 2, 2, 2, 2, 1, 2, 3, 2, 2, 2, 2, 1, 2, 2, 3, 2, 2, 2, 1, 2, 2, 2, 3, 2, 2, 1, 2, 2, 2, 2, 3, 2, 1, 2, 2, 2, 2, 2, 3, 1, 1, 1, 1, 1, 1, 1, 1]);
+  L = Zlattice(B, gram = G)
+
+  @test Hecke.to_hecke_string(L) isa String
+  @test Hecke.to_magma_string(L) isa String
+  @test Hecke.to_sage_string(L) isa String
+  @test Hecke.to_sage_string(dual(L)) isa String
+
 end


### PR DESCRIPTION
Add conversions to parseble Magma and Sage codes for `ZLat`. 

Minor fix on the Hecke one: one entry argument was missing (while useless in this case... is it necessary though for `HermLat` and `QuadLat` ?)