### PR TITLE
Fix Vararg type

### DIFF
--- a/docs/src/quad_forms/basics.md
+++ b/docs/src/quad_forms/basics.md
@@ -217,7 +217,7 @@ is_represented_by(H2, H)
 orthogonal_complement(::AbsSpace, ::MatElem)
 orthogonal_projection(::AbsSpace, ::MatElem)
 orthogonal_sum(::AbsSpace, ::AbsSpace)
-direct_sum(x::Vararg{<:QuadSpace})
+direct_sum(x::Vararg{QuadSpace})
 ```
 
 ### Example

--- a/src/QuadForm/Spaces.jl
+++ b/src/QuadForm/Spaces.jl
@@ -754,7 +754,7 @@ Given a collection of quadratic spaces $V_1, \ldots, V_n$,
 return their complete direct sum $V := V_1 \oplus \ldots \oplus V_n$,
 together with the injections $V_i \to V$ and the projections $V \to V_i$.
 """
-function direct_sum(x::Vararg{<:QuadSpace})
+function direct_sum(x::Vararg{QuadSpace})
   x = collect(x)
   @req length(x) >= 2 "Input must consist of at least two quadratic spaces"
   return _orthogonal_sum_with_injections_and_projections(x)


### PR DESCRIPTION
@StevellM FIY: The version `Vararg{<:Bla}` is deprecated (and it is the same as `Vararg{Bla}` anyway).