### PR TITLE
`orthogonal_projection` for `AbsSpace`

### DIFF
--- a/docs/src/quad_forms/basics.md
+++ b/docs/src/quad_forms/basics.md
@@ -215,6 +215,7 @@ is_represented_by(H2, H)
 
 ```@docs
 orthogonal_complement(::AbsSpace, ::MatElem)
+orthogonal_projection(::AbsSpace, ::MatElem)
 orthogonal_sum(::AbsSpace, ::AbsSpace)
 ```
 

--- a/src/QuadForm/Spaces.jl
+++ b/src/QuadForm/Spaces.jl
@@ -642,7 +642,7 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    orthogonal_complement(V::AbsSpace, M::T) where T -> T
+    orthogonal_complement(V::AbsSpace, M::T) where T <: MatElem -> T
 
 Given a space `V` and a subspace `W` with basis matrix `M`, return a basis
 matrix of the orthogonal complement of `W` inside `V`.
@@ -666,7 +666,6 @@ function orthogonal_projection(V::AbsSpace, M::MatElem)
   @req rank(_Q) == nrows(_Q) "Subspace must be non-degenerate for the inner product on V"
   U = orthogonal_complement(V, M)
   B = vcat(U, M)
-  E = base_ring(V)
   p = vcat(U, zero(M))
   pr = inv(B)*p
   return hom(V, V, pr)

--- a/src/QuadForm/Spaces.jl
+++ b/src/QuadForm/Spaces.jl
@@ -1,7 +1,7 @@
 export ambient_space, rank, gram_matrix, inner_product, involution, ishermitian, is_quadratic, is_regular,
        is_local_square, is_isometric, is_rationally_isometric, is_isotropic, is_isotropic_with_vector, quadratic_space,
        hermitian_space, diagonal, invariants, hasse_invariant, witt_invariant, orthogonal_basis, fixed_field,
-       restrict_scalars, orthogonal_complement
+       restrict_scalars, orthogonal_complement, orthogonal_projection
 
 ################################################################################
 #
@@ -642,9 +642,9 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    orthogonal_complement(V::AbsSpace, M::MatElem)
+    orthogonal_complement(V::AbsSpace, M::T) where T -> T
 
-Given a space `V` and a subspace `W` with basis matrix `M`, returns a basis
+Given a space `V` and a subspace `W` with basis matrix `M`, return a basis
 matrix of the orthogonal complement of `W` inside `V`.
 """
 function orthogonal_complement(V::AbsSpace, M::MatElem)
@@ -652,6 +652,24 @@ function orthogonal_complement(V::AbsSpace, M::MatElem)
   r, K = left_kernel(N)
   @assert r == nrows(K)
   return K
+end
+
+@doc Markdown.doc"""
+    orthogonal_projection(V::AbsSpace, M::T) where T <: MatElem -> AbsSpaceMor
+
+Given a space `V` and a non-degenerate subspace `W` with basis matrix `M`,
+return the endomorphism of `V` corresponding to the projection onto the
+complement of `W` in `V`.
+"""
+function orthogonal_projection(V::AbsSpace, M::MatElem)
+  _Q = inner_product(V, M, M)
+  @req rank(_Q) == nrows(_Q) "Subspace must be non-degenerate for the inner product on V"
+  U = orthogonal_complement(V, M)
+  B = vcat(U, M)
+  E = base_ring(V)
+  p = vcat(U, zero(M))
+  pr = inv(B)*p
+  return hom(V, V, pr)
 end
 
 ################################################################################

--- a/test/QuadForm/Quad/Spaces.jl
+++ b/test/QuadForm/Quad/Spaces.jl
@@ -452,4 +452,42 @@
       end
     end
   end
+
+  @testset "orthogonal proj" begin
+    L = root_lattice(:E, 8)
+    f = matrix(QQ, 8, 8, [ 1  0  0  0  0  0  0  0;
+                           0  1  0  0  0  0  0  0;
+                           1  2  4  4  3  2  1  2;
+                          -2 -4 -6 -5 -4 -3 -2 -3;
+                           2  4  6  4  3  2  1  3;
+                          -1 -2 -3 -2 -1  0  0 -2;
+                           0  0  0  0  0 -1  0  0;
+                          -1 -2 -3 -3 -2 -1  0 -1])
+    M = invariant_lattice(L, f)
+    pr = @inferred orthogonal_projection(ambient_space(L), basis_matrix(M))
+    @test pr.matrix^2 == pr.matrix # in fact, it is a projection
+    @test rank(pr.matrix) == 4 # M has rank 4 so pr should project onto a 4 dimensional subspace
+                               # of the ambient
+    @test rank(pr(M)) == 0     # orthogonal projection along M => M should be sent to the zero vector
+    N = orthogonal_submodule(L, M)
+    @test rank(pr(N)) == 4     # the image of N should be of full rank under the projection
+    @test basis_matrix(N)*pr.matrix == basis_matrix(N) # N is contained in the complement in
+                                                       # in the ambient, so its basis is fixed
+                                                       # by projection
+
+    r, B = left_kernel(pr.matrix)
+    @test r == 4
+    Msup = lattice(ambient_space(L), B)
+    @test is_sublattice(Msup, M) # A priori the kernel is bigger since M is integral
+    @test !is_integral(Msup)
+    @test intersect(L, Msup) == M # in our case M is primitive integral in L, it is a kernel
+    @test iszero(inner_product(ambient_space(L), basis_matrix(Msup), basis_matrix(N)))
+    @test rank(intersect(Msup, N)) == 0 # in fact this is the intersection of M and N
+                                        # which are orthogonal by def. of N
+
+    B2 = hnf(pr.matrix)[1:rank(pr.matrix), :] # basis matrix for the complement of M in the ambient
+    Nsup = lattice(ambient_space(L), B2)
+    @test is_sublattice(Nsup, N)
+    @test iszero(inner_product(ambient_space(L), B, B2))
+  end
 end


### PR DESCRIPTION
I chose by convention to send the given basis matrix to the zero vector and to fix the basis matrix of the complement in the given space.