### PR TITLE
Fix (anti)-isometry test for `TorQuadMod` is totally degenerate case

### DIFF
--- a/src/QuadForm/Torsion.jl
+++ b/src/QuadForm/Torsion.jl
@@ -1000,6 +1000,8 @@ function is_isometric_with_isometry(T::TorQuadMod, U::TorQuadMod)
     fabs = hom(Tabs, Uabs, identity_matrix(ZZ, length(elementary_divisors(T))))
     fab = compose(inv(TabstoTab), compose(fabs, UabstoUab))
     return true, hom(T, U, fab.map)
+  else
+    is_zero(gram_matrix_quadratic(U)) && return (false, hz)
   end
   if is_semi_regular(T)
     return _isometry_semiregular(T, U)
@@ -1122,6 +1124,8 @@ function is_anti_isometric_with_anti_isometry(T::TorQuadMod, U::TorQuadMod)
     fabs = hom(Tabs, Uabs, identity_matrix(ZZ, length(elementary_divisors(T))))
     fab = compose(inv(TabstoTab), compose(fabs, UabstoUab))
     return true, hom(T, U, fab.map)
+  else
+    is_zero(gram_matrix_quadratic(U)) && return (false, hz)
   end
 
   Ue = rescale(U, -1)

--- a/src/QuadForm/Torsion.jl
+++ b/src/QuadForm/Torsion.jl
@@ -992,6 +992,15 @@ function is_isometric_with_isometry(T::TorQuadMod, U::TorQuadMod)
   if modulus_quadratic_form(T) != modulus_quadratic_form(U)
     return (false, hz)
   end
+  # the case where there is no quadratic structure
+  if is_zero(gram_matrix_quadratic(T))
+    is_zero(gram_matrix_quadratic(U)) || return (false, hz)
+    Tabs, TabstoTab = snf(abelian_group(T))
+    Uabs, UabstoUab = snf(abelian_group(U))
+    fabs = hom(Tabs, Uabs, identity_matrix(ZZ, length(elementary_divisors(T))))
+    fab = compose(inv(TabstoTab), compose(fabs, UabstoUab))
+    return true, hom(T, U, fab.map)
+  end
   if is_semi_regular(T)
     return _isometry_semiregular(T, U)
   else
@@ -1105,6 +1114,16 @@ function is_anti_isometric_with_anti_isometry(T::TorQuadMod, U::TorQuadMod)
   if modulus_quadratic_form(T) != modulus_quadratic_form(U)
     return (false, hz)
   end
+  # the case where there is no quadratic structure
+  if is_zero(gram_matrix_quadratic(T))
+    is_zero(gram_matrix_quadratic(U)) || return (false, hz)
+    Tabs, TabstoTab = snf(abelian_group(T))
+    Uabs, UabstoUab = snf(abelian_group(U))
+    fabs = hom(Tabs, Uabs, identity_matrix(ZZ, length(elementary_divisors(T))))
+    fab = compose(inv(TabstoTab), compose(fabs, UabstoUab))
+    return true, hom(T, U, fab.map)
+  end
+
   Ue = rescale(U, -1)
   UetoU = hom(Ue, U, U.(lift.(gens(Ue))))
   if is_semi_regular(T)

--- a/test/QuadForm/Torsion.jl
+++ b/test/QuadForm/Torsion.jl
@@ -228,6 +228,9 @@
   @test bool
   @test is_bijective(phi)
   @test !is_anti_isometric_with_anti_isometry(Tsub, T2)[1]
+  rq2, _ = radical_quadratic(Tsub) # the same as before but diffrent julia object
+  @test is_isometric_with_isometry(rq, rq2)[1]
+  @test is_anti_isometric_with_anti_isometry(rq, rq2)[1]
 
   L = root_lattice(:E, 8)
   @test sprint(show, "text/plain", rescale(discriminant_group(L), 2)) isa String


### PR DESCRIPTION
In the case where the gram matrix of the quadratic form of the of the two is trivial, the case was not covered: actually it was returning an error because of the computation of the normal form. In this case, we can conclude before-hand looking at the moduli, the gram matrices and the underlying abelian groups.