### PR TITLE
Fail CI on deprecation warning

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,6 +58,8 @@ jobs:
           HECKE_TEST_PARALLEL: "2"
 
         uses: julia-actions/julia-runtest@latest
+        with:
+          depwarn: error
         #      - name: "Process code coverage"
         #        uses: julia-actions/julia-processcoverage@v1
         #      - name: "Upload coverage data to Codecov"


### PR DESCRIPTION
The same as https://github.com/oscar-system/Oscar.jl/pull/1957, i.e. the tests should now fail once a deprecation warning is encountered.

cc @thofma @fieker @fingolfin