### PR TITLE
Primary/elementary discriminant group

### DIFF
--- a/src/QuadForm/Quad/ZGenus.jl
+++ b/src/QuadForm/Quad/ZGenus.jl
@@ -1,7 +1,7 @@
 export genus, rank, det, dim, prime, symbol, representative, signature,
        oddity, excess, level, genera, scale, norm, mass, orthogonal_sum,
        quadratic_space,hasse_invariant, genera, local_symbol, local_symbols,
-       ZGenus, ZpGenus, representatives
+       ZGenus, ZpGenus, representatives, is_elementary, is_primary, is_unimodular
 
 @doc Markdown.doc"""
     ZpGenus
@@ -2109,5 +2109,95 @@ function represents(G1::ZGenus, G2::ZGenus)
     end
   end
   return true
+end
+
+########################################################################
+#
+# Primary/elementary genera
+#
+########################################################################
+
+@doc Markdown.doc"""
+    is_primary(G::ZGenus) -> Bool, fmpz
+
+Given a genus of $\mathbb Z$-lattices `G`, return whether it is primary,
+that is whether its associated discriminant form is a `p`-group for some
+prime number `p`. In case it is, `p` is also returned as second output.
+
+Note that for unimodular genera, this function returns `(true, 1)`. If the
+genus is not primary, the second return value is `-1` by default.
+"""
+function is_primary(G::ZGenus)
+  length(primes(G)) >= 3 && return false, ZZ(-1)
+  
+  sym = local_symbols(G)
+  if length(sym) == 1 # symbol only at 2
+    if sym[1]._symbol[end][1] != 0
+      return true, ZZ(2)
+    else
+        return true, ZZ(1)
+    end
+  end
+  
+  if sym[1]._symbol[end][1] != 0
+      return false, ZZ(-1)
+  end
+
+  return true, primes(G)[end]
+end
+
+@doc Markdown.doc"""
+    is_primary(G::ZGenus, p::Union{Integer, fmpz}) -> Bool
+
+Given a genus of $\mathbb Z$-lattices `G` and a prime number `p`, return
+whether `G` is `p`-primary, that is whether its associated discriminant
+form is a `p`-group.
+"""
+function is_primary(G::ZGenus, p::Union{Integer, fmpz})
+  bool, q = is_primary(G)
+  return bool && q == p
+end
+
+@doc Markdown.doc"""
+    is_unimodular(G::ZGenus) -> Bool
+
+Given a genus of $\mathbb Z$-lattices `G`, return whether `G` is unimodular,
+that is whether its associated discriminant form is trivial.
+"""
+is_unimodular(G::ZGenus) = is_primary(G, 1)
+
+@doc Markdown.doc"""
+    is_elementary(G::ZGenus) -> Bool, fmpz
+
+Given a genus of $\mathbb Z$-lattices `G`, return whether it is elementary,
+that is whether its associated discriminant form is an elementary `p`-group
+for some prime number `p`. In case it is, `p` is also returned as second output.
+
+Note that for unimodular genera, this function returns `(true, 1)`. If the
+genus is not elementary, the second return value is `-1` by default.
+"""
+function is_elementary(G::ZGenus)
+  bool, p = is_primary(G)
+  bool || return bool, p
+  if p == 1
+    return bool, p
+  end
+  symp = local_symbol(G, p)
+  if symp._symbol[end][1] != 1
+    return false, ZZ(-1)
+  end
+  return true, p
+end
+
+@doc Markdown.doc"""
+    is_elementary(G::ZGenus, p::Union{Integer, fmpz}) -> Bool
+
+Given a genus of $\mathbb Z$-lattices `G` and a prime number `p`, return
+whether `G` is `p`-elementary, that is whether its associated discriminant
+form is an elementary `p`-group.
+"""
+function is_elementary(G::ZGenus, p::Union{Integer, fmpz})
+  bool, q = is_elementary(G)
+  return bool && q == p
 end
 

--- a/src/QuadForm/Quad/ZLattices.jl
+++ b/src/QuadForm/Quad/ZLattices.jl
@@ -1813,3 +1813,81 @@ function overlattice(glue_map::TorQuadModMor)
   return lattice(ambient_space(S), B[end-rank(S)-rank(R)+1:end,:])
 end
 
+################################################################################
+#
+#  Primary/elementary lattices
+#
+################################################################################
+
+@doc Markdown.doc"""
+    is_primary(L::ZLat) -> Bool, fmpz
+
+Given a $\mathbb Z$-lattice `L`, return whether `L` is primary, that is whether its
+discriminant group is a `p`-group for some prime number `p. In case it is, `p` is
+also returned as second output.
+
+Note that for unimodular lattices, this function returns `(true, 1)`. If the
+lattice is not primary, the second return value is `-1` by default.
+"""
+function is_primary(L::ZLat)
+  @req is_integral(L) "L must be integral"
+  d = ZZ(det(L))
+  if d == 1
+    return true, d
+  end
+  pd = prime_divisors(d)
+  if length(pd) != 1
+    return false, ZZ(-1)
+  end
+  return true, pd[1]
+end
+
+@doc Markdown.doc"""
+    is_primary(L::ZLat, p::Union{Integer, fmpz}) -> Bool
+
+Given a $\mathbb Z$-lattice `L` and a prime number `p`, return whether `L` is
+`p`-primary, that is whether its discriminant group is a `p`-group.
+"""
+function is_primary(L::ZLat, p::Union{Integer, fmpz})
+  bool, q = is_primary(L)
+  return bool && q == p
+end
+
+@doc Markdown.doc"""
+    is_unimodular(L::ZLat) -> Bool
+
+Given a $\mathbb Z$-lattice `L`, return whether `L` is unimodular, that is 
+"""
+is_unimodular(L::ZLat) = is_primary(L, 1)
+
+@doc Markdown.doc"""
+    is_elementary(L::ZLat) -> Bool, fmpz
+
+Given a $\mathbb Z$-lattice `L`, return whether `L` is elementary, that is whether
+its discriminant group is an elemenentary `p`-group for some prime number `p`. In
+case it is, `p` is also returned as second output.
+
+Note that for unimodular lattices, this function returns `(true, 1)`. If the lattice
+is not elementary, the second return value is `-1` by default.
+"""
+function is_elementary(L::ZLat)
+  bool, p = is_primary(L)
+  bool || return false, ZZ(-1)
+  if !is_integer(p*scale(dual(L)))
+    return false, ZZ(-1)
+  end
+  return bool, p
+end
+
+@doc Markdown.doc"""
+    is_elementary(L::ZLat, p::Union{Integer, fmpz}) -> Bool
+
+Given a $\mathbb Z$-lattice `L` and a prime number `p`, return whether `L`
+is `p`-elementary, that is whether its discriminant group is an elementary
+`p`-group.
+"""
+function is_elementary(L::ZLat, p::Union{Integer, fmpz})
+  bool, q = is_elementary(L)
+  return bool && q == p
+end
+

--- a/src/QuadForm/Quad/ZLattices.jl
+++ b/src/QuadForm/Quad/ZLattices.jl
@@ -1823,7 +1823,7 @@ end
     is_primary(L::ZLat) -> Bool, fmpz
 
 Given a $\mathbb Z$-lattice `L`, return whether `L` is primary, that is whether its
-discriminant group is a `p`-group for some prime number `p. In case it is, `p` is
+discriminant group is a `p`-group for some prime number `p`. In case it is, `p` is
 also returned as second output.
 
 Note that for unimodular lattices, this function returns `(true, 1)`. If the
@@ -1831,7 +1831,7 @@ lattice is not primary, the second return value is `-1` by default.
 """
 function is_primary(L::ZLat)
   @req is_integral(L) "L must be integral"
-  d = ZZ(det(L))
+  d = ZZ(abs(det(L)))
   if d == 1
     return true, d
   end
@@ -1856,7 +1856,8 @@ end
 @doc Markdown.doc"""
     is_unimodular(L::ZLat) -> Bool
 
-Given a $\mathbb Z$-lattice `L`, return whether `L` is unimodular, that is 
+Given a $\mathbb Z$-lattice `L`, return whether `L` is unimodular, that is
+whether its discriminant group is trivial.
 """
 is_unimodular(L::ZLat) = is_primary(L, 1)
 

--- a/test/QuadForm/Quad/ZGenus.jl
+++ b/test/QuadForm/Quad/ZGenus.jl
@@ -373,4 +373,29 @@
   lis = @inferred primes(G)
   @test lis == fmpz[2,3,5,7,37]
 
+  # primary and elementary
+
+  L = Zlattice(gram=matrix(ZZ, [[2, -1, 0, 0, 0, 0],[-1, 2, -1, -1, 0, 0],[0, -1, 2, 0, 0, 0],[0, -1, 0, 2, 0, 0],[0, 0, 0, 0, 6, 3],[0, 0, 0, 0, 3, 6]]))
+  Lr = root_sublattice(L) #this is D4
+  Ls = orthogonal_submodule(L, Lr)
+  G = genus(L)
+  Gr = genus(Lr)
+  Gs = genus(Ls)
+  @test !is_primary(G)[1]
+  @test is_elementary(Gr, 2)
+  bool, p = @inferred is_primary(Gs)
+  @test bool && !is_elementary(Gs, p)
+
+  for i in [6,7,8]
+    L = root_lattice(:E, i)
+    G = genus(L)
+    @test is_elementary(G, 9-i)
+    @test i != 8 || is_unimodular(G)
+  end
+  G = [genus(root_lattice(:D, j)) for j in [4,5,6,7]]
+  @test all(g -> is_primary(g, 2), G)
+  @test all(g -> !is_unimodular(g), G)
+  j = any(g -> !is_elementary(g,2), G)
+  @test j !== nothing
+
 end

--- a/test/QuadForm/Quad/ZLattices.jl
+++ b/test/QuadForm/Quad/ZLattices.jl
@@ -565,5 +565,28 @@ end
 
   L2 = @inferred overlattice(glue)
   @test L2 == L  # We found back our initial overlattice
+
+  # primary and elementary lattices
+
+  L = Zlattice(gram=matrix(ZZ, [[2, -1, 0, 0, 0, 0],[-1, 2, -1, -1, 0, 0],[0, -1, 2, 0, 0, 0],[0, -1, 0, 2, 0, 0],[0, 0, 0, 0, 6, 3],[0, 0, 0, 0, 3, 6]]))
+  @test_throws ArgumentError is_primary(dual(L))
+  bool, p = @inferred is_primary(L)
+  @test !bool && p == -1
+
+  for i in [6,7,8]
+    L = root_lattice(:E, i)
+    @test is_elementary(L, 9-i)
+    @test i != 8 || is_unimodular(L)
+  end
+
+  for i in [1,2,4,6,10,12,16,18]
+    A = root_lattice(:A, i)
+    bool, p = @inferred is_elementary(A)
+    @test bool
+    @test p == i+1
+  end
+  L = orthogonal_sum(hyperbolic_plane_lattice(), root_lattice(:D, 7))[1]
+  @test is_primary(L, 2) && !is_elementary(L, 2)
+  @test is_unimodular(hyperbolic_plane_lattice())
 end
 

--- a/test/QuadForm/Torsion.jl
+++ b/test/QuadForm/Torsion.jl
@@ -230,6 +230,7 @@
   @test !is_anti_isometric_with_anti_isometry(Tsub, T2)[1]
 
   L = root_lattice(:E, 8)
+  @test sprint(show, "text/plain", rescale(discriminant_group(L), 2)) isa String
   agg = automorphism_group_generators(L)
   for f in agg
     if isone(f)
@@ -285,5 +286,25 @@
   @test is_injective(qL1inq) && is_injective(qL2inq)
   bool, _ = is_isometric_with_isometry(qL3, q)
   @test bool
+
+  # primary/elementary
+
+  L = Zlattice(gram=matrix(ZZ, [[2, -1, 0, 0, 0, 0],[-1, 2, -1, -1, 0, 0],[0, -1, 2, 0, 0, 0],[0, -1, 0, 2, 0, 0],[0, 0, 0, 0, 6, 3],[0, 0, 0, 0, 3, 6]]))
+  T = discriminant_group(L)
+  Tsub, _ = sub(T, [2*T[1], 3*T[2]])
+  @test_throws ArgumentError is_primary(Tsub)
+  bool, p = @inferred is_primary(T)
+  @test !bool && p == -1
+  @test is_primary(primary_part(T, 2), 2)
+  @test !is_elementary(primary_part(T, 3), 3)
+
+  for i in [6,7,8]
+    L = root_lattice(:E, i)
+    qL = discriminant_group(L)
+    @test is_elementary(qL, 9-i)
+  end
+  L = orthogonal_sum(root_lattice(:A, 7), root_lattice(:D, 7))[1]
+  qL = discriminant_group(L)
+  @test is_primary(qL, 2) && !is_elementary(qL, 2)
 end
 


### PR DESCRIPTION
I am not strict on the naming, though it seems to be the ones usually used.

I fixed the `rescale` function for `TorQuadMod` which was buggy (for the printing) in the case where we were rescaling a trivial torsion quadratic module.