### PR TITLE
`VecSpaceRes` as `HeckeMap`

### DIFF
--- a/src/QuadForm/Misc.jl
+++ b/src/QuadForm/Misc.jl
@@ -4,32 +4,27 @@
 #
 ################################################################################
 
-mutable struct VecSpaceRes{S, T}
-  field::S
-  domain_dim::Int
-  codomain_dim::Int
-  absolute_basis::Vector{T}
-  absolute_degree::Int
-end
+mutable struct VecSpaceRes{S, T} <: Map{S, T, HeckeMap, VecSpaceRes}
+  header::MapHeader{S, T}
+  absolute_basis
 
-function VecSpaceRes(K::S, n::Int) where {S}
-  B = absolute_basis(K)
-  d = absolute_degree(K)
-  domain_dim = n * d
-  codomain_dim = n
-
-  return VecSpaceRes{S, elem_type(K)}(K, domain_dim, codomain_dim, B, d)
+  function VecSpaceRes(D::S, C::T) where {S, T}
+    z = new{S, T}()
+    z.header = MapHeader{S, T}(D, C)
+    z.absolute_basis = absolute_basis(base_ring(C))
+    return z
+  end
 end
 
 function Base.show(io::IO, f::VecSpaceRes)
-  n = f.domain_dim
-  m = f.codomain_dim
+  n = dim(domain(f))
+  m = dim(codomain(f))
   println(io, "Restriction of scalars QQ^", n , " -> K^", m)
   println(io, "where K is")
-  println(io, f.field)
+  println(io, base_ring(codomain(f)))
 end
 
-(f::VecSpaceRes)(a) = image(f, a)
+(f::VecSpaceRes)(v::Vector) = image(f, v)
 
 function image(f::VecSpaceRes{S, T}, v::Vector) where {S, T}
   if v isa Vector{fmpq}
@@ -41,15 +36,15 @@ function image(f::VecSpaceRes{S, T}, v::Vector) where {S, T}
 end
 
 function _image(f::VecSpaceRes{S, T}, v::Vector{fmpq}) where {S, T}
-  n = f.codomain_dim
-  d = f.absolute_degree
-  m = f.domain_dim
+  n = dim(codomain(f))
+  d = length(f.absolute_basis)
+  m = dim(domain(f))
   B = f.absolute_basis
   @req length(v) == m "Vector must have length $m ($(length(v)))"
-  z = Vector{T}(undef, n)
+  z = Vector{elem_type(base_ring(codomain(f)))}(undef, n)
   l = 1
   for i in 1:n
-    z[i] = zero(f.field)
+    z[i] = zero(base_ring(codomain(f)))
     for k in 1:d
       z[i] = z[i] + v[l] * B[k]
       l = l + 1
@@ -61,23 +56,23 @@ end
 Base.:(\)(f::VecSpaceRes, a) = preimage(f, a)
 
 function preimage(f::VecSpaceRes{S, T}, v::Vector) where {S, T}
-  if v isa Vector{T}
+  if v isa Vector{elem_type(base_ring(codomain(f)))}
     vv = v
   else
-    vv = map(f.field, v)::Vector{T}
+    vv = map(base_ring(codomain(f)), v)::Vector{elem_type(base_ring(codomain(f)))}
   end
   return _preimage(f, vv)
 end
 
-function _preimage(f::VecSpaceRes{S, T}, w::Vector{T}) where {S, T}
-  n = f.codomain_dim
-  d = f.absolute_degree
+function _preimage(f::VecSpaceRes{S, T}, w::Vector) where {S, T}
+  n = dim(codomain(f))
+  d = length(f.absolute_basis)
   @req length(w) == n "Vector must have length $n ($(length(w)))"
-  z = Vector{fmpq}(undef, f.domain_dim)
+  z = Vector{fmpq}(undef, dim(domain(f)))
   k = 1
   for i in 1:n
     y = w[i]
-    @assert parent(y) === f.field
+    @assert parent(y) === base_ring(codomain(f))
     co = absolute_coordinates(y)
     for j in 1:d
       z[k] = co[j]

--- a/src/QuadForm/Spaces.jl
+++ b/src/QuadForm/Spaces.jl
@@ -552,8 +552,9 @@ function restrict_scalars(V::AbsSpace, K::FlintRationalField,
       r = r + 1
     end
   end
-
-  return quadratic_space(FlintQQ, G, check = false), VecSpaceRes(E, rank(V))
+  Vres = quadratic_space(FlintQQ, G, check = false)
+  VrestoV = VecSpaceRes(Vres, V)
+  return Vres, VrestoV
 end
 
 ################################################################################

--- a/test/QuadForm/Lattices.jl
+++ b/test/QuadForm/Lattices.jl
@@ -186,3 +186,22 @@ end
   B, B, S = jordan_decomposition(L, p)
   @test length(S) == 1
 end
+
+@testset "Restricton of scalars" begin
+  Qx, x = PolynomialRing(FlintQQ, "x")
+  f = x^3 + x^2 - 2*x - 1
+  K, a = NumberField(f, "a", cached = false)
+  Kt, t = PolynomialRing(K, "t")
+  g = t^2 - a*t + 1
+  E, b = NumberField(g, "b", cached = false)
+  D = matrix(E, 4, 4, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1])
+  gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [1, 0, 0, 0]), map(E, [(b + 1//b), 0, 0, 0]), map(E, [(b + 1//b)^2, 0, 0, 0]), map(E, [b, 0, 0, 0]), map(E, [(b + 1//b)*b, 0, 0, 0]), map(E, [(b + 1//b)^2*b, 0, 0, 0]), map(E, [0, 1, 0, 0]), map(E, [0, (b + 1//b), 0, 0]), map(E, [0, (b + 1//b)^2, 0, 0]), map(E, [0, b, 0, 0]), map(E, [0, (b + 1//b)*b, 0, 0]), map(E, [0, (b + 1//b)^2*b, 0, 0]), map(E, [0, 0, 1, 0]), map(E, [0, 0, (b + 1//b), 0]), map(E, [0, 0, (b + 1//b)^2, 0]), map(E, [0, 0, b, 0]), map(E, [0, 0, (b + 1//b)*b, 0]), map(E, [0, 0, (b + 1//b)^2*b, 0]), map(E, [0, 0, 0, 1]), map(E, [0, 0, 0, (b + 1//b)]), map(E, [0, 0, 0, (b + 1//b)^2]), map(E, [0, 0, 0, b]), map(E, [0, 0, 0, (b + 1//b)*b]), map(E, [0, 0, 0, (b + 1//b)^2*b])]
+  L = hermitian_lattice(E, gens, gram = D)
+  Vres, VrestoV = restrict_scalars(ambient_space(L))
+  @test domain(VrestoV) === Vres
+  @test codomain(VrestoV) === ambient_space(L)
+  Lres = restrict_scalars(L)
+  @test ambient_space(Lres) === Vres
+  @test all(v- > VrestoV(VrestoV\v), generators(L))
+end
+

--- a/test/QuadForm/Lattices.jl
+++ b/test/QuadForm/Lattices.jl
@@ -197,11 +197,11 @@ end
   D = matrix(E, 4, 4, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1])
   gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [1, 0, 0, 0]), map(E, [(b + 1//b), 0, 0, 0]), map(E, [(b + 1//b)^2, 0, 0, 0]), map(E, [b, 0, 0, 0]), map(E, [(b + 1//b)*b, 0, 0, 0]), map(E, [(b + 1//b)^2*b, 0, 0, 0]), map(E, [0, 1, 0, 0]), map(E, [0, (b + 1//b), 0, 0]), map(E, [0, (b + 1//b)^2, 0, 0]), map(E, [0, b, 0, 0]), map(E, [0, (b + 1//b)*b, 0, 0]), map(E, [0, (b + 1//b)^2*b, 0, 0]), map(E, [0, 0, 1, 0]), map(E, [0, 0, (b + 1//b), 0]), map(E, [0, 0, (b + 1//b)^2, 0]), map(E, [0, 0, b, 0]), map(E, [0, 0, (b + 1//b)*b, 0]), map(E, [0, 0, (b + 1//b)^2*b, 0]), map(E, [0, 0, 0, 1]), map(E, [0, 0, 0, (b + 1//b)]), map(E, [0, 0, 0, (b + 1//b)^2]), map(E, [0, 0, 0, b]), map(E, [0, 0, 0, (b + 1//b)*b]), map(E, [0, 0, 0, (b + 1//b)^2*b])]
   L = hermitian_lattice(E, gens, gram = D)
-  Vres, VrestoV = restrict_scalars(ambient_space(L))
+  Vres, VrestoV = restrict_scalars(ambient_space(L), QQ)
   @test domain(VrestoV) === Vres
   @test codomain(VrestoV) === ambient_space(L)
   Lres = restrict_scalars(L)
   @test ambient_space(Lres) === Vres
-  @test all(v- > VrestoV(VrestoV\v), generators(L))
+  @test all(v -> VrestoV(VrestoV\v) == v, generators(L))
 end
 


### PR DESCRIPTION
Needed a way to access the domain and codomain of the map from `restrict_scalars` for `AbsSpace`. Seemed that the type `VecSpaceRes` was not seen as a subtype of `HeckeMap`, so it had no header. I made this change, and modify the functions accordingly to match the new caching.