### PR TITLE
Fix log(one(K)) for local fields

### DIFF
--- a/src/LocalField/Elem.jl
+++ b/src/LocalField/Elem.jl
@@ -653,6 +653,9 @@ extended so that $log(p) = 0$.
 function log(a::LocalFieldElem)
   K = parent(a)
   va = valuation(a)
+  if isone(a)
+    return zero(K)
+  end
   if iszero(va) && valuation(a-1) > 0
     return _log_one_units(a)
   end

--- a/test/LocalField/LocalField.jl
+++ b/test/LocalField/LocalField.jl
@@ -130,6 +130,7 @@
     L, b = Hecke.eisenstein_extension(x^7+2, "a")
     pi = uniformizer(L)
     @test iszero(log(pi))
+    @test iszero(log(one(L)))
     B = basis(L)
     for i = 15:20
       el = sum([rand(FlintZZ, 0:10)*B[j] for j = 1:7])*pi^i


### PR DESCRIPTION
Alternatively, we could let this case be handled by `_log_one_units`.