### PR TITLE
Fix invalidations in FacElemMon constructor

### DIFF
--- a/src/HeckeTypes.jl
+++ b/src/HeckeTypes.jl
@@ -544,7 +544,7 @@ mutable struct FacElemMon{S} <: Ring
 
   function FacElemMon{S}(R::S, cached::Bool = false) where {S}
     return get_cached!(FacElemMonDict, R, cached) do
-      new{AnticNumberField}(R,
+      new{S}(R,
         Dict{RingElem, Vector{arb}}(),
         Dict{RingElem, Vector{arb}}(),
         Dict{Int, Dict{nf_elem, Vector{arb}}}()

--- a/src/HeckeTypes.jl
+++ b/src/HeckeTypes.jl
@@ -544,12 +544,11 @@ mutable struct FacElemMon{S} <: Ring
 
   function FacElemMon{S}(R::S, cached::Bool = false) where {S}
     return get_cached!(FacElemMonDict, R, cached) do
-      z = new()
-      z.base_ring = R
-      z.basis_conjugates_log = Dict{RingElem, Vector{arb}}()
-      z.basis_conjugates = Dict{RingElem, Vector{arb}}()
-      z.conj_log_cache = Dict{Int, Dict{nf_elem, arb}}()
-      return z
+      new{AnticNumberField}(R,
+        Dict{RingElem, Vector{arb}}(),
+        Dict{RingElem, Vector{arb}}(),
+        Dict{Int, Dict{nf_elem, Vector{arb}}}()
+        )
     end::FacElemMon{S}
   end
 
@@ -561,11 +560,11 @@ mutable struct FacElemMon{S} <: Ring
       F = get_attribute(R, :fac_elem_mon)::FacElemMon{AnticNumberField}
       return F
     end
-    z = new{AnticNumberField}()
-    z.base_ring = R
-    z.basis_conjugates_log = Dict{RingElem, Vector{arb}}()
-    z.basis_conjugates = Dict{RingElem, Vector{arb}}()
-    z.conj_log_cache = Dict{Int, Dict{nf_elem, Vector{arb}}}()
+    z = new{AnticNumberField}(R,
+      Dict{RingElem, Vector{arb}}(),
+      Dict{RingElem, Vector{arb}}(),
+      Dict{Int, Dict{nf_elem, Vector{arb}}}()
+      )
     if cached
       set_attribute!(R, :fac_elem_mon => z)
     end

--- a/src/NumFieldOrd/NfOrd/FacElem.jl
+++ b/src/NumFieldOrd/NfOrd/FacElem.jl
@@ -141,19 +141,9 @@ _base_ring(x::FacElem{nf_elem}) = base_ring(x)::AnticNumberField
 
 function _conjugates_arb_log(A::FacElemMon{AnticNumberField}, a::nf_elem, abs_tol::Int)
   abs_tol = 1<<nbits(abs_tol)
-  if haskey(A.conj_log_cache, abs_tol)
-    if haskey(A.conj_log_cache[abs_tol], a)
-      return A.conj_log_cache[abs_tol][a]::Vector{arb}
-    else
-      z = conjugates_arb_log(a, abs_tol)
-      A.conj_log_cache[abs_tol][a] = z
-      return z::Vector{arb}
-    end
-  else
-    A.conj_log_cache[abs_tol] = Dict{nf_elem, arb}()
-    z = conjugates_arb_log(a, abs_tol)
-    A.conj_log_cache[abs_tol][a] = z
-    return z::Vector{arb}
+  the_cache = get!(Dict{nf_elem, Vector{arb}}, A.conj_log_cache, abs_tol)
+  return get!(the_cache, a) do
+    conjugates_arb_log(a, abs_tol)
   end
 end
 


### PR DESCRIPTION
The assignment `z.conj_log_cache = ...` is lowered to a call to `setproperty!(::FacElemMon{AnticNumberField}, ::Symbol, ::Dict{RingElem, Vector{arb}})` and this ultimately was the source of an invalidation when Singular.jl got loaded. We now avoid this by passing the new dicts directly as arguments to `new`.

In the `FacElemMon{S}` there also was a bug in that it used `Dict{Int, Dict{nf_elem, arb}}`, i.e. with `arb` instead of `Vector{arb}`. The same issue was also present in `_conjugates_arb_log`. I ended up rewriting the latter using `get!` to make it much simpler.

Before (with improved CxxWrap, not yet released;  in Julia 1.10-DEV on my M1 MacBook Pro):
```
julia> using Hecke, Singular; @time @eval maximal_order(quadratic_field(-3)[1]);
...

  1.354915 seconds (1.27 M allocations: 84.366 MiB, 1.15% gc time, 99.62% compilation time: 98% of which was recompilation)
```

After (with improved CxxWrap, not yet released)::
```
julia> using Hecke, Singular; @time @eval maximal_order(quadratic_field(-3)[1]);
...

  0.029961 seconds (75.30 k allocations: 5.015 MiB, 82.98% compilation time)
```
