### PR TITLE
Intersection, saturation and orthogonal submodule of `AbsLat`

### DIFF
--- a/docs/src/quad_forms/basics.md
+++ b/docs/src/quad_forms/basics.md
@@ -115,6 +115,7 @@ gram_matrix(::AbsSpace{T}, ::Vector{Vector{U}}) where {T, U}
 inner_product(::AbsSpace, ::Vector, ::Vector)
 orthogonal_basis(::AbsSpace)
 diagonal(::AbsSpace)
+restrict_scalars(::AbsSpace, ::FlintRationalField, ::FieldElem)
 ```
 
 ### Examples

--- a/docs/src/quad_forms/lattices.md
+++ b/docs/src/quad_forms/lattices.md
@@ -232,8 +232,7 @@ Base.:(*)(::NumFieldOrdFracIdl, ::AbsLat)
 rescale(::AbsLat, ::NumFieldElem)
 dual(::AbsLat)
 intersect(::AbsLat, ::AbsLat)
-intersect_via_restriction_of_scalars(::AbsLat, ::AbsLat)
-saturate_via_restriction_of_scalars(::AbsLat, ::AbsLat)
+saturate(::AbsLat)
 orthogonal_submodule(::AbsLat, ::AbsLat)
 ```
 

--- a/docs/src/quad_forms/lattices.md
+++ b/docs/src/quad_forms/lattices.md
@@ -232,7 +232,7 @@ Base.:(*)(::NumFieldOrdFracIdl, ::AbsLat)
 rescale(::AbsLat, ::NumFieldElem)
 dual(::AbsLat)
 intersect(::AbsLat, ::AbsLat)
-saturate(::AbsLat)
+primitive_closure(::AbsLat, ::AbsLat)
 orthogonal_submodule(::AbsLat, ::AbsLat)
 ```
 

--- a/docs/src/quad_forms/lattices.md
+++ b/docs/src/quad_forms/lattices.md
@@ -226,12 +226,15 @@ pseudo-bases) but in space $(V, a\Phi)$.
 
 ```@docs
 Base.:(+)(::AbsLat, ::AbsLat)
-intersect(::AbsLat, ::AbsLat)
 Base.:(*)(::NumFieldElem, ::AbsLat)
 Base.:(*)(::NumFieldOrdIdl, ::AbsLat)
 Base.:(*)(::NumFieldOrdFracIdl, ::AbsLat)
 rescale(::AbsLat, ::NumFieldElem)
 dual(::AbsLat)
+intersect(::AbsLat, ::AbsLat)
+intersect_via_restriction_of_scalars(::AbsLat, ::AbsLat)
+saturate_via_restriction_of_scalars(::AbsLat, ::AbsLat)
+orthogonal_submodule(::AbsLat, ::AbsLat)
 ```
 
 ### Examples

--- a/src/QuadForm/Lattices.jl
+++ b/src/QuadForm/Lattices.jl
@@ -614,8 +614,7 @@ function intersect(L::T, M::T) where {T <: AbsLat}
 end
 
 @doc Markdown.doc"""
-    intersect_via_restriction_of_scalars(L::T, M::T)
-                                    where T <: Union{HermLat, QuadLat} -> T
+    intersect_via_restriction_of_scalars(L::AbsLat, M::AbsLat) -> AbsLat
 
 Return the intersection of the lattices `L` and `M` using restriction
 of scalars (see [`restrict_scalars`](@ref)).

--- a/src/QuadForm/Spaces.jl
+++ b/src/QuadForm/Spaces.jl
@@ -588,9 +588,22 @@ end
 #
 ################################################################################
 
-# TODO: Use absolute_coordinates
+# TODO: Change VecSpaceRes/SpaceRes to allow restriction of scalars
+# to non rational subfields
+@doc Markdown.doc"""
+    restrict_scalars(V::AbsSpace, K::FlintRationalField,
+                                  alpha::FieldElem = one(base_ring(V)))
+                                                          -> QuadSpace, SpaceRes
+
+Given a space $(V, \Phi)$ and a subfield `K` of the base algebra `E` of `V`, return the
+quadratic space `W` obtained by restricting the scalars of $(V, \alpha\Phi)$ to `K`,
+together with the map `f` for extending the scalars back.
+The rescaling factor $\aplha$ is set to 1 by default.
+
+Note that for now one can only restrict scalars to $\mathbb Q$.
+"""
 function restrict_scalars(V::AbsSpace, K::FlintRationalField,
-                                       alpha = one(base_ring(V)))
+                                       alpha::FieldElem = one(base_ring(V)))
   E = base_ring(V)
   n = rank(V)
   d = absolute_degree(E)

--- a/src/QuadForm/Spaces.jl
+++ b/src/QuadForm/Spaces.jl
@@ -598,6 +598,7 @@ end
 Given a space $(V, \Phi)$ and a subfield `K` of the base algebra `E` of `V`, return the
 quadratic space `W` obtained by restricting the scalars of $(V, \alpha\Phi)$ to `K`,
 together with the map `f` for extending the scalars back.
+The form on the restriction is given by ``Tr \circ \Phi`` where ``Tr: E \to K`` is the trace form.  
 The rescaling factor $\alpha$ is set to 1 by default.
 
 Note that for now one can only restrict scalars to $\mathbb Q$.

--- a/src/QuadForm/Spaces.jl
+++ b/src/QuadForm/Spaces.jl
@@ -598,7 +598,7 @@ end
 Given a space $(V, \Phi)$ and a subfield `K` of the base algebra `E` of `V`, return the
 quadratic space `W` obtained by restricting the scalars of $(V, \alpha\Phi)$ to `K`,
 together with the map `f` for extending the scalars back.
-The rescaling factor $\aplha$ is set to 1 by default.
+The rescaling factor $\alpha$ is set to 1 by default.
 
 Note that for now one can only restrict scalars to $\mathbb Q$.
 """

--- a/test/QuadForm/Lattices.jl
+++ b/test/QuadForm/Lattices.jl
@@ -244,7 +244,7 @@ end
   @test L == LL
 end
 
-@testset "Intersection/saturation restrict scalars" begin
+@testset "Intersection/primitive closure restrict scalars" begin
   Qx, x = PolynomialRing(FlintQQ, "x")
   f = x - 1
   K, a = NumberField(f, "a", cached = false)
@@ -265,10 +265,12 @@ end
   @test intersect(L1, L2) == Hecke._intersect_via_restriction_of_scalars(L1, L2) #full rank case
   @test_throws ArgumentError intersect(L1, L4)
 
-  L3sat = saturate(L3)
-  @test is_sublattice(L3sat, L3) && !is_sublattice(L3, L3sat)
+  L13clos1 = @inferred primitive_closure(L1, L13)
+  L13clos3 = @inferred primitive_closure(L3, L13)
+  @test L13clos1 == L13
+  @test L13clos3 != L13 && is_sublattice(L13clos3, L13)
+  @test intersect(L13clos1, L13clos3) == L13
 
-  L3res, f = restrict_scalars_with_map(L3)
-  L3ressat = restrict_scalars(L3sat, f)
-  @test saturate(L3res) == L3ressat
+  L13orth = @inferred orthogonal_submodule(L1, L13)
+  @test rank(intersect(L13clos1, L13orth)) == 0
 end

--- a/test/QuadForm/Lattices.jl
+++ b/test/QuadForm/Lattices.jl
@@ -254,7 +254,7 @@ end
   D = matrix(E, 3, 3, [1, 0, 0, 0, 1, 0, 0, 0, 1])
   gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [-6, -10*b + 10, 0]), map(E, [-6*b + 7, 37//2*b + 21//2, -3//2*b + 5//2]), map(E, [-46*b + 71, 363//2*b + 145//2, -21//2*b + 49//2])]
   gens2 = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [-6, -10*b + 10, 0]), map(E, [-6*b + 7, 37//2*b + 21//2, -3//2*b + 5//2]), map(E, [1 + a + b, 1, 0])]
-  gens3 = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [-6*b + 7, 37//2*b + 21//2, -3//2*b + 5//2]), map(E, [1 + a + b, 1, 0])]
+  gens3 = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [-6*b + 7, 37//2*b + 21//2, -3//2*b + 5//2]), map(E, [2 + 2*a + 2*b, 2, 0])]
   L1 = hermitian_lattice(E, gens, gram = D)
   L2 = hermitian_lattice(E, gens2, gram = D)
   L3 = hermitian_lattice(E, gens3, gram = D)
@@ -262,10 +262,13 @@ end
 
   L13 = @inferred intersect(L1, L3) #non full rank case
   @test is_sublattice(L1, L13) && is_sublattice(L3, L13)
-  @test intersect(L1, L2) == intersect_via_restriction_of_scalars(L1, L2) #full rank case
+  @test intersect(L1, L2) == Hecke._intersect_via_restriction_of_scalars(L1, L2) #full rank case
   @test_throws ArgumentError intersect(L1, L4)
-  @test_throws ArgumentError intersect_via_restriction_of_scalars(L1, L4)
 
-  L3sat = saturate_via_restriction_of_scalars(L3)
-  @test is_sublattice(L3sat, L3)
+  L3sat = saturate(L3)
+  @test is_sublattice(L3sat, L3) && !is_sublattice(L3, L3sat)
+
+  L3res, f = restrict_scalars_with_map(L3)
+  L3ressat = restrict_scalars(L3sat, f)
+  @test saturate(L3res) == L3ressat
 end

--- a/test/QuadForm/Lattices.jl
+++ b/test/QuadForm/Lattices.jl
@@ -8,7 +8,7 @@
   D = matrix(K, 3, 3, [1//64, 0, 0, 0, 1//64, 0, 0, 0, 1//64])
   gensM = [[32, 0, 0], [720*a+448, 0, 0], [16, 16, 0], [152*a+208, 152*a+208, 0], [4*a+24, 4*a, 8], [116*a+152, 20*a+32, 32*a+40]]
   M = @inferred quadratic_lattice(K, gensM, gram = D)
-  @test norm(volume(M))*discriminant(K)^rank(L) == abs(det(restrict_scalars(M)))
+  @test norm(volume(M))*discriminant(K)^rank(L) == abs(det(restrict_scalars(M, FlintQQ)))
 
   p = prime_decomposition(base_ring(L), 2)[1][1]
   @test @inferred is_locally_isometric(L, M, p)
@@ -36,7 +36,7 @@
   OK = maximal_order(K)
   p3 = prime_ideals_over(OK, 3)[1]
   @test is_modular(L, p3)[1]
-  @test norm(volume(L))*discriminant(OK)^rank(L) == abs(det(restrict_scalars(L)))
+  @test norm(volume(L))*discriminant(OK)^rank(L) == abs(det(restrict_scalars(L, FlintQQ)))
 
   @test ambient_space(dual(L)) === ambient_space(L)
   @test ambient_space(Hecke.lattice_in_same_ambient_space(L,pseudo_matrix(L))) === ambient_space(L)
@@ -195,7 +195,7 @@ end
   Vres, VrestoV = restrict_scalars(ambient_space(L), QQ)
   @test domain(VrestoV) === Vres
   @test codomain(VrestoV) === ambient_space(L)
-  Lres = restrict_scalars(L)
+  Lres = restrict_scalars(L, FlintQQ)
   @test ambient_space(Lres) === Vres
   @test all(v -> VrestoV(VrestoV\v) == v, generators(L))
 
@@ -222,7 +222,7 @@ end
   gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [-1, -4*b + 6, 0]), map(E, [16*b - 2, -134*b - 71, -2*b - 1]), map(E, [3*b - 92, -1041//2*b + 1387//2, -15//2*b + 21//2])]
   O = hermitian_lattice(E, gens, gram = D)
 
-  Lres, f = Hecke.restrict_scalars_with_map(L)
+  Lres, f = Hecke.restrict_scalars_with_map(L, FlintQQ)
   Mres = Hecke.restrict_scalars(M, f)
   @test Lres == Hecke.restrict_scalars(L, f)
   @test issublattice(Lres, Mres)
@@ -266,7 +266,7 @@ end
   @test_throws ArgumentError intersect(L1, L4)
 
   L13clos1 = @inferred primitive_closure(L1, L13)
-  L13clos3 = @inferred primitive_closure(L3, L13)
+  L13clos3 = @inferred saturate(L3, L13)
   @test L13clos1 == L13
   @test L13clos3 != L13 && is_sublattice(L13clos3, L13)
   @test intersect(L13clos1, L13clos3) == L13


### PR DESCRIPTION
This is an implementation of intersection, saturation and orthogonal submodule for `HermLat` and `QuadLat`, using restriction of scalars. These work also in the case of non full-rank modules/pseudo-matrices.

This pull request shall replace the previously opened #857 .

I modified `orthogonal_complement` into `orthogonal_submodule` to fit with the function defined for `ZLat`... I hope the implementation does what it should do, @simonbrandhorst ?

At least the broken tests pass now.