### PR TITLE
Correctly set `nnz` in `can_solve_with_solution`

### DIFF
--- a/src/Sparse/Solve.jl
+++ b/src/Sparse/Solve.jl
@@ -417,6 +417,7 @@ function can_solve_with_solution(A::SMat{T}, B::SMat{T}; side::Symbol = :right) 
       end
       push!(sol.rows[p[i]].pos, j)
       push!(sol.rows[p[i]].values, mu.rows[i].values[k])
+      sol.nnz += 1
     end
   end
   if side == :left

--- a/test/Sparse/Solve.jl
+++ b/test/Sparse/Solve.jl
@@ -5,14 +5,18 @@
   fl, sol = can_solve_with_solution(M, b, side = :left)
   @test fl
   @test matrix(sol)*matrix(M) == matrix(b)
+  @test nnz(sol) == sum(length(sol.rows[i].values) for i = 1:nrows(sol))
   sol = solve(M, b, side = :left)
   @test matrix(sol)*matrix(M) == matrix(b)
+  @test nnz(sol) == sum(length(sol.rows[i].values) for i = 1:nrows(sol))
 
   fl, sol = can_solve_with_solution(M, transpose(b), side = :right)
   @test fl
   @test matrix(M)*matrix(sol) == matrix(transpose(b))
+  @test nnz(sol) == sum(length(sol.rows[i].values) for i = 1:nrows(sol))
   sol = solve(M, transpose(b), side = :right)
   @test matrix(M)*matrix(sol) == matrix(transpose(b))
+  @test nnz(sol) == sum(length(sol.rows[i].values) for i = 1:nrows(sol))
 
   fl, sol = can_solve_with_solution(M, b.rows[1])
   @test fl
@@ -26,6 +30,7 @@
     N = matrix(FlintQQ, rand([0,0,0,0,0,0,0,0,0,0,1], r, 2))
     Ns = sparse_matrix(N)
     fl, sol = can_solve_with_solution(Ms, Ns, side = :right)
+    @test nnz(sol) == sum(length(sol.rows[i].values) for i = 1:nrows(sol); init = 0)
     fl2, sol2 = can_solve_with_solution(M, N, side = :right)
     @test fl == fl2
     if fl


### PR DESCRIPTION
I forgot to set the `nnz` of the solution, when I wrote `can_solve_with_solution` for sparse matrices. Sorry!