### PR TITLE
`direct_sum` as an alias for `_orthogonal_sum_with_...`

### DIFF
--- a/docs/src/quad_forms/basics.md
+++ b/docs/src/quad_forms/basics.md
@@ -216,6 +216,7 @@ is_represented_by(H2, H)
 ```@docs
 orthogonal_complement(::AbsSpace, ::MatElem)
 orthogonal_sum(::AbsSpace, ::AbsSpace)
+direct_sum(x::Vararg{<:QuadSpace})
 ```
 
 ### Example

--- a/docs/src/quad_forms/discriminant_group.md
+++ b/docs/src/quad_forms/discriminant_group.md
@@ -116,3 +116,9 @@ genus(T::TorQuadMod, signature_pair::Tuple{Int, Int})
 brown_invariant(T::TorQuadMod)
 is_genus(T::TorQuadMod, signature_pair::Tuple{Int, Int})
 ```
+
+### Orthogonal sums
+```@docs
+orthogonal_sum(T::TorQuadMod, U::TorQuadMod)
+direct_sum(x::Vararg{TorQuadMod})
+```

--- a/docs/src/quad_forms/integer_lattices.md
+++ b/docs/src/quad_forms/integer_lattices.md
@@ -134,6 +134,7 @@ is_primitive(M::ZLat, N::ZLat)
 ```@docs
 orthogonal_sum(::ZLat, ::ZLat)
 orthogonal_submodule(::ZLat, ::ZLat)
+direct_sum(x::Vararg{ZLat})
 ```
 
 ### Dual lattice

--- a/src/QuadForm/Quad/ZGenus.jl
+++ b/src/QuadForm/Quad/ZGenus.jl
@@ -554,7 +554,7 @@ $\mathbb Z$-lattices are also supported.
 - `min_scale`: a rational number; return only genera whose scale is an integer
   multiple of `min_scale` (default: `min(one(QQ), QQ(abs(determinant)))`)
 - `max_scale`: a rational number; return only genera such that `max_scale` is an
-  integer multiple of the scale (default: `min(one(QQ), QQ(abs(determinant)))`)
+  integer multiple of the scale (default: `max(one(QQ), QQ(abs(determinant)))`)
 - `even`: boolean; if set to true, return only the even genera (default: `false`)
 """
 function genera(sig_pair::Tuple{Int,Int}, determinant::RationalUnion;

--- a/src/QuadForm/Quad/ZLattices.jl
+++ b/src/QuadForm/Quad/ZLattices.jl
@@ -226,6 +226,23 @@ function _orthogonal_sum_with_injections_and_projections(x::Vector{ZLat})
 end
 
 @doc Markdown.doc"""
+    direct_sum(x::Vararg{ZLat}) -> ZLat, Vector{AbsSpaceMor}, Vector{AbsSpaceMor}
+    direct_sum(x::Vector{ZLat}) -> ZLat, Vector{AbsSpaceMor}, Vector{AbsSpaceMor}
+
+Given a collection of $\mathbb Z$-lattices $L_1, \ldots, L_n$,
+return their complete direct sum $L := L_1 \oplus \ldots \oplus L_n$,
+together with the injections $L_i \to L$ and the projections $L \to L_i$
+(seen as maps between the corresponding ambient spaces).
+"""
+function direct_sum(x::Vararg{ZLat})
+  x = collect(x)
+  @req length(x) >= 2 "Input must consist of at least two lattices"
+  return _orthogonal_sum_with_injections_and_projections(x)
+end
+
+direct_sum(x::Vector{ZLat}) = _orthogonal_sum_with_injections_and_projections(x)
+
+@doc Markdown.doc"""
     orthogonal_submodule(L::ZLat, S::ZLat) -> ZLat
 
 Return the largest submodule of `L` orthogonal to `S`.

--- a/src/QuadForm/Spaces.jl
+++ b/src/QuadForm/Spaces.jl
@@ -729,6 +729,22 @@ function _orthogonal_sum_with_injections_and_projections(x::Vector{<:QuadSpace})
   return V, inj, proj
 end
 
+@doc Markdown.doc"""
+    direct_sum(x::Vararg{QuadSpace}) -> QuadSpace, Vector{AbsSpaceMor}, Vector{AbsSpaceMor}
+    direct_sum(x::Vector{QuadSpace}) -> QuadSpace, Vector{AbsSpaceMor}, Vector{AbsSpaceMor}
+
+Given a collection of quadratic spaces $V_1, \ldots, V_n$,
+return their complete direct sum $V := V_1 \oplus \ldots \oplus V_n$,
+together with the injections $V_i \to V$ and the projections $V \to V_i$.
+"""
+function direct_sum(x::Vararg{<:QuadSpace})
+  x = collect(x)
+  @req length(x) >= 2 "Input must consist of at least two quadratic spaces"
+  return _orthogonal_sum_with_injections_and_projections(x)
+end
+
+direct_sum(x::Vector{<:QuadSpace}) = _orthogonal_sum_with_injections_and_projections(x)
+
 ################################################################################
 #
 #  Embeddings

--- a/src/QuadForm/Torsion.jl
+++ b/src/QuadForm/Torsion.jl
@@ -1790,6 +1790,22 @@ function _orthogonal_sum_with_injections_and_projections(x::Vector{TorQuadMod})
   return S, inj2, proj2
 end
 
+@doc Markdown.doc"""
+    direct_sum(x::Vararg{TorQuadMod}) -> TorQuadMod, Vector{TorQuadModMor}, Vector{TorQuadModMor}
+    direct_sum(x::Vector{TorQuadMod}) -> TorQuadMod, Vector{TorQuadModMor}, Vector{TorQuadModMor}
+
+Given a collection of torsion quadratic modules $T_1, \ldots, T_n$,
+return their complete direct sum $T := T_1 \oplus \ldots \oplus T_n$,
+together with the injections $T_i \to T$ and the projections $T \to T_i$.
+"""
+function direct_sum(x::Vararg{TorQuadMod})
+  x = collect(x)
+  @req length(x) >= 2 "Input must consist of at least two torsion quadratic module"
+  return _orthogonal_sum_with_injections_and_projections(x)
+end
+
+direct_sum(x::Vector{TorQuadMod}) = _orthogonal_sum_with_injections_and_projections(x)
+
 ###############################################################################
 #
 #  Primary/elementary torsion quadratic module

--- a/test/QuadForm/Quad/Spaces.jl
+++ b/test/QuadForm/Quad/Spaces.jl
@@ -453,3 +453,17 @@
     end
   end
 end
+
+@testset "orthogomal sums" begin
+  K, _ = cyclotomic_field(27, cached=false)
+  V = quadratic_space(K, 4)
+  S, inj, proj = @inferred direct_sum(V, rescale(V, -1//5))
+  @test dim(S) == 8
+  for i in 1:2, j in 1:2
+    f = compose(inj[i], proj[j])
+    m = f.matrix
+    @test i != j ? iszero(m) : isone(m)
+  end
+  S, inj, proj = @inferred direct_sum(V, V, V)
+  @test_throws ArgumentError direct_sum(V)
+end

--- a/test/QuadForm/Quad/ZLattices.jl
+++ b/test/QuadForm/Quad/ZLattices.jl
@@ -586,7 +586,7 @@ end
     @test bool
     @test p == i+1
   end
-  L = orthogonal_sum(hyperbolic_plane_lattice(), root_lattice(:D, 7))[1]
+  L = direct_sum(hyperbolic_plane_lattice(), root_lattice(:D, 7))[1]
   @test is_primary(L, 2) && !is_elementary(L, 2)
   @test is_unimodular(hyperbolic_plane_lattice())
 end
@@ -617,3 +617,16 @@ end
   @test genus(L1)==genus(L2)
   @test !Hecke.is_isometric(L1, L2)
 end
+
+@testset "orthogonal sums" begin
+  L1 = root_lattice(:A, 6)
+  L2 = root_lattice(:E, 7)
+  L, inj, proj = @inferred direct_sum([L1, L2])
+  @test genus(L) == orthogonal_sum(genus(L1), genus(L2))
+  for i in 1:2, j in 1:2
+    f = compose(inj[i], proj[j])
+    m = f.matrix
+    @test i != j ? iszero(m) : isone(m)
+  end
+end
+

--- a/test/QuadForm/Torsion.jl
+++ b/test/QuadForm/Torsion.jl
@@ -320,12 +320,14 @@
   # Additional orthogonal sum
   list_lat = [root_lattice(:A, i) for i in 1:7]
   list_quad = discriminant_group.(list_lat)
-  S, inj, proj = Hecke._orthogonal_sum_with_injections_and_projections(list_quad)
+  S, inj, proj = direct_sum(list_quad)
   @test order(S) == prod(order.(list_quad))
   for i in 1:7, j in 1:7
     f = compose(inj[i], proj[j])
     m = f.map_ab.map
     @test i == j ? isone(m) : iszero(m)
   end
+  T = discriminant_group(root_lattice(:D, 6))
+  S, inj, proj = @inferred direct_sum(T, T, T)
 end
 


### PR DESCRIPTION
In order to access for `ZLat`, `QuadSpace` (for now, should be extended to `HermSpace`, `QuadLat` and `HermLat` when needed) and `TorQuadMod` to multiple orthogonal sums with the corresponding injections and projections (we are in nice categories), we add the alias `direct_sum`. It is close to the similar function for abelian groups.