### PR TITLE
Orthogonal sums with injections and projections

### DIFF
--- a/src/QuadForm/Quad/ZLattices.jl
+++ b/src/QuadForm/Quad/ZLattices.jl
@@ -221,6 +221,15 @@ function orthogonal_sum(L1::ZLat, L2::ZLat)
   return lattice(V, B), f1, f2
 end
 
+function _orthogonal_sum_with_injections_and_projections(x::Vector{ZLat})
+  @assert length(x) >= 2
+  y = ambient_space.(x)
+  Bs = basis_matrix.(x)
+  B = diagonal_matrix(Bs)
+  V, inj, proj = Hecke._orthogonal_sum_with_injections_and_projections(y)
+  return lattice(V, B), inj, proj
+end
+
 @doc Markdown.doc"""
     orthogonal_submodule(L::ZLat, S::ZLat) -> ZLat
 

--- a/src/QuadForm/Quad/ZLattices.jl
+++ b/src/QuadForm/Quad/ZLattices.jl
@@ -222,7 +222,7 @@ function orthogonal_sum(L1::ZLat, L2::ZLat)
 end
 
 function _orthogonal_sum_with_injections_and_projections(x::Vector{ZLat})
-  @assert length(x) >= 2
+  @req length(x) >= 2 "Input must contain at least two lattices"
   y = ambient_space.(x)
   Bs = basis_matrix.(x)
   B = diagonal_matrix(Bs)
@@ -247,7 +247,6 @@ function orthogonal_submodule(L::ZLat, S::ZLat)
   Ks = saturate(K)
   return lattice(V, Ks*B)
 end
-
 
 ################################################################################
 #

--- a/src/QuadForm/Spaces.jl
+++ b/src/QuadForm/Spaces.jl
@@ -703,9 +703,9 @@ function orthogonal_sum(V::HermSpace, W::HermSpace)
 end
 
 function _orthogonal_sum_with_injections_and_projections(x::Vector{<:QuadSpace})
-  @assert length(x) >= 2
+  @req length(x) >= 2 "Input must contain at least two quadratic spaces"
   K = base_ring(x[1])
-  @assert all(i -> base_ring(x[i]) === K, 2:length(x))
+  @req all(i -> base_ring(x[i]) === K, 2:length(x)) "All spaces must be defined over the same field"
   G = diagonal_matrix(gram_matrix.(x))
   V = quadratic_space(K, G)
   n = sum(dim.(x))

--- a/src/QuadForm/Spaces.jl
+++ b/src/QuadForm/Spaces.jl
@@ -702,6 +702,33 @@ function orthogonal_sum(V::HermSpace, W::HermSpace)
   return VplusW, f1, f2
 end
 
+function _orthogonal_sum_with_injections_and_projections(x::Vector{<:QuadSpace})
+  @assert length(x) >= 2
+  K = base_ring(x[1])
+  @assert all(i -> base_ring(x[i]) === K, 2:length(x))
+  G = diagonal_matrix(gram_matrix.(x))
+  V = quadratic_space(K, G)
+  n = sum(dim.(x))
+  inj = AbsSpaceMor[]
+  proj = AbsSpaceMor[]
+  dec = 0
+  for W in x
+    iW = zero_matrix(K, dim(W), n)
+    pW = zero_matrix(K, n, dim(W))
+    for i in 1:dim(W)
+      iW[i, i+dec] = 1
+      pW[i+dec, i] = 1
+    end
+    iW = hom(W, V, iW)
+    pW = hom(V, W, pW)
+    push!(inj, iW)
+    push!(proj, pW)
+    dec += dim(W)
+  end
+  @assert dec == n
+  return V, inj, proj
+end
+
 ################################################################################
 #
 #  Embeddings

--- a/src/QuadForm/Torsion.jl
+++ b/src/QuadForm/Torsion.jl
@@ -1757,6 +1757,39 @@ function orthogonal_sum(T::TorQuadMod, U::TorQuadMod)
   return S, TinS, UinS
 end
 
+function _orthogonal_sum_with_injections_and_projections(x::Vector{TorQuadMod})
+  @assert length(x) >= 2
+  mbf = modulus_bilinear_form(x[1])
+  mqf = modulus_quadratic_form(x[1])
+  @assert all(i -> modulus_bilinear_form(x[i]) == mbf, 2:length(x))
+  @assert all(i -> modulus_quadratic_form(x[i]) == mqf, 2:length(x))
+  cs = cover.(x)
+  rs = relations.(x)
+  C, inj, proj = _orthogonal_sum_with_injections_and_projections(cs)
+  R = lattice(ambient_space(C), block_diagonal_matrix(basis_matrix.(rs)))
+  gensinj = Vector{Vector{fmpq}}[]
+  gensproj = Vector{Vector{fmpq}}[]
+  inj2 = TorQuadModMor[]
+  proj2 = TorQuadModMor[]
+  for i in 1:length(x)
+    gene = [inj[i](lift(a)) for a in gens(x[i])]
+    push!(gensinj, gene)
+  end
+  S = torsion_quadratic_module(C, R, gens = reduce(vcat, gensinj), modulus = mbf, modulus_qf = mqf)
+  for i in 1:length(x)
+    gene = [proj[i](lift(a)) for a in gens(S)]
+    push!(gensproj, gene)
+  end
+  for i in 1:length(x)
+    T = x[i]
+    iT = hom(T, S, S.(gensinj[i]))
+    pT = hom(S, T, T.(gensproj[i]))
+    push!(inj2, iT)
+    push!(proj2, pT)
+  end
+  return S, inj2, proj2
+end
+
 ###############################################################################
 #
 #  Primary/elementary torsion quadratic module

--- a/src/QuadForm/Torsion.jl
+++ b/src/QuadForm/Torsion.jl
@@ -1758,11 +1758,11 @@ function orthogonal_sum(T::TorQuadMod, U::TorQuadMod)
 end
 
 function _orthogonal_sum_with_injections_and_projections(x::Vector{TorQuadMod})
-  @assert length(x) >= 2
+  @req length(x) >= 2 "Input must contain at least two torsion quadratic modules"
   mbf = modulus_bilinear_form(x[1])
   mqf = modulus_quadratic_form(x[1])
-  @assert all(i -> modulus_bilinear_form(x[i]) == mbf, 2:length(x))
-  @assert all(i -> modulus_quadratic_form(x[i]) == mqf, 2:length(x))
+  @req all(i -> modulus_bilinear_form(x[i]) == mbf, 2:length(x)) "All torsion quadratic modules must have same bilinear modulus"
+  @req all(i -> modulus_quadratic_form(x[i]) == mqf, 2:length(x)) "All torsion quadratic modules must have same quadratic modulus"
   cs = cover.(x)
   rs = relations.(x)
   C, inj, proj = _orthogonal_sum_with_injections_and_projections(cs)

--- a/test/QuadForm/Torsion.jl
+++ b/test/QuadForm/Torsion.jl
@@ -309,5 +309,16 @@
   L = orthogonal_sum(root_lattice(:A, 7), root_lattice(:D, 7))[1]
   qL = discriminant_group(L)
   @test is_primary(qL, 2) && !is_elementary(qL, 2)
+
+  # Additional orthogonal sum
+  list_lat = [root_lattice(:A, i) for i in 1:7]
+  list_quad = discriminant_group.(list_lat)
+  S, inj, proj = Hecke._orthogonal_sum_with_injections_and_projections(list_quad)
+  @test order(S) == prod(order.(list_quad))
+  for i in 1:7, j in 1:7
+    f = compose(inj[i], proj[j])
+    m = f.map_ab.map
+    @test i == j ? isone(m) : iszero(m)
+  end
 end
 


### PR DESCRIPTION
I guess this should be here temporarily, until we decide what we exactly do with `orthogonal_sum`. Things is that I would need the part for `TorQuadMod` on Oscar. Since it can be made on Hecke and could be of general use, I decided to implement this here.

Ideally with this pattern, we could have 4 functions each time: one without maps, one with injections, one with projections and one with both. 