### PR TITLE
fix precision issue in normal form

### DIFF
--- a/src/QuadForm/Quad/NormalForm.jl
+++ b/src/QuadForm/Quad/NormalForm.jl
@@ -176,7 +176,6 @@ end
 # For a definition in the even case, see Definition 4.6 of Miranda, Morrison,
 # "Embeddings of Integral Quadratic Forms", 2009.
 function _padic_normal_form(G::fmpq_mat, p::fmpz; prec::Int = -1, partial::Bool = false)
-
   _G = deepcopy(G)
   dd = denominator(G)
   G0 = change_base_ring(FlintZZ, dd * G)
@@ -251,7 +250,6 @@ function _padic_normal_form(G::fmpq_mat, p::fmpz; prec::Int = -1, partial::Bool 
 
   DD = map_entries(x -> FlintQQ(lift(x))//p^d, D)
   BB = map_entries(x -> FlintQQ(lift(x)), B)
-
   return (DD, BB)::Tuple{fmpq_mat, fmpq_mat}
 end
 

--- a/src/QuadForm/Torsion.jl
+++ b/src/QuadForm/Torsion.jl
@@ -1400,7 +1400,7 @@ function normal_form(T::TorQuadMod; partial=false)
     # the normal form is implemented for p-adic lattices
     # so we should work with the lattice q_p --> q_p^-1
     q_p1 = inv(q_p)
-    prec = valuation(exponent(T), p) + 5
+    prec = 2*valuation(exponent(T), p) + 5
     D, U = padic_normal_form(q_p1, p, prec=prec, partial=partial)
     R = ResidueRing(ZZ, ZZ(p)^prec)
     U = map_entries(x->R(ZZ(x)),U)
@@ -1727,7 +1727,6 @@ function _is_genus_brown(T::TorQuadMod, signature_pair::Tuple{Int, Int})
         return false
       end
     end
-    @show "hi"
     if p == 2
       if mod(rank, 2) != mod(length_p, 2)
         return false

--- a/test/QuadForm/Torsion.jl
+++ b/test/QuadForm/Torsion.jl
@@ -157,7 +157,7 @@
   q = QQ[1//2 0 1//2 1//2; 0 1//2 0 1//2; 1//2 0 1//8 5//16; 1//2 1//2 5//16 27//16]
   d = torsion_quadratic_module(q)
   nf = normal_form(d)[1]
-  @test gram_matrix_quadratic(nf) == QQ[1//2 0 0 0; 0 1//2 0 0; 0 0 3//16 0; 0 0 0 7//16]
+  @test Hecke.gram_matrix_quadratic(nf) == QQ[1//2 0 0 0; 0 1//2 0 0; 0 0 3//16 0; 0 0 0 7//16]
 
   #test for brown invariant
   L1 = Zlattice(gram=matrix(ZZ, [[2,-1,0,0],[-1,2,-1,-1],[0,-1,2,0],[0,-1,0,2]]))

--- a/test/QuadForm/Torsion.jl
+++ b/test/QuadForm/Torsion.jl
@@ -154,6 +154,10 @@
   g4 = QQ[1//36 1//72;
           1//72 1//36]
   @test Hecke.gram_matrix_quadratic(n4) == g4
+  q = QQ[1//2 0 1//2 1//2; 0 1//2 0 1//2; 1//2 0 1//8 5//16; 1//2 1//2 5//16 27//16]
+  d = torsion_quadratic_module(q)
+  nf = normal_form(d)[1]
+  @test gram_matrix_quadratic(nf) == QQ[1//2 0 0 0; 0 1//2 0 0; 0 0 3//16 0; 0 0 0 7//16]
 
   #test for brown invariant
   L1 = Zlattice(gram=matrix(ZZ, [[2,-1,0,0],[-1,2,-1,-1],[0,-1,2,0],[0,-1,0,2]]))
@@ -165,6 +169,7 @@
   L3 = Zlattice(gram=matrix(ZZ, [[1,0,0],[0,1,0],[0,0,1]]))
   T3 = torsion_quadratic_module((1//10)*L3, L3)
   @test_throws ArgumentError Hecke.brown_invariant(T3)
+
 
   #test for genus
   L = Zlattice(gram=diagonal_matrix(fmpz[1,2,3,4]))


### PR DESCRIPTION
Some time ago I thought I was clever and set the precision lower than I did in sage. Turns out I am not that clever. 