### PR TITLE
Isometry between `TorQuadMod`'s in the non split degenerate case

### DIFF
--- a/src/QuadForm/Torsion.jl
+++ b/src/QuadForm/Torsion.jl
@@ -901,7 +901,7 @@ function _isometry_non_split_degenerate(T::TorQuadMod, U::TorQuadMod)
     card = prod([order(Ts[k]) for k in 1:(i+1)], init = ZZ(1))
     for u in u_cand[i+1]
       if all(k -> u*f[k] == t*Ts[k], 1:i)
-        fnew = [j for j in f]
+        fnew = copy(f)
         push!(fnew, u)
         if order(sub(U, fnew)[1]) == card
           push!(waiting, fnew)

--- a/test/QuadForm/Torsion.jl
+++ b/test/QuadForm/Torsion.jl
@@ -276,7 +276,7 @@
   ok, phi = @inferred is_isometric_with_isometry(T1sub, T2sub)
   @test ok
   @test is_bijective(phi)
-  @test all(a -> a -> Hecke.quadratic_product(a) == Hecke.quadratic_product(phi(a)), T1sub)
+  @test all(a -> Hecke.quadratic_product(a) == Hecke.quadratic_product(phi(a)), T1sub)
   ok, phi = @inferred is_anti_isometric_with_anti_isometry(T1sub, rescale(T1sub, -1))
   @test ok
   @test is_bijective(phi)

--- a/test/QuadForm/Torsion.jl
+++ b/test/QuadForm/Torsion.jl
@@ -269,6 +269,19 @@
   qLf = discriminant_group(Lf)
   @test modulus_quadratic_form(qLf) == 2
 
+  T = TorQuadMod(matrix(QQ, 1, 1, [1//27]))
+  @test Hecke._isometry_non_split_degenerate(T, T)[1]
+  T1sub, _ = sub(T, 3*gens(T))
+  T2sub, _ = sub(T, 15*gens(T))
+  ok, phi = @inferred is_isometric_with_isometry(T1sub, T2sub)
+  @test ok
+  @test is_bijective(phi)
+  @test all(a -> a -> Hecke.quadratic_product(a) == Hecke.quadratic_product(phi(a)), T1sub)
+  ok, phi = @inferred is_anti_isometric_with_anti_isometry(T1sub, rescale(T1sub, -1))
+  @test ok
+  @test is_bijective(phi)
+  @test all(a -> Hecke.quadratic_product(a) == (-1)*Hecke.quadratic_product(phi(a)), T1sub)
+
   # orthogonal sum
 
   B = matrix(FlintQQ, 3, 3 ,[1, 1, 0, 1, -1, 0, 0, 1, -1])


### PR DESCRIPTION
We cover the last case which was not covered by the previous algorithms, namely isometry test between two `TorQuadMod` which are not semi-regular and which do not split their respective radical quadratic. It uses partial isometries.