### PR TITLE
Fix #859

### DIFF
--- a/src/NumFieldOrd/NfOrd/LinearAlgebra.jl
+++ b/src/NumFieldOrd/NfOrd/LinearAlgebra.jl
@@ -868,16 +868,22 @@ function _contained_in_span_of_pseudohnf(v::Generic.Mat{T}, P::PMat{T, S}, shape
   end
   w = deepcopy(v)
   for i = start:step:stop
-    if !(w[1, i]//P.matrix[i, i] in P.coeffs[i])
+    # find pivot
+    if shape === :upperright
+      piv = findfirst(k -> !iszero(P.matrix[i, k]), 1:ncols(P))::Int
+    else
+      piv = findlast(k -> !iszero(P.matrix[i, k]), 1:ncols(P))::Int
+    end
+    if !(w[1, piv]//P.matrix[i, piv] in P.coeffs[i])
       return false
     end
-    e = w[1, i]//P.matrix[i, i]
+    e = w[1, piv]//P.matrix[i, piv]
     if shape == :upperright
-      for j = i:ncols(P)
+      for j = piv:ncols(P)
         w[1, j] = w[1, j] - e*P.matrix[i, j]
       end
     elseif shape == :lowerleft
-      for j = 1:i
+      for j = 1:piv
         w[1, j] = w[1, j] - e*P.matrix[i, j]
       end
     end

--- a/src/QuadForm/Quad/Lattices.jl
+++ b/src/QuadForm/Quad/Lattices.jl
@@ -16,7 +16,7 @@ end
 #
 ################################################################################
 
-function lattice(V::QuadSpace, B::PMat ; check::Bool = true)
+function lattice(V::QuadSpace, B::PMat; check::Bool = true)
   K = base_ring(V)
   if check
     @req rank(matrix(B)) == min(nrows(B), ncols(B)) "B must be of full rank"

--- a/test/NfOrd/LinearAlgebra.jl
+++ b/test/NfOrd/LinearAlgebra.jl
@@ -157,4 +157,14 @@
       @test reproducible(m)
     end
   end
+
+  # issue 859
+  Qx, x = PolynomialRing(FlintQQ, "x");
+  K, a = NumberField(x^2 + 1, "a", cached = false);
+  M = matrix(K, 1, 3, [5*a, 3*a, 0])
+  pm = pseudo_hnf(pseudo_matrix(M), :lowerleft)
+  @test Hecke._spans_subset_of_pseudohnf(pm, pm, :lowerleft)
+  M = matrix(K, 1, 3, [0, 0, 3*a])
+  pm = pseudo_hnf(pseudo_matrix(M), :lowerleft)
+  @test Hecke._spans_subset_of_pseudohnf(pm, pm, :upperright)
 end


### PR DESCRIPTION
The function `_spans_subset_of_pseudohnf` assumed that the pseudo-HNF
was full rank and thus the diagonals were the pivot entries.

Adjusted to work also in the non-full rank case.

CC: @StevellM 