### PR TITLE
`automorphism_group_generators` for rank 2 indefinite `ZLat`

### DIFF
--- a/src/QuadForm/Quad/GenusRep.jl
+++ b/src/QuadForm/Quad/GenusRep.jl
@@ -6,7 +6,7 @@
 add_verbose_scope(:GenRep)
 add_assert_scope(:GenRep)
 
-export genus_representatives
+export automorphism_group_generators, genus_representatives
 
 ################################################################################
 #

--- a/src/QuadForm/Quad/ZLattices.jl
+++ b/src/QuadForm/Quad/ZLattices.jl
@@ -293,6 +293,17 @@ function assert_has_automorphisms(L::ZLat; redo::Bool = false,
     return nothing
   end
 
+  if !is_definite(L)
+    @assert rank(L) == 2
+    G = gram_matrix(L)
+    d = denominator(G)
+    GG = change_base_ring(ZZ, d*G)
+    b = binary_quadratic_form(GG[1,1], 2*GG[1,2], GG[2,2])
+    gens = transpose.(automorphism_group_generators(b))
+    L.automorphism_group_generators = gens
+    return nothing
+  end
+
   V = ambient_space(L)
   GL = gram_matrix(L)
   d = denominator(GL)
@@ -350,7 +361,7 @@ end
 
 function automorphism_group_generators(L::ZLat; ambient_representation::Bool = true)
 
-  @req rank(L) == 0 || is_definite(L) "The lattice must be definite"
+  @req rank(L) in [0, 2] || is_definite(L) "The lattice must be definite or of rank at most 2"
   assert_has_automorphisms(L)
 
   gens = L.automorphism_group_generators
@@ -359,7 +370,6 @@ function automorphism_group_generators(L::ZLat; ambient_representation::Bool = t
   else
     # Now translate to get the automorphisms with respect to basis_matrix(L)
     bm = basis_matrix(L)
-    gens = L.automorphism_group_generators
     V = ambient_space(L)
     if rank(L) == rank(V)
       bminv = inv(bm)
@@ -385,6 +395,7 @@ end
 # documented in ../Lattices.jl
 
 function automorphism_group_order(L::ZLat)
+  @req is_definite(L) "The lattice must be definite"
   assert_has_automorphisms(L)
   return L.automorphism_group_order
 end

--- a/test/QuadForm/Quad/ZLattices.jl
+++ b/test/QuadForm/Quad/ZLattices.jl
@@ -271,6 +271,22 @@ end
     @test automorphism_group_order(L) == lattice_automorphism_group_order(D, i)
   end
 
+  # automorphisms for indefinite of rank 2
+  U = hyperbolic_plane_lattice()
+  G = @inferred automorphism_group_generators(U)
+  @test length(G) == 2
+  @test all(m -> multiplicative_order(m) == 2, G)
+  @test_throws ArgumentError automorphism_group_order(U)
+
+  g = genera((1,1), 12)
+  Lg = representative.(g)
+  for L in Lg
+    V = ambient_space(L)
+    G = @inferred automorphism_group_generators(L, ambient_representation = false)
+    @test all(m -> m*gram_matrix(L)*transpose(m) == gram_matrix(L), G)
+    G = @inferred automorphism_group_generators(L)
+    @test all(m -> m*gram_matrix(V)*transpose(m) == gram_matrix(V), G)
+  end
   # isometry
 
   for (m, o) in lattices_and_aut_order


### PR DESCRIPTION
This was a missing corner case that can be handled using algorithms for binary quadratic forms.

Note: there was a unexpected behaviour of `automorphism_group_generators(::QuadBin{fmpz})`, so I decided to export the function locally in the file `src/QuadForm/Quad/GenusRep.jl`.