### PR TITLE
CI: update codecov/codecov-action to latest version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -75,7 +75,7 @@ jobs:
         #      - name: "Process code coverage"
         #        uses: julia-actions/julia-processcoverage@v1
         #      - name: "Upload coverage data to Codecov"
-        #        uses: codecov/codecov-action@v2
+        #        uses: codecov/codecov-action@v3
 
   docs:
     name: Documentation

--- a/.github/workflows/CILong.yml
+++ b/.github/workflows/CILong.yml
@@ -63,4 +63,4 @@ jobs:
         uses: julia-actions/julia-processcoverage@v1
       - name: "Upload coverage data to Codecov"
         continue-on-error: true
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3


### PR DESCRIPTION
This should avoid some warnings in the GH Actions web view