### PR TITLE
Add `sparse_matrix(R,n,m)` as alternative to zero_matrix(SMat,R,n,m)

### DIFF
--- a/docs/src/sparse/intro.md
+++ b/docs/src/sparse/intro.md
@@ -90,6 +90,7 @@ As a consequence, unlike their dense counterparts, sparse matrices have a mutabl
 ### Construction
 ```@docs
 sparse_matrix(::Ring)
+sparse_matrix(::Ring, ::Int, ::Int)
 ```
 
 Sparse matrices can also be created from dense matrices as well as from julia arrays:

--- a/src/Sparse/Matrix.jl
+++ b/src/Sparse/Matrix.jl
@@ -135,10 +135,23 @@ end
 
 Return an empty sparse matrix with base ring $R$.
 """
-function sparse_matrix(R::T) where T <: Ring
+function sparse_matrix(R::Ring)
   r = SMat{elem_type(R)}()
   r.base_ring = R
   return r
+end
+
+@doc Markdown.doc"""
+    sparse_matrix(R::Ring, n::Int, m::Int) -> SMat
+
+Return a sparse $n$ times $m$ zero matrix over $R$.
+"""
+function sparse_matrix(R::Ring, n::Int, m::Int)
+  S = sparse_matrix(R)
+  S.rows = [sparse_row(R) for i=1:n]
+  S.r = n
+  S.c = m
+  return S
 end
 
 ################################################################################
@@ -219,7 +232,7 @@ end
 
 # A dangerous interface for checking whether an entry is zero
 #
-# fl, t = _is_zero_entry(A, i, j) 
+# fl, t = _is_zero_entry(A, i, j)
 # then A[i, j] == _get(t)
 #
 # This is to avoid the allocation and double "lookup" for flint matrices
@@ -1187,25 +1200,14 @@ end
 
 Return a sparse $n$ times $n$ zero matrix over $R$.
 """
-function zero_matrix(::Type{SMat}, R::Ring, n::Int)
-  S = sparse_matrix(R)
-  S.rows = [sparse_row(R) for i=1:n]
-  S.c = S.r = n
-  return S
-end
+zero_matrix(::Type{SMat}, R::Ring, n::Int) = sparse_matrix(R, n, n)
 
 @doc Markdown.doc"""
     zero_matrix(::Type{SMat}, R::Ring, n::Int, m::Int)
 
 Return a sparse $n$ times $m$ zero matrix over $R$.
 """
-function zero_matrix(::Type{SMat}, R::Ring, n::Int, m::Int)
-  S = sparse_matrix(R)
-  S.rows = [sparse_row(R) for i=1:n]
-  S.r = n
-  S.c = m
-  return S
-end
+zero_matrix(::Type{SMat}, R::Ring, n::Int, m::Int) = sparse_matrix(R, n, m)
 
 ################################################################################
 #

--- a/test/Sparse/Matrix.jl
+++ b/test/Sparse/Matrix.jl
@@ -176,6 +176,7 @@ using SparseArrays
   D = sparse_matrix(FlintZZ, [1 5 3; 0 0 0; 0 1 0])
   E = @inferred 0 * D
   @test E == zero_matrix(SMat, FlintZZ, 3)
+  @test E == sparse_matrix(FlintZZ, 3, 3)
   E = @inferred BigInt(2) * D
   @test E == sparse_matrix(FlintZZ, [2 10 6; 0 0 0; 0 2 0])
   E = @inferred fmpz(2) * D
@@ -245,8 +246,10 @@ using SparseArrays
   @test D == sparse_matrix(FlintZZ, [1 0 0; 0 1 0; 0 0 1]);
   D = @inferred zero_matrix(SMat, FlintZZ, 3)
   @test D == sparse_matrix(FlintZZ, [0 0 0; 0 0 0; 0 0 0]);
+  @test D == sparse_matrix(FlintZZ, 3, 3)
   D = @inferred zero_matrix(SMat, FlintZZ, 4, 3)
   @test D == sparse_matrix(FlintZZ, [0 0 0; 0 0 0; 0 0 0; 0 0 0]);
+  @test D == sparse_matrix(FlintZZ, 4, 3)
 
   # Concatenation syntax
 


### PR DESCRIPTION
I discussed with @HechtiDerLachs today how to create sparse matrices, and it took us a bit to determine that we should use `zero_matrix(SMat,R,n,m)` to specify an initial column count (i.e., we used `n=0` and set `m` to the final column count).

We both expected `sparse_matrix` to allow us to specify a row and/or column count. Based on this, my suggestion was to just add that. Instead of writing an issue, here is a proof of concept. If this is deemed acceptable, I can finish it up by linking the new constructor into the manual and adding a test.