### PR TITLE
Allow "column vectors" in the construction of group elements

### DIFF
--- a/src/GrpAb/Elem.jl
+++ b/src/GrpAb/Elem.jl
@@ -291,12 +291,17 @@ end
 @doc Markdown.doc"""
     (A::GrpAbFinGen)(x::fmpz_mat) -> GrpAbFinGenElem
 
-Given a matrix over the integers with $1$ row and `ngens(A)` columns,
-this function returns the element of $A$ with components `x`.
+Given a matrix over the integers with either $1$ row and `ngens(A)` columns
+or `ngens(A)` rows and $1$ column, this function returns the element of $A$
+with components `x`.
 """
 function (A::GrpAbFinGen)(x::fmpz_mat)
+  if nrows(x) != 1
+    ncols(x) != 1 && error("Matrix should either have only one row or one column")
+    ngens(A) != nrows(x) && error("Lengths do not coincide")
+    x = transpose(x)
+  end
   ngens(A) != ncols(x) && error("Lengths do not coincide")
-  nrows(x) != 1 && error("Matrix should have only one row")
   z = GrpAbFinGenElem(A, Base.deepcopy(x))
   return z
 end

--- a/test/GrpAb/Elem.jl
+++ b/test/GrpAb/Elem.jl
@@ -12,6 +12,15 @@
     a = @inferred GrpAbFinGenElem(G, N)
     @test @inferred parent(a) == G
     @test a.coeff == N
+
+    N = matrix(FlintZZ, 1, 2, [ 1, 1 ])
+    a = @inferred G(N)
+    @test @inferred parent(a) == G
+    @test a.coeff == N
+    N = transpose(N)
+    a = @inferred G(N)
+    @test @inferred parent(a) == G
+    @test a.coeff == transpose(N)
   end
 
   @testset "Generators" begin


### PR DESCRIPTION
A small change to allow this:
```
julia> G = abelian_group([3, 0]);

julia> N = matrix(FlintZZ, 2, 1, [ 1, 1 ]);

julia> G(N)
Element of
GrpAb: Z/3 x Z
with components [1 1]

```
Seems to me to be the easiest way to make the construction in https://github.com/oscar-system/Oscar.jl/blob/5c7916ed7831ef993ba108418151f01ff0f5c9f2/src/Rings/mpoly-graded.jl#L182 work (without having to write a separate function for `fmpz_mat` there).