### PR TITLE
Some renamings

### DIFF
--- a/docs/src/quad_forms/Zgenera.md
+++ b/docs/src/quad_forms/Zgenera.md
@@ -37,7 +37,7 @@ genus(A::MatElem)
 ### Enumeration of genus symbols
 
 ```@docs
-genera(sig_pair::Tuple{Int,Int}, determinant::Union{Int,fmpz})
+Zgenera(sig_pair::Tuple{Int,Int}, determinant::Union{Int,fmpz})
 ```
 ### From other genus symbols
 ```@docs

--- a/docs/src/quad_forms/basics.md
+++ b/docs/src/quad_forms/basics.md
@@ -43,14 +43,14 @@ The *discriminant* $\text{disc}(V, \Phi)$ of $(V, \Phi)$ is defined to be
 $(-1)^{(m(m-1)/2)}\text{det}(V, \Phi)$, where $m$ is the rank of $(V, \Phi)$.
 
 ```@docs
-rank(::AbsSpace)
-dim(::AbsSpace)
-gram_matrix(::AbsSpace)
-involution(::AbsSpace)
-base_ring(::AbsSpace)
-fixed_field(::AbsSpace)
-det(::AbsSpace)
-discriminant(::AbsSpace)
+rank(::AbstractSpace)
+dim(::AbstractSpace)
+gram_matrix(::AbstractSpace)
+involution(::AbstractSpace)
+base_ring(::AbstractSpace)
+fixed_field(::AbstractSpace)
+det(::AbstractSpace)
+discriminant(::AbstractSpace)
 ```
 
 ### Examples
@@ -82,12 +82,12 @@ positive or all totally negative. In the former case, $V$ is said to be
 In all the other cases, we say that $V$ is *indefinite*.
 
 ```@docs
-is_regular(::AbsSpace)
-is_quadratic(::AbsSpace)
-ishermitian(::AbsSpace)
-is_positive_definite(::AbsSpace)
-is_negative_definite(::AbsSpace)
-is_definite(::AbsSpace)
+is_regular(::AbstractSpace)
+is_quadratic(::AbstractSpace)
+ishermitian(::AbstractSpace)
+is_positive_definite(::AbstractSpace)
+is_negative_definite(::AbstractSpace)
+is_definite(::AbstractSpace)
 ```
 
 Note that the `ishermitian` function tests whether the space is non-quadratic.
@@ -110,12 +110,12 @@ is_definite(Q), is_positive_definite(H)
 ## Inner products and diagonalization
 
 ```@docs
-gram_matrix(::AbsSpace{T}, ::MatElem{S}) where {S, T}
-gram_matrix(::AbsSpace{T}, ::Vector{Vector{U}}) where {T, U}
-inner_product(::AbsSpace, ::Vector, ::Vector)
-orthogonal_basis(::AbsSpace)
-diagonal(::AbsSpace)
-restrict_scalars(::AbsSpace, ::FlintRationalField, ::FieldElem)
+gram_matrix(::AbstractSpace{T}, ::MatElem{S}) where {S, T}
+gram_matrix(::AbstractSpace{T}, ::Vector{Vector{U}}) where {T, U}
+inner_product(::AbstractSpace, ::Vector, ::Vector)
+orthogonal_basis(::AbstractSpace)
+diagonal(::AbstractSpace)
+restrict_scalars(::AbstractSpace, ::FlintRationalField, ::FieldElem)
 ```
 
 ### Examples
@@ -148,8 +148,8 @@ called an *embedding*.
 ```@docs
 hasse_invariant(::QuadSpace, p)
 witt_invariant(::QuadSpace, p)
-is_isometric(::AbsSpace, ::AbsSpace)
-is_isometric(::AbsSpace, ::AbsSpace, p)
+is_isometric(::AbstractSpace, ::AbstractSpace)
+is_isometric(::AbstractSpace, ::AbstractSpace, p)
 invariants(::QuadSpace)
 ```
 
@@ -185,8 +185,8 @@ quadratic and hermitian cases, completions are taken at finite places of the fix
 field $K$.
 
 ```@docs
-is_locally_represented_by(::AbsSpace, ::AbsSpace, p)
-is_represented_by(::AbsSpace, ::AbsSpace)
+is_locally_represented_by(::AbstractSpace, ::AbstractSpace, p)
+is_represented_by(::AbstractSpace, ::AbstractSpace)
 ```
 
 ### Examples
@@ -214,9 +214,9 @@ is_represented_by(H2, H)
 ## Orthogonality operations
 
 ```@docs
-orthogonal_complement(::AbsSpace, ::MatElem)
-orthogonal_projection(::AbsSpace, ::MatElem)
-orthogonal_sum(::AbsSpace, ::AbsSpace)
+orthogonal_complement(::AbstractSpace, ::MatElem)
+orthogonal_projection(::AbstractSpace, ::MatElem)
+orthogonal_sum(::AbstractSpace, ::AbstractSpace)
 direct_sum(x::Vararg{QuadSpace})
 ```
 
@@ -246,7 +246,7 @@ $\Phi_{\mathfrak p}(x,x) = 0$, where $\Phi_{\mathfrak p}$ is the continuous
 extension of $\Phi$ to $V_{\mathfrak p} \times V_{\mathfrak p}$.
 
 ```@docs
-is_isotropic(::AbsSpace, p)
+is_isotropic(::AbstractSpace, p)
 ```
 ### Example
 

--- a/docs/src/quad_forms/discriminant_group.md
+++ b/docs/src/quad_forms/discriminant_group.md
@@ -27,7 +27,7 @@ torsion_quadratic_module(M::ZLat, N::ZLat)
 
 ### The underlying Type
 ```@docs
-TorQuadMod
+TorQuadModule
 ```
 
 Most of the functionality mirrors that of `AbGrp` its elements and homomorphisms.
@@ -35,53 +35,53 @@ Here we display the part that is specific to elements of torsion quadratic modul
 ### Attributes
 
 ```@docs
-abelian_group(T::TorQuadMod)
-cover(T::TorQuadMod)
-relations(T::TorQuadMod)
-value_module(T::TorQuadMod)
-value_module_quadratic_form(T::TorQuadMod)
-gram_matrix_bilinear(T::TorQuadMod)
-gram_matrix_quadratic(T::TorQuadMod)
-modulus_bilinear_form(T::TorQuadMod)
-modulus_quadratic_form(T::TorQuadMod)
+abelian_group(T::TorQuadModule)
+cover(T::TorQuadModule)
+relations(T::TorQuadModule)
+value_module(T::TorQuadModule)
+value_module_quadratic_form(T::TorQuadModule)
+gram_matrix_bilinear(T::TorQuadModule)
+gram_matrix_quadratic(T::TorQuadModule)
+modulus_bilinear_form(T::TorQuadModule)
+modulus_quadratic_form(T::TorQuadModule)
 ```
 
 ### Elements
 
 ```@docs
-quadratic_product(a::TorQuadModElem)
-inner_product(a::TorQuadModElem, b::TorQuadModElem)
+quadratic_product(a::TorQuadModuleElem)
+inner_product(a::TorQuadModuleElem, b::TorQuadModuleElem)
 ```
 
 ### Lift to the cover
 ```@docs
-lift(a::TorQuadModElem)
-representative(::TorQuadModElem)
+lift(a::TorQuadModuleElem)
+representative(::TorQuadModuleElem)
 ```
 
 ### Orthogonal submodules
 ```@docs
-orthogonal_submodule(T::TorQuadMod, S::TorQuadMod)
+orthogonal_submodule(T::TorQuadModule, S::TorQuadModule)
 ```
 
 ### Isometry
 ```@docs
-is_isometric_with_isometry(T::TorQuadMod, U::TorQuadMod)
-is_anti_isometric_with_anti_isometry(T::TorQuadMod, U::TorQuadMod)
+is_isometric_with_isometry(T::TorQuadModule, U::TorQuadModule)
+is_anti_isometric_with_anti_isometry(T::TorQuadModule, U::TorQuadModule)
 ```
 
 ### Primary and elementary modules
 ```docs
-is_primary_with_prime(T::TorQuadMod)
-is_primary(T::TorQuadMod, p::Union{Integer, fmpz})
-is_elementary_with_prime(T::TorQuadMod)
-is_elementary(T::TorQuadMod, p::Union{Integer, fmpz})
+is_primary_with_prime(T::TorQuadModule)
+is_primary(T::TorQuadModule, p::Union{Integer, fmpz})
+is_elementary_with_prime(T::TorQuadModule)
+is_elementary(T::TorQuadModule, p::Union{Integer, fmpz})
 ```
 
 ### Smith normal form
 ```docs
-snf(T::TorQuadMod)
-is_snf(T::TorQuadMod)
+snf(T::TorQuadModule)
+is_snf(T::TorQuadModule)
 ```
 
 ## Discriminant Groups
@@ -103,28 +103,28 @@ torsion_quadratic_module(q::fmpq_mat)
 
 ### Rescaling the form
 ```@docs
-rescale(T::TorQuadMod, k::RingElement)
+rescale(T::TorQuadModule, k::RingElement)
 ```
 
 ### Invariants
 
 ```@docs
-is_degenerate(T::TorQuadMod)
-is_semi_regular(T::TorQuadMod)
-radical_bilinear(T::TorQuadMod)
-radical_quadratic(T::TorQuadMod)
-normal_form(T::TorQuadMod; partial=false)
+is_degenerate(T::TorQuadModule)
+is_semi_regular(T::TorQuadModule)
+radical_bilinear(T::TorQuadModule)
+radical_quadratic(T::TorQuadModule)
+normal_form(T::TorQuadModule; partial=false)
 ```
 
 ### Genus
 ```@docs
-genus(T::TorQuadMod, signature_pair::Tuple{Int, Int})
-brown_invariant(T::TorQuadMod)
-is_genus(T::TorQuadMod, signature_pair::Tuple{Int, Int})
+genus(T::TorQuadModule, signature_pair::Tuple{Int, Int})
+brown_invariant(T::TorQuadModule)
+is_genus(T::TorQuadModule, signature_pair::Tuple{Int, Int})
 ```
 
 ### Orthogonal sums
 ```@docs
-orthogonal_sum(T::TorQuadMod, U::TorQuadMod)
-direct_sum(x::Vararg{TorQuadMod})
+orthogonal_sum(T::TorQuadModule, U::TorQuadModule)
+direct_sum(x::Vararg{TorQuadModule})
 ```

--- a/docs/src/quad_forms/genusherm.md
+++ b/docs/src/quad_forms/genusherm.md
@@ -67,13 +67,13 @@ There are two ways of creating a local genus symbol for hermitian lattices:
 ```julia
    genus(HermLat, E::NumField, p::NfOrdIdl, data::Vector; type::Symbol = :det,
                                                           check::Bool = false)
-                                                             -> LocalGenusHerm
+                                                             -> HermLocalGenus
 ```
   - or by constructing the local genus symbol of the completion of a hermitian
     lattice $L$ over $E/K$ at a prime ideal $\mathfrak p$ of $\mathcal O_K$.
 
 ```julia
-   genus(L::HermLat, p::NfOrdIdl) -> LocalGenusHerm
+   genus(L::HermLat, p::NfOrdIdl) -> HermLocalGenus
 ```
 
 #### Examples
@@ -100,9 +100,9 @@ g2 = genus(L, p)
 ### Attributes
 
 ```@docs
-length(::LocalGenusHerm)
-base_field(::LocalGenusHerm)
-prime(::LocalGenusHerm)
+length(::HermLocalGenus)
+base_field(::HermLocalGenus)
+prime(::HermLocalGenus)
 ```
 
 #### Examples
@@ -126,19 +126,19 @@ prime(g1)
 ### Invariants
 
 ```@docs
-scale(::LocalGenusHerm, ::Int)
-scale(::LocalGenusHerm)
-scales(::LocalGenusHerm)
-rank(::LocalGenusHerm, ::Int)
-rank(::LocalGenusHerm)
-ranks(::LocalGenusHerm)
-det(::LocalGenusHerm, ::Int)
-det(::LocalGenusHerm)
-dets(::LocalGenusHerm)
-discriminant(::LocalGenusHerm, ::Int)
-discriminant(::LocalGenusHerm)
-norm(::LocalGenusHerm, ::Int)
-norms(::LocalGenusHerm)
+scale(::HermLocalGenus, ::Int)
+scale(::HermLocalGenus)
+scales(::HermLocalGenus)
+rank(::HermLocalGenus, ::Int)
+rank(::HermLocalGenus)
+ranks(::HermLocalGenus)
+det(::HermLocalGenus, ::Int)
+det(::HermLocalGenus)
+dets(::HermLocalGenus)
+discriminant(::HermLocalGenus, ::Int)
+discriminant(::HermLocalGenus)
+norm(::HermLocalGenus, ::Int)
+norms(::HermLocalGenus)
 ```
 
 #### Examples
@@ -167,10 +167,10 @@ rank(g2), det(g2), discriminant(g2)
 ### Predicates
 
 ```@docs
-is_ramified(::LocalGenusHerm)
-is_split(::LocalGenusHerm)
-is_inert(::LocalGenusHerm)
-is_dyadic(::LocalGenusHerm)
+is_ramified(::HermLocalGenus)
+is_split(::HermLocalGenus)
+is_inert(::HermLocalGenus)
+is_dyadic(::HermLocalGenus)
 ```
 
 #### Examples
@@ -192,7 +192,7 @@ is_ramified(g1), is_split(g1), is_inert(g1), is_dyadic(g1)
 ### Local uniformizer
 
 ```@docs
-uniformizer(::LocalGenusHerm)
+uniformizer(::HermLocalGenus)
 ```
 
 #### Example
@@ -218,8 +218,8 @@ determinants are local norms or not. It is possible to get a representative of t
 determinant class in terms of powers of the uniformizer of $g$.
 
 ```@docs
-det_representative(::LocalGenusHerm, ::Int)
-det_representative(::LocalGenusHerm)
+det_representative(::HermLocalGenus, ::Int)
+det_representative(::HermLocalGenus)
 ```
 
 #### Examples
@@ -242,8 +242,8 @@ det_representative(g1,2)
 ### Gram matrices
 
 ```@docs
-gram_matrix(::LocalGenusHerm, ::Int)
-gram_matrix(::LocalGenusHerm)
+gram_matrix(::HermLocalGenus, ::Int)
+gram_matrix(::HermLocalGenus)
 ```
 
 #### Examples
@@ -291,7 +291,7 @@ lattices:
     that this requires the given invariants to satisfy the product formula for Hilbert
     symbols.
 ```julia
-   genus(S::Vector{LocalGenusHerm}, signatures) -> GenusHerm
+   genus(S::Vector{HermLocalGenus}, signatures) -> HermGenus
 ```
   Here `signatures` can be a dictionary with keys the infinite places and values
   the corresponding signatures, or a collection of tuples of the type
@@ -299,7 +299,7 @@ lattices:
 
   - or by constructing the global genus symbol of a given hermitian lattice $L$.
 ```julia
-   genus(L::HermLat) -> GenusHerm
+   genus(L::HermLat) -> HermGenus
 ```
 
 #### Examples
@@ -330,12 +330,12 @@ G2 = genus(L)
 ### Attributes
 
 ```@docs
-base_field(::GenusHerm)
-primes(::GenusHerm)
-signatures(::GenusHerm)
-rank(::GenusHerm)
-is_integral(::GenusHerm)
-local_symbols(::GenusHerm)
+base_field(::HermGenus)
+primes(::HermGenus)
+signatures(::HermGenus)
+rank(::HermGenus)
+is_integral(::HermGenus)
+local_symbols(::HermGenus)
 ```
 
 #### Examples
@@ -400,11 +400,11 @@ mass(L)
 ## Representatives of a genus
 
 ```@docs
-representative(::LocalGenusHerm)
-Base.in(::HermLat, ::LocalGenusHerm)
-representative(::GenusHerm)
-Base.in(::HermLat, ::GenusHerm)
-representatives(::GenusHerm)
+representative(::HermLocalGenus)
+Base.in(::HermLat, ::HermLocalGenus)
+representative(::HermGenus)
+Base.in(::HermLat, ::HermGenus)
+representatives(::HermGenus)
 genus_representatives(::HermLat)
 ```
 
@@ -435,8 +435,8 @@ length(representatives(G1))
 ## Sum of genera
 
 ```@docs
-orthogonal_sum(::LocalGenusHerm, ::LocalGenusHerm)
-orthogonal_sum(::GenusHerm, ::GenusHerm)
+orthogonal_sum(::HermLocalGenus, ::HermLocalGenus)
+orthogonal_sum(::HermGenus, ::HermGenus)
 ```
 
 ### Examples
@@ -467,8 +467,8 @@ orthogonal_sum(G1, G2)
 ## Enumeration of genera
 
 ```@docs
-local_genera_hermitian(E, p, ::Int, ::Int, ::Int, ::Int)
-genera_hermitian(::Hecke.NfRel, ::Int, ::Dict{InfPlc, Int}, ::Union{Hecke.NfRelOrdIdl, Hecke.NfRelOrdFracIdl})
+hermitian_local_genera(E, p, ::Int, ::Int, ::Int, ::Int)
+hermitian_genera(::Hecke.NfRel, ::Int, ::Dict{InfPlc, Int}, ::Union{Hecke.NfRelOrdIdl, Hecke.NfRelOrdFracIdl})
 ```
 
 ### Examples
@@ -479,16 +479,16 @@ K, a = CyclotomicRealSubfield(8, "a");
 Kt, t = K["t"];
 E, b = number_field(t^2 - a * t + 1);
 p = prime_decomposition(maximal_order(K), 2)[1][1];
-local_genera_hermitian(E, p, 4, 2, 4)
+hermitian_local_genera(E, p, 4, 2, 4)
 infp = infinite_places(E);
 SEK = unique([r.base_field_place for r in infp if isreal(r.base_field_place) && !isreal(r)]);
-genera_hermitian(E, 3, Dict(SEK[1] => 1, SEK[2] => 1), 30 * maximal_order(E))
+hermitian_genera(E, 3, Dict(SEK[1] => 1, SEK[2] => 1), 30 * maximal_order(E))
 ```
 
 ## Rescaling
 
 ```@docs
-rescale(g::LocalGenusHerm, a::Union{FieldElem, RationalUnion})
-rescale(G::GenusHerm, a::Union{FieldElem, RationalUnion})
+rescale(g::HermLocalGenus, a::Union{FieldElem, RationalUnion})
+rescale(G::HermGenus, a::Union{FieldElem, RationalUnion})
 ```
 

--- a/docs/src/quad_forms/integer_lattices.md
+++ b/docs/src/quad_forms/integer_lattices.md
@@ -151,7 +151,7 @@ See [`discriminant_group(L::ZLat)`](@ref).
 ### Overlattices
 ```@docs
 glue_map(L::ZLat, S::ZLat, R::ZLat; check=true)
-overlattice(glue_map::TorQuadModMor)
+overlattice(glue_map::TorQuadModuleMor)
 local_modification(M::ZLat, L::ZLat, p)
 maximal_integral_lattice(L::ZLat)
 ```

--- a/docs/src/quad_forms/lattices.md
+++ b/docs/src/quad_forms/lattices.md
@@ -11,10 +11,10 @@ DocTestSetup = quote
 ### Inside a given ambient space
 
 ```@docs
-lattice(::AbsSpace)
-lattice(::AbsSpace, ::PMat)
-lattice(::AbsSpace, ::MatElem)
-lattice(::AbsSpace, ::Vector)
+lattice(::AbstractSpace)
+lattice(::AbstractSpace, ::PMat)
+lattice(::AbstractSpace, ::MatElem)
+lattice(::AbstractSpace, ::Vector)
 ```
 
 ### Quadratic lattice over a number field
@@ -84,11 +84,11 @@ lattice(hlb, 426)
 ## Ambient space and rational span
 
 ```@docs
-ambient_space(::AbsLat)
-rational_span(::AbsLat)
-basis_matrix_of_rational_span(::AbsLat)
-gram_matrix_of_rational_span(::AbsLat)
-diagonal_of_rational_span(::AbsLat)
+ambient_space(::AbstractLat)
+rational_span(::AbstractLat)
+basis_matrix_of_rational_span(::AbstractLat)
+gram_matrix_of_rational_span(::AbstractLat)
+diagonal_of_rational_span(::AbstractLat)
 ```
 
 ### Examples
@@ -119,8 +119,8 @@ diagonal_of_rational_span(Lquad)
 ```@docs
 hasse_invariant(L::QuadLat, p)
 witt_invariant(L::QuadLat, p)
-is_rationally_isometric(::AbsLat, ::AbsLat, ::NfAbsOrdIdl)
-is_rationally_isometric(L::AbsLat, M::AbsLat)
+is_rationally_isometric(::AbstractLat, ::AbstractLat, ::NfAbsOrdIdl)
+is_rationally_isometric(L::AbstractLat, M::AbstractLat)
 ```
 
 ### Examples
@@ -164,21 +164,21 @@ coordinates of the $x_i$'s in the canonical basis of the ambient space of $L$
 (conversely, given any such pseudo-matrix, one can define the corresponding pseudo-basis).
 
 ```@docs
-rank(L::AbsLat)
-degree(L::AbsLat)
-discriminant(::AbsLat)
-base_field(::AbsLat)
-base_ring(::AbsLat)
-fixed_field(::AbsLat)
-fixed_ring(::AbsLat)
-involution(::AbsLat)
-pseudo_matrix(::AbsLat)
-pseudo_basis(::AbsLat)
-coefficient_ideals(::AbsLat)
-absolute_basis_matrix(::AbsLat)
-absolute_basis(::AbsLat)
-generators(L::AbsLat; minimal::Bool = false)
-gram_matrix_of_generators(::AbsLat; minimal::Bool = false)
+rank(L::AbstractLat)
+degree(L::AbstractLat)
+discriminant(::AbstractLat)
+base_field(::AbstractLat)
+base_ring(::AbstractLat)
+fixed_field(::AbstractLat)
+fixed_ring(::AbstractLat)
+involution(::AbstractLat)
+pseudo_matrix(::AbstractLat)
+pseudo_basis(::AbstractLat)
+coefficient_ideals(::AbstractLat)
+absolute_basis_matrix(::AbstractLat)
+absolute_basis(::AbstractLat)
+generators(L::AbstractLat; minimal::Bool = false)
+gram_matrix_of_generators(::AbstractLat; minimal::Bool = false)
 ```
 
 ### Examples
@@ -225,15 +225,15 @@ $L^a$ to be the lattice over $E/K$ with the same underlying module as $L$ (i.e. 
 pseudo-bases) but in space $(V, a\Phi)$.
 
 ```@docs
-Base.:(+)(::AbsLat, ::AbsLat)
-Base.:(*)(::NumFieldElem, ::AbsLat)
-Base.:(*)(::NumFieldOrdIdl, ::AbsLat)
-Base.:(*)(::NumFieldOrdFracIdl, ::AbsLat)
-rescale(::AbsLat, ::NumFieldElem)
-dual(::AbsLat)
-intersect(::AbsLat, ::AbsLat)
-primitive_closure(::AbsLat, ::AbsLat)
-orthogonal_submodule(::AbsLat, ::AbsLat)
+Base.:(+)(::AbstractLat, ::AbstractLat)
+Base.:(*)(::NumFieldElem, ::AbstractLat)
+Base.:(*)(::NumFieldOrdIdl, ::AbstractLat)
+Base.:(*)(::NumFieldOrdFracIdl, ::AbstractLat)
+rescale(::AbstractLat, ::NumFieldElem)
+dual(::AbstractLat)
+intersect(::AbstractLat, ::AbstractLat)
+primitive_closure(::AbstractLat, ::AbstractLat)
+orthogonal_submodule(::AbstractLat, ::AbstractLat)
 ```
 
 ### Examples
@@ -273,9 +273,9 @@ Let $L$ be a lattice over $E/K$, in the space $(V, \Phi)$. We define:
 Note that these are fractional ideals of $\mathcal O_E$.
 
 ```@docs
-norm(::AbsLat)
-scale(L::AbsLat)
-volume(L::AbsLat)
+norm(::AbstractLat)
+scale(L::AbstractLat)
+volume(L::AbstractLat)
 ```
 
 ### Examples
@@ -304,13 +304,13 @@ of $\mathcal O_E$ (resp. an integer $v$) such that $\mathfrak aL^{\#} = L$ (resp
 $\mathfrak p^vL_{\mathfrak p}^{\#} = L_{\mathfrak p}$).
 
 ```@docs
-is_integral(::AbsLat)
-is_modular(::AbsLat)
-is_modular(::AbsLat, p)
-is_positive_definite(L::AbsLat)
-is_negative_definite(L::AbsLat)
-is_definite(L::AbsLat)
-can_scale_totally_positive(L::AbsLat)
+is_integral(::AbstractLat)
+is_modular(::AbstractLat)
+is_modular(::AbstractLat, p)
+is_positive_definite(L::AbstractLat)
+is_negative_definite(L::AbstractLat)
+is_definite(L::AbstractLat)
+can_scale_totally_positive(L::AbstractLat)
 ```
 
 ### Examples
@@ -337,9 +337,9 @@ can_scale_totally_positive(Lherm)
 ## Local properties
 
 ```@docs
-local_basis_matrix(L::AbsLat, p; type::Symbol = :any)
-jordan_decomposition(L::AbsLat, p::NfOrdIdl)
-is_isotropic(::AbsLat, p)
+local_basis_matrix(L::AbstractLat, p; type::Symbol = :any)
+jordan_decomposition(L::AbstractLat, p::NfOrdIdl)
+is_isotropic(::AbstractLat, p)
 ```
 
 ### Examples
@@ -374,8 +374,8 @@ called an *embedding*. We refer to the set of isometries from a lattice $L$ to i
 as the *automorphism group of $L$*.
 
 ```@docs
-automorphism_group_order(::AbsLat)
-automorphism_group_generators(::AbsLat)
+automorphism_group_order(::AbstractLat)
+automorphism_group_generators(::AbstractLat)
 ```
 
 ### Examples
@@ -399,9 +399,9 @@ automorphism_group_generators(Lquad)
 ## Isometry
 
 ```@docs
-is_isometric(::AbsLat, ::AbsLat)
-is_isometric_with_isometry(::AbsLat, ::AbsLat)
-is_locally_isometric(::AbsLat, ::AbsLat, p::NfOrdIdl)
+is_isometric(::AbstractLat, ::AbstractLat)
+is_isometric_with_isometry(::AbstractLat, ::AbstractLat)
+is_locally_isometric(::AbstractLat, ::AbstractLat, p::NfOrdIdl)
 ```
 
 ### Examples
@@ -426,12 +426,12 @@ is_locally_isometric(Lquad, Lquad2, p)
 ## Maximal integral lattices
 
 ```@docs
-is_maximal_integral(::AbsLat, p)
-is_maximal_integral(::AbsLat)
-is_maximal(::AbsLat, p)
-maximal_integral_lattice(::AbsLat, p)
-maximal_integral_lattice(::AbsLat)
-maximal_integral_lattice(::AbsSpace)
+is_maximal_integral(::AbstractLat, p)
+is_maximal_integral(::AbstractLat)
+is_maximal(::AbstractLat, p)
+maximal_integral_lattice(::AbstractLat, p)
+maximal_integral_lattice(::AbstractLat)
+maximal_integral_lattice(::AbstractSpace)
 ```
 
 ### Examples

--- a/src/NumFieldOrd/NfOrd/LLLctx.jl
+++ b/src/NumFieldOrd/NfOrd/LLLctx.jl
@@ -1,10 +1,10 @@
-mutable struct NfLattice{T}
+mutable struct NfLat{T}
   basis::Vector{T}
   discriminant::fmpz
   is_minkowski_exact::Bool
   minkowski_gram_exact::fmpz_mat
   minkowski_gram_scaled::Tuple{Int, fmpz_mat}
-  function NfLattice{T}(v::Vector{T}, discriminant::fmpz) where {T <: NumFieldElem}
+  function NfLat{T}(v::Vector{T}, discriminant::fmpz) where {T <: NumFieldElem}
     n = new{T}()
     n.basis = v
     n.discriminant = discriminant
@@ -16,33 +16,33 @@ end
 
 function lattice(v::Vector{T}, disc::fmpz; is_exact::Bool = false) where T <: NumFieldElem
   @assert !isempty(v)
-  L = NfLattice{T}(v, abs(disc))
+  L = NfLat{T}(v, abs(disc))
   L.is_minkowski_exact = is_exact
   return L
 end
 
-function dim(L::NfLattice)
+function dim(L::NfLat)
   return length(L.basis)
 end
 
-function basis(L::NfLattice)
+function basis(L::NfLat)
   return L.basis
 end
 
-function discriminant(L::NfLattice)
+function discriminant(L::NfLat)
   return L.discriminant
 end
 
-function nf(L::NfLattice{T}) where T <: NumFieldElem
+function nf(L::NfLat{T}) where T <: NumFieldElem
   return parent(basis(L)[1])
 end
 
-function minkowski_matrix(L::NfLattice, p::Int)
+function minkowski_matrix(L::NfLat, p::Int)
   return minkowski_matrix(basis(L), p)
 end
 
 #apply the change of basis given by M, creating a new lattice.
-function apply(L::NfLattice{T}, t::fmpz_mat) where T <: NumFieldElem
+function apply(L::NfLat{T}, t::fmpz_mat) where T <: NumFieldElem
   K = nf(L)
   B = basis(L)
   new_basis = Vector{T}(undef, dim(L))
@@ -58,7 +58,7 @@ function apply(L::NfLattice{T}, t::fmpz_mat) where T <: NumFieldElem
   return lattice(new_basis, discriminant(L), is_exact = L.is_minkowski_exact)
 end
 
-function minkowski_gram_mat_scaled(L::NfLattice, p::Int)
+function minkowski_gram_mat_scaled(L::NfLat, p::Int)
   if L.is_minkowski_exact
     L.minkowski_gram_exact = _exact_minkowski_matrix(basis(L))
     return L.minkowski_gram_exact
@@ -83,7 +83,7 @@ function minkowski_gram_mat_scaled(L::NfLattice, p::Int)
   return A
 end
 
-function weighted_minkowski_gram_scaled(L::NfLattice, v::fmpz_mat, prec::Int)
+function weighted_minkowski_gram_scaled(L::NfLat, v::fmpz_mat, prec::Int)
   c = deepcopy(minkowski_matrix(L, prec))
   mult_by_2pow_diag!(c, v)
   d = zero_matrix(FlintZZ, nrows(c), ncols(c))
@@ -97,7 +97,7 @@ function weighted_minkowski_gram_scaled(L::NfLattice, v::fmpz_mat, prec::Int)
   return g
 end
 
-function lll(L::NfLattice, weights::fmpz_mat = zero_matrix(FlintZZ, 1, 1); starting_prec::Int = 100 + 25*div(dim(L), 3) + Int(round(log(abs(discriminant(L))))))
+function lll(L::NfLat, weights::fmpz_mat = zero_matrix(FlintZZ, 1, 1); starting_prec::Int = 100 + 25*div(dim(L), 3) + Int(round(log(abs(discriminant(L))))))
   if L.is_minkowski_exact
     M = _exact_minkowski_matrix(basis(L))
     l, v = lll_gram_with_transform(M)
@@ -133,7 +133,7 @@ function lll(L::NfLattice, weights::fmpz_mat = zero_matrix(FlintZZ, 1, 1); start
   return l1, v
 end
 
-function _lll(L::NfLattice, weights::fmpz_mat, prec::Int)
+function _lll(L::NfLat, weights::fmpz_mat, prec::Int)
   @vprint :LLL 1 "Computing Minkowski Gram matrix with precision $(prec) \n"
   local d::fmpz_mat
   local sv::fmpz
@@ -179,7 +179,7 @@ function _lll(L::NfLattice, weights::fmpz_mat, prec::Int)
   return fl, FakeFmpqMat(d, fmpz(2)^prec), g
 end
 
-function lll_basis(L::NfLattice{T}) where T
+function lll_basis(L::NfLat{T}) where T
   K = nf(L)
   l, t = lll(L)
   L1 = apply(L, t)

--- a/src/QuadForm/Database.jl
+++ b/src/QuadForm/Database.jl
@@ -7,13 +7,13 @@
 export number_of_lattices, lattice_name, lattice,
        lattice_automorphism_group_order, lattice_database
 
-struct LatticeDB
+struct LatDB
   path::String
   max_rank::Int
   db::Vector{Vector{NamedTuple{(:name, :rank, :deg, :amb, :basis_mat, :min, :aut, :kissing),
                                Tuple{String, Int, Int, Vector{Rational{BigInt}}, Vector{Rational{BigInt}}, BigInt, BigInt, BigInt}}}}
 
-  function LatticeDB(path::String)
+  function LatDB(path::String)
     db = Meta.eval(Meta.parse(Base.read(path, String)))
     max_rank = length(db)
     return new(path, max_rank, db)
@@ -22,7 +22,7 @@ end
 
 # TODO: Write a parser for the data
 
-function show(io::IO, L::LatticeDB)
+function show(io::IO, L::LatDB)
   print(io, "Nebe-Sloan database of lattices (rank limit = ", L.max_rank, ")")
 end
 
@@ -35,11 +35,11 @@ const default_lattice_db = Ref(joinpath(artifact"ZLatDB", "ZLatDB", "data"))
 ################################################################################
 
 function lattice_database()
-  return LatticeDB(default_lattice_db[])
+  return LatDB(default_lattice_db[])
 end
 
 function lattice_database(path::String)
-  return LatticeDB(path)
+  return LatDB(path)
 end
 
 ################################################################################
@@ -48,7 +48,7 @@ end
 #
 ################################################################################
 
-function from_linear_index(L::LatticeDB, i::Int)
+function from_linear_index(L::LatDB, i::Int)
   k = 1
   while i > length(L.db[k])
     i = i - length(L.db[k])
@@ -86,36 +86,36 @@ end
 #
 ################################################################################
 
-function number_of_lattices(L::LatticeDB, r::Int)
+function number_of_lattices(L::LatDB, r::Int)
   _check_rank_range(L, r)
   return length(L.db[r])
 end
 
-function number_of_lattices(L::LatticeDB)
+function number_of_lattices(L::LatDB)
   return sum(length.(L.db))
 end
 
-function lattice_name(L::LatticeDB, r::Int, i::Int)
+function lattice_name(L::LatDB, r::Int, i::Int)
   _check_range(L, r, i)
   return L.db[r][i].name
 end
 
-function lattice_name(L::LatticeDB, i::Int)
+function lattice_name(L::LatDB, i::Int)
   _check_range(L, i)
   return lattice_name(L, from_linear_index(L, i)...)
 end
 
-function lattice_automorphism_group_order(L::LatticeDB, r::Int, i::Int)
+function lattice_automorphism_group_order(L::LatDB, r::Int, i::Int)
   _check_range(L, r, i)
   return L.db[r][i].aut
 end
 
-function lattice_automorphism_group_order(L::LatticeDB, i::Int)
+function lattice_automorphism_group_order(L::LatDB, i::Int)
   _check_range(L, i)
   return lattice_automorphism_group_order(L, from_linear_index(L, i)...)
 end
 
-function lattice(L::LatticeDB, r::Int, i::Int)
+function lattice(L::LatDB, r::Int, i::Int)
   _check_range(L, r, i)
   d = L.db[r][i].deg
   A = matrix(FlintQQ, d, d, L.db[r][i].amb)
@@ -123,7 +123,7 @@ function lattice(L::LatticeDB, r::Int, i::Int)
   return Zlattice(B, gram = A)
 end
 
-function lattice(L::LatticeDB, i::Int)
+function lattice(L::LatDB, i::Int)
   _check_range(L, i)
   return lattice(L, from_linear_index(L, i)...)
 end

--- a/src/QuadForm/Herm/Genus.jl
+++ b/src/QuadForm/Herm/Genus.jl
@@ -1,5 +1,5 @@
 export genus, representative, rank, det, uniformizer, det_representative,
-       gram_matrix, genera_hermitian, local_genera_hermitian, rank,
+       gram_matrix, hermitian_genera, hermitian_local_genera, rank,
        orthogonal_sum, is_inert, scales, ranks, dets, is_split, is_ramified,
        is_dyadic, norms, primes, signatures
 
@@ -10,7 +10,7 @@ export genus, representative, rank, det, uniformizer, det_representative,
 ################################################################################
 
 # Need to make this type stable once we have settled on a design
-mutable struct LocalGenusHerm{S, T}
+mutable struct HermLocalGenus{S, T}
   E::S                                # Field
   p::T                                # prime of base_field(E)
   data::Vector{Tuple{Int, Int, Int}}  # data
@@ -22,13 +22,13 @@ mutable struct LocalGenusHerm{S, T}
   non_norm_rep::FieldElem             # u in K*\N(E*)
   ni::Vector{Int}                     # ni for the ramified, dyadic case
 
-  function LocalGenusHerm{S, T}() where {S, T}
+  function HermLocalGenus{S, T}() where {S, T}
     z = new{S, T}()
     return z
   end
 end
 
-local_genus_herm_type(E) = LocalGenusHerm{typeof(E), ideal_type(order_type(base_field(E)))}
+local_genus_herm_type(E) = HermLocalGenus{typeof(E), ideal_type(order_type(base_field(E)))}
 
 ################################################################################
 #
@@ -36,7 +36,7 @@ local_genus_herm_type(E) = LocalGenusHerm{typeof(E), ideal_type(order_type(base_
 #
 ################################################################################
 
-function Base.show(io::IO, ::MIME"text/plain", G::LocalGenusHerm)
+function Base.show(io::IO, ::MIME"text/plain", G::HermLocalGenus)
   compact = get(io, :compact, false)
   if !compact
     if is_dyadic(G) && is_ramified(G)
@@ -64,7 +64,7 @@ function Base.show(io::IO, ::MIME"text/plain", G::LocalGenusHerm)
   end
 end
 
-function Base.show(io::IO, G::LocalGenusHerm)
+function Base.show(io::IO, G::HermLocalGenus)
   if is_dyadic(G) && is_ramified(G)
     for i in 1:length(G)
       print(io, "(", scale(G, i), ", ", rank(G, i), ", ",
@@ -91,73 +91,73 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    scale(g::LocalGenusHerm, i::Int) -> Int
+    scale(g::HermLocalGenus, i::Int) -> Int
 
 Given a local genus symbol `g` for hermitian lattices over $E/K$ at a prime $\mathfrak
 p$ of $\mathcal O_K$, return the $\mathfrak P$-valuation of the scale of the `i`th
 Jordan block of `g`, where $\mathfrak P$ is a prime ideal of $\mathcal O_E$ lying
 over $\mathfrak p$.
 """
-scale(G::LocalGenusHerm, i::Int) = G.data[i][1]
+scale(G::HermLocalGenus, i::Int) = G.data[i][1]
 
 @doc Markdown.doc"""
-    scale(g::LocalGenusHerm) -> NfOrdFracIdl
+    scale(g::HermLocalGenus) -> NfOrdFracIdl
 
 Given a local genus symbol `g` for hermitian lattices over $E/K$ at a prime
 $\mathfrak p$ of $\mathcal O_K$, return the scale of the Jordan block of minimum
 $\mathfrak P$-valuation, where $\mathfrakP$ is a prime ideal of $\mathcal O_E$
 lying over $\mathfrak p$.
 """
-scale(g::LocalGenusHerm) = prime(g)^(scale(g, i))
+scale(g::HermLocalGenus) = prime(g)^(scale(g, i))
 
 @doc Markdown.doc"""
-    scales(g::LocalGenusHerm) -> Vector{Int}
+    scales(g::HermLocalGenus) -> Vector{Int}
 
 Given a local genus symbol `g` for hermitian lattices over $E/K$ at a prime $\mathfrak
 p$ of $\mathcal O_K$, return the $\mathfrak P$-valuation of the scales of the Jordan
 blocks of `g`, where $\mathfrak P$ is a prime ideal of $\mathcal O_E$ lying over $\mathfrak p$.
 """
-scales(G::LocalGenusHerm) = map(i -> scale(G, i), 1:length(G))::Vector{Int}
+scales(G::HermLocalGenus) = map(i -> scale(G, i), 1:length(G))::Vector{Int}
 
 @doc Markdown.doc"""
-    rank(g::LocalGenusHerm, i::Int) -> Int
+    rank(g::HermLocalGenus, i::Int) -> Int
 
 Given a local genus symbol `g` for hermitian lattices, return the rank of the
 `i`th Jordan block of `g`.
 """
-rank(G::LocalGenusHerm, i::Int) = G.data[i][2]
+rank(G::HermLocalGenus, i::Int) = G.data[i][2]
 
 @doc Markdown.doc"""
-    rank(g::LocalGenusHerm) -> Int
+    rank(g::HermLocalGenus) -> Int
 
 Given a local genus symbol `g` for hermitian lattices over $E/K$ at a prime ideal
 $\mathfrak p$ of $\mathcal O_K$, return the rank of any hermitian lattice whose
 $\mathfrak p$-adic completion has local genus symbol `g`.
 """
-function rank(G::LocalGenusHerm)
+function rank(G::HermLocalGenus)
   return reduce(+, (rank(G, i) for i in 1:length(G)), init = Int(0))
 end
 
 @doc Markdown.doc"""
-    ranks(g::LocalGenusHerm) -> Vector{Int}
+    ranks(g::HermLocalGenus) -> Vector{Int}
 
 Given a local genus symbol `g` for hermitian lattices, return the ranks of the
 Jordan blocks of `g`.
 """
-ranks(G::LocalGenusHerm) = map(i -> rank(G, i), 1:length(G))::Vector{Int}
+ranks(G::HermLocalGenus) = map(i -> rank(G, i), 1:length(G))::Vector{Int}
 
 @doc Markdown.doc"""
-    det(g::LocalGenusHerm, i::Int) -> Int
+    det(g::HermLocalGenus, i::Int) -> Int
 
 Given a local genus symbol `g` for hermitian lattices over $E/K$, return the determinant
 of the `i`th Jordan block of `g`.
 
 The returned value is $1$ or $-1$ depending on whether the determinant is a local norm in `K`.
 """
-det(G::LocalGenusHerm, i::Int) = G.data[i][3]
+det(G::HermLocalGenus, i::Int) = G.data[i][3]
 
 @doc Markdown.doc"""
-    det(g::LocalGenusHerm) -> Int
+    det(g::HermLocalGenus) -> Int
 
 Given a local genus symbol `g` for hermitian lattices over $E/K$ at a prime ideal
 $\mathfrak p$ of $\mathcal O_K$, return the determinant of a hermitian lattice
@@ -166,12 +166,12 @@ whose $\mathfrak p$-adic completion has local genus symbol `g`.
 The returned value is $1$ or $-1$ depending on whether the determinant is a local
 norm in `K`.
 """
-function det(G::LocalGenusHerm)
+function det(G::HermLocalGenus)
   return reduce(*, (det(G, i) for i in 1:length(G)), init = Int(1))
 end
 
 @doc Markdown.doc"""
-    dets(g::LocalGenusHerm) -> Vector{Int}
+    dets(g::HermLocalGenus) -> Vector{Int}
 
 Given a local genus symbol `g` for hermitian lattices over $E/K$, return the determinants
 of the Jordan blocks of `g`.
@@ -179,17 +179,17 @@ of the Jordan blocks of `g`.
 The returned values are $1$ or $-1$ depending on whether the respective determinants are
 are local norms in `K`.
 """
-dets(G::LocalGenusHerm) = map(i -> det(G, i), 1:length(G))::Vector{Int}
+dets(G::HermLocalGenus) = map(i -> det(G, i), 1:length(G))::Vector{Int}
 
 @doc Markdown.doc"""
-    discriminant(g::LocalGenusHerm, i::Int) -> Int
+    discriminant(g::HermLocalGenus, i::Int) -> Int
 
 Given a local genus symbol `g` for hermitian lattices over $E/K$, return the discriminant
 of the `i`th Jordan block of `g`.
 
 The returned value is $1$ or $-1$ depending on whether the discriminant is a local norm in `K`.
 """
-function discriminant(G::LocalGenusHerm, i::Int)
+function discriminant(G::HermLocalGenus, i::Int)
   d = det(G, i)
   r = rank(G, i) % 4
   if !is_ramified(G) || r == 0 || r == 1
@@ -205,7 +205,7 @@ function discriminant(G::LocalGenusHerm, i::Int)
 end
 
 @doc Markdown.doc"""
-    discriminant(g::LocalGenusHerm) -> Int
+    discriminant(g::HermLocalGenus) -> Int
 
 Given a local genus symbol `g` for hermitian lattices over $E/K$ at a prime ideal
 $\mathfrak p$ of $\mathcal O_K$, return the discriminant of a hermitian lattice
@@ -214,7 +214,7 @@ whose $\mathfrak p$-adic completion has local genus symbol `g`.
 The returned value is $1$ or $-1$ depending on whether the discriminant is a local
 norm in `K`.
 """
-function discriminant(G::LocalGenusHerm)
+function discriminant(G::HermLocalGenus)
   d = det(G)
   r = rank(G) % 4
   if !is_ramified(G) || r == 0 || r == 1
@@ -231,81 +231,81 @@ end
 
 # this only works if it is ramified and dyadic
 @doc Markdown.doc"""
-    norm(g::LocalGenusHerm, i::Int) -> Int
+    norm(g::HermLocalGenus, i::Int) -> Int
 
 Given a ramified dyadic local genus symbol `g` for hermitian lattices over $E/K$ at a
 prime ideal $\mathfrak p$ of $\mathcal O_K$, return the $\mathfrak p$-valuation of
 the norm of the `i`th Jordan block of `g`.
 """
-norm(G::LocalGenusHerm, i::Int) = begin @assert is_dyadic(G) && is_ramified(G); G.norm_val[i] end
+norm(G::HermLocalGenus, i::Int) = begin @assert is_dyadic(G) && is_ramified(G); G.norm_val[i] end
 
 # this only works if it is ramified and dyadic
 @doc Markdown.doc"""
-    norms(g::LocalGenusHerm) -> Vector{Int}
+    norms(g::HermLocalGenus) -> Vector{Int}
 
 Given a ramified dyadic local genus symbol `g` for hermitian lattices over $E/K$ at a
 prime ideal $\mathfrak p$ of $\mathcal O_K$, return the $\mathfrak p$-valuations of the
 norms of the Jordan blocks of `g`.
 """
-norms(G::LocalGenusHerm) = begin @assert is_dyadic(G) && is_ramified(G); G.norm_val end
+norms(G::HermLocalGenus) = begin @assert is_dyadic(G) && is_ramified(G); G.norm_val end
 
 @doc Markdown.doc"""
-    is_ramified(g::LocalGenusHerm) -> Bool
+    is_ramified(g::HermLocalGenus) -> Bool
 
 Given a local genus symbol `g` for hermitian lattices over $E/K$ at a prime ideal
 $\mathfrak p$ of $\mathcal O_K$, return whether $\mathfrak p$ is ramified in
 $\mathcal O_E$.
 """
-is_ramified(g::LocalGenusHerm) = g.is_ramified
+is_ramified(g::HermLocalGenus) = g.is_ramified
 
 @doc Markdown.doc"""
-    is_split(g::LocalGenusHerm) -> Bool
+    is_split(g::HermLocalGenus) -> Bool
 
 Given a local genus symbol `g` for hermitian lattices over $E/K$ at a prime ideal
 $\mathfrak p$ of $\mathcal O_K$, return whether $\mathfrak p$ is split in
 $\mathcal O_E$.
 """
-is_split(g::LocalGenusHerm) = g.is_split
+is_split(g::HermLocalGenus) = g.is_split
 
 @doc Markdown.doc"""
-    is_inert(g::LocalGenusHerm) -> Bool
+    is_inert(g::HermLocalGenus) -> Bool
 
 Given a local genus symbol `g` for hermitian lattices over $E/K$ at a prime ideal
 $\mathfrak p$ of $\mathcal O_K$, return whether $\mathfrak p$ is inert in
 $\mathcal O_E$.
 """
-is_inert(g::LocalGenusHerm) = !g.is_ramified && !g.is_split
+is_inert(g::HermLocalGenus) = !g.is_ramified && !g.is_split
 
 @doc Markdown.doc"""
-    is_dyadic(g::LocalGenusHerm) -> Bool
+    is_dyadic(g::HermLocalGenus) -> Bool
 
 Given a local genus symbol `g` for hermitian lattices over $E/K$ at a prime ideal
 $\mathfrak p$ of $\mathcal O_K$, return whether $\mathfrak p$ is dyadic.
 """
-is_dyadic(G::LocalGenusHerm) = G.is_dyadic
+is_dyadic(G::HermLocalGenus) = G.is_dyadic
 
 @doc Markdown.doc"""
-    length(g::LocalGenusHerm) -> Int
+    length(g::HermLocalGenus) -> Int
 
 Given a local genus symbol `g` for hermitian lattices, return the number of Jordan blocks
 of `g`.
 """
-length(G::LocalGenusHerm) = length(G.data)
+length(G::HermLocalGenus) = length(G.data)
 
 @doc Markdown.doc"""
-    base_field(g::LocalGenusHerm) -> NumField
+    base_field(g::HermLocalGenus) -> NumField
 
 Given a local genus symbol `g` for hermitian lattices over $E/K$, return `E`.
 """
-base_field(G::LocalGenusHerm) = G.E
+base_field(G::HermLocalGenus) = G.E
 
 @doc Markdown.doc"""
-    prime(g::LocalGenusHerm) -> NfOrdIdl
+    prime(g::HermLocalGenus) -> NfOrdIdl
 
 Given a local genus symbol `g` for hermitian lattices over $E/K$ at a prime ideal
 $\mathfrak p$ of $\mathcal O_K$, return $\mathfrak p$.
 """
-prime(G::LocalGenusHerm) = G.p
+prime(G::HermLocalGenus) = G.p
 
 ################################################################################
 #
@@ -315,7 +315,7 @@ prime(G::LocalGenusHerm) = G.p
 
 # If G is defined over E/K at a prime p of O_K, this returns an unit in K which is
 # not a local norm at p.
-function _non_norm_rep(G::LocalGenusHerm)
+function _non_norm_rep(G::HermLocalGenus)
   if isdefined(G, :non_norm_rep)
     return G.non_norm_rep::elem_type(base_field(base_field(G)))
   end
@@ -332,14 +332,14 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    uniformizer(g::LocalGenusHerm) -> NumFieldElem
+    uniformizer(g::HermLocalGenus) -> NumFieldElem
 
 Given a local genus symbol `g` for hermitian lattices over $E/K$ at a prime ideal
 $\mathfrak p$ of $\mathcal O_K$, return a generator for the largest ideal of $\mathcal O_E$
 containing $\mathfrak p$ and invariant under the action of the non-trivial involution
 of `E`.
 """
-function uniformizer(G::LocalGenusHerm)
+function uniformizer(G::HermLocalGenus)
   E = base_field(G)
   K = base_field(E)
   if is_ramified(G)
@@ -364,7 +364,7 @@ end
 ################################################################################
 
 # Get the "ni" for the ramified dyadic case
-function _get_ni_from_genus(G::LocalGenusHerm)
+function _get_ni_from_genus(G::HermLocalGenus)
   @assert is_ramified(G)
   @assert is_dyadic(G)
   t = length(G)
@@ -389,12 +389,12 @@ end
 # but the scale is with respect to P and thus the determinant of a G is
 # represented P^(scale*rank) = p^(scale*rank/2) times u.
 @doc Markdown.doc"""
-    det_representative(g::LocalGenusHerm) -> NumFieldElem
+    det_representative(g::HermLocalGenus) -> NumFieldElem
 
 Given a local genus symbol `g` for hermitian lattices over $E/K$, return a
 representative of the norm class of the determinant of `g` in $K^{\times}$.
 """
-function det_representative(G::LocalGenusHerm)
+function det_representative(G::HermLocalGenus)
   d = det(G)
   v = sum(scale(G, i) * rank(G, i) for i in 1:length(G); init = 0)
   if !is_ramified(G)
@@ -414,13 +414,13 @@ function det_representative(G::LocalGenusHerm)
 end
 
 @doc Markdown.doc"""
-    det_representative(g::LocalGenusHerm, i::Int) -> NumFieldElem
+    det_representative(g::HermLocalGenus, i::Int) -> NumFieldElem
 
 Given a local genus symbol `g` for hermitian lattices over $E/K$, return a
 representative of the norm class of the determinant of the `i`th Jordan block of
 `g` in $K^{\times}$.
 """
-function det_representative(G::LocalGenusHerm, i::Int)
+function det_representative(G::HermLocalGenus, i::Int)
   d = det(G, i)
   v = scale(G, i) * rank(G, i)
   if !is_ramified(G)
@@ -445,14 +445,14 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    gram_matrix(g::LocalGenusHerm) -> MatElem
+    gram_matrix(g::HermLocalGenus) -> MatElem
 
 Given a local genus symbol `g` for hermitian lattices over $E/K$ at a prime ideal
 $\mathfrak p$ of $\mathcal O_K$, return a Gram matrix `M` of `g`, with coefficients
 in `E`.`M` is such that any hermitian lattice over $E/K$ with Gram matrix `M` satisfies
 that the local genus symbol of its completion at $\mathfrak p$ is `g`.
 """
-function gram_matrix(G::LocalGenusHerm)
+function gram_matrix(G::HermLocalGenus)
   if rank(G) == 0
     return zero_matrix(base_field(G), 0, 0)
   end
@@ -460,7 +460,7 @@ function gram_matrix(G::LocalGenusHerm)
 end
 
 @doc Markdown.doc"""
-    gram_matrix(g::LocalGenusHerm, i::Int) -> MatElem
+    gram_matrix(g::HermLocalGenus, i::Int) -> MatElem
 
 Given a local genus symbol `g` for hermitian lattices over $E/K$ at a prime ideal
 $\mathfrak p$ of $\mathcal O_K$, return a Gram matrix `M` of the `i`th Jordan block
@@ -468,7 +468,7 @@ of `g`, with coefficients in `E`. `M` is such that any hermitian lattice over $E
 with Gram matrix `M` satisfies that the local genus symbol of its completion at
 $\mathfrak p$ is equal to the `i`th Jordan block of `g`.
 """
-function gram_matrix(G::LocalGenusHerm, l::Int)
+function gram_matrix(G::HermLocalGenus, l::Int)
   i = scale(G, l)
   m = rank(G, l)
   d = det(G, l)
@@ -559,13 +559,13 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    representative(g::LocalGenusHerm) -> HermLat
+    representative(g::HermLocalGenus) -> HermLat
 
 Given a local genus symbol `g` for hermitian lattices over $E/K$ at a prime ideal
 $\mathfrak p$ of $\mathcal O_K$, return a hermitian lattice over $E/K$ whose
 completion at $\mathfrak p$ admits `g` as local genus symbol.
 """
-function representative(G::LocalGenusHerm)
+function representative(G::HermLocalGenus)
   E = base_field(G)
   L = lattice(hermitian_space(E, gram_matrix(G)))
   S = ideal_type(base_ring(base_ring(L)))
@@ -588,7 +588,7 @@ end
 @doc Markdown.doc"""
     genus(HermLat, E::NumField, p::NfOrdIdl, data::Vector; type::Symbol = :det,
 		                                           check::Bool = true)
-                                                                 -> LocalGenusHerm
+                                                                 -> HermLocalGenus
 
 Construct the local genus symbol `g` for hermitian lattices over the algebra `E`,
 with base field $K$, at the prime ideal `p` of $\mathcal O_K$. Its invariants are
@@ -630,7 +630,7 @@ end
 # This is the internal function which requires the decomposition behavior of
 # the prime to be already determined and does not do any internal checks.
 function _genus(::Type{HermLat}, E::S, p::T, data::Vector{Tuple{Int, Int, Int}}, is_dyadic, is_ramified, is_split) where {S, T}
-  z = LocalGenusHerm{S, T}()
+  z = HermLocalGenus{S, T}()
   z.E = E
   z.p = p
   @hassert :Lattice 1 !(is_dyadic && is_ramified)
@@ -788,7 +788,7 @@ end
 #
 # First the internal function, which has as additonal argument the vector of norm valuations.
 function _genus(::Type{HermLat}, E::S, p::T, data::Vector{Tuple{Int, Int, Int}}, norms::Vector{Int}) where {S <: NumField, T}
-  z = LocalGenusHerm{S, T}()
+  z = HermLocalGenus{S, T}()
   z.E = E
   z.p = p
   z.is_dyadic = is_dyadic(p)
@@ -860,7 +860,7 @@ end
 # TODO: better documentation
 
 @doc Markdown.doc"""
-    genus(L::HermLat, p::NfOrdIdl) -> LocalGenusHerm
+    genus(L::HermLat, p::NfOrdIdl) -> HermLocalGenus
 
 Return the local genus symbol `g` for hermitian lattices over $E/K$ of the completion
 of the hermitian lattice `L` at the prime ideal `p` of $\mathcal O_K$.
@@ -918,13 +918,13 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    in(L::HermLat, g::LocalGenusHerm) -> Bool
+    in(L::HermLat, g::HermLocalGenus) -> Bool
 
 Return whether `g` and the local genus symbol of the completion of the hermitian
 lattice `L` at `prime(g)` agree. Note that `L` being in `g` requires both `L` and
 `g` to be defined over the same extension $E/K$.
 """
-Base.in(L::HermLat, G::LocalGenusHerm) = base_field(L) === base_field(G) && genus(L, prime(G)) == G
+Base.in(L::HermLat, G::HermLocalGenus) = base_field(L) === base_field(G) && genus(L, prime(G)) == G
 
 ################################################################################
 #
@@ -933,14 +933,14 @@ Base.in(L::HermLat, G::LocalGenusHerm) = base_field(L) === base_field(G) && genu
 ################################################################################
 
 @doc Markdown.doc"""
-    ==(g1::LocalGenusHerm, g2::LocalGenusHerm) -> Bool
+    ==(g1::HermLocalGenus, g2::HermLocalGenus) -> Bool
 
 Given two local genus symbols `g1` and `g2`, return whether their respective Jordan
 decompositions are of the same Jordan type. Note that equality requires `g1` and `g2`
 to be defined over the same extension $E/K$ and at the same prime ideal $\mathfrak p$
 of $\mathcal O_K$.
 """
-function ==(G1::LocalGenusHerm, G2::LocalGenusHerm)
+function ==(G1::HermLocalGenus, G2::HermLocalGenus)
   if base_field(G1) != base_field(G2)
     return false
   end
@@ -1062,14 +1062,14 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    orthogonal_sum(g1::LocalGenusHerm, g2::LocalGenusHerm) -> LocalGenusHerm
+    orthogonal_sum(g1::HermLocalGenus, g2::HermLocalGenus) -> HermLocalGenus
 
 Given two local genus symbols `g1` and `g2` for hermitian lattices over $E/K$
 at the same prime ideal $\mathfrak p$ of $\mathcal O_K$, return their orthogonal
 sum. It corresponds to the local genus symbol of the $\mathfrak p$-adic completion
 of the orthogonal sum of respective representatives of `g1` and `g2`.
 """
-function orthogonal_sum(G1::LocalGenusHerm, G2::LocalGenusHerm)
+function orthogonal_sum(G1::HermLocalGenus, G2::HermLocalGenus)
   @req prime(G1) == prime(G2) "Local genera must have the same prime ideal"
   if !G1.is_dyadic || !G2.is_ramified
     return _direct_sum_easy(G1, G2)
@@ -1081,7 +1081,7 @@ function orthogonal_sum(G1::LocalGenusHerm, G2::LocalGenusHerm)
   end
 end
 
-function _direct_sum_easy(G1::LocalGenusHerm, G2::LocalGenusHerm)
+function _direct_sum_easy(G1::HermLocalGenus, G2::HermLocalGenus)
   # We do a merge sort
   i1 = 1
   i2 = 1
@@ -1118,14 +1118,14 @@ end
 #
 ################################################################################
 
-mutable struct GenusHerm{S, T, U, V}
+mutable struct HermGenus{S, T, U, V}
   E::S
   primes::Vector{T}
   LGS::Vector{U}
   rank::Int
   signatures::V
 
-  function GenusHerm(E::S, r, LGS::Vector{U}, signatures::V) where {S, U, V}
+  function HermGenus(E::S, r, LGS::Vector{U}, signatures::V) where {S, U, V}
     K = base_field(E)
     primes = Vector{ideal_type(order_type(K))}(undef, length(LGS))
 
@@ -1138,7 +1138,7 @@ mutable struct GenusHerm{S, T, U, V}
   end
 end
 
-genus_herm_type(E) = GenusHerm{typeof(E), ideal_type(order_type(base_field(E))), local_genus_herm_type(E), Dict{place_type(base_field(E)), Int}}
+genus_herm_type(E) = HermGenus{typeof(E), ideal_type(order_type(base_field(E))), local_genus_herm_type(E), Dict{place_type(base_field(E)), Int}}
 
 ################################################################################
 #
@@ -1146,7 +1146,7 @@ genus_herm_type(E) = GenusHerm{typeof(E), ideal_type(order_type(base_field(E))),
 #
 ################################################################################
 
-function Base.show(io::IO, ::MIME"text/plain", G::GenusHerm)
+function Base.show(io::IO, ::MIME"text/plain", G::HermGenus)
   print(io, "Global genus symbol over ")
   print(io, G.E)
   print(io, "\n", "with local genus symbols",)
@@ -1183,7 +1183,7 @@ function _print_short(io::IO, a::acb)
   end
 end
 
-function Base.show(io::IO, G::GenusHerm)
+function Base.show(io::IO, G::HermGenus)
   print(io, "Global genus symbol\n")
   for i in 1:length(G.primes)
     print(IOContext(io, :compact => true), G.primes[i], " => ", G.LGS[i],)
@@ -1206,22 +1206,22 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    base_field(G::GenusHerm) -> NumField
+    base_field(G::HermGenus) -> NumField
 
 Given a global genus symbol `G` for hermitian lattices over $E/K$, return `E`.
 """
-base_field(G::GenusHerm) = G.E
+base_field(G::HermGenus) = G.E
 
 @doc Markdown.doc"""
-    primes(G::GenusHerm) -> Vector{NfOrdIdl}
+    primes(G::HermGenus) -> Vector{NfOrdIdl}
 
 Given a global genus symbol `G` for hermitian lattices over $E/K$, return
 the list of prime ideals of $\mathcal O_K$ at which `G` has a local genus symbol.
 """
-primes(G::GenusHerm) = G.primes
+primes(G::HermGenus) = G.primes
 
 @doc Markdown.doc"""
-    signatures(G::GenusHerm) -> Dict{InfPlc, Int}
+    signatures(G::HermGenus) -> Dict{InfPlc, Int}
 
 Given a global genus symbol `G` for hermitian lattices over $E/K$, return
 the signatures at the infinite places of `K`. For each real place, it is
@@ -1231,20 +1231,20 @@ a hermitian lattice whose global genus symbol is `G`.
 The output is given as a dictionary with keys the infinite places of `K` and value
 the corresponding signatures.
 """
-signatures(G::GenusHerm) = G.signatures
+signatures(G::HermGenus) = G.signatures
 
 @doc Markdown.doc"""
-    rank(G::GenusHerm) -> Int
+    rank(G::HermGenus) -> Int
 
 Return the rank of any hermitian lattice with global genus symbol `G`.
 """
-rank(G::GenusHerm) = G.rank
+rank(G::HermGenus) = G.rank
 
 # if G is defined over E/K, this returns the fractional ideal of K
 # obtained by multiplying p_i^s_i where the p_i's are the prime ideals
 # of the local symbols of G, and s_i's represent their respective
 # minimal scale valuation.
-function _scale(G::GenusHerm)
+function _scale(G::HermGenus)
   I = maximal_order(base_field(base_field(G)))
   for p in primes(G)
     s = minimum(scales(G[p]))
@@ -1254,14 +1254,14 @@ function _scale(G::GenusHerm)
 end
 
 @doc Markdown.doc"""
-    is_integral(G::GenusHerm) -> Bool
+    is_integral(G::HermGenus) -> Bool
 
 Return whether `G` defines a genus of integral hermitian lattices.
 """
-is_integral(G::GenusHerm) = is_integral(_scale(G))
+is_integral(G::HermGenus) = is_integral(_scale(G))
 
 @doc Markdown.doc"""
-    local_symbols(G::GenusHerm) -> Vector{LocalGenusHerm}
+    local_symbols(G::HermGenus) -> Vector{HermLocalGenus}
 
 Given a global genus symbol of hermitian lattices, return its
 associated local genus symbols.
@@ -1275,13 +1275,13 @@ local_symbols(G) = copy(G.LGS)
 ################################################################################
 
 @doc Markdown.doc"""
-    ==(G1::GenusHerm, G2::GenusHerm) -> Bool
+    ==(G1::HermGenus, G2::HermGenus) -> Bool
 
 Given two global genus symbols `G1` and `G2` for hermitian lattices, return whether
 they share the same local genus symbols. Note that equality requires `G1` and `G2`
 to be defined over the same extension $E/K$.
 """
-function ==(G1::GenusHerm, G2::GenusHerm)
+function ==(G1::HermGenus, G2::HermGenus)
   if G1.E != G2.E
     return false
   end
@@ -1313,13 +1313,13 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    orthogonal_sum(G1::GenusHerm, G2::GenusHerm) -> GenusHerm
+    orthogonal_sum(G1::HermGenus, G2::HermGenus) -> HermGenus
 
 Given two global genus symbols `G1` and `G2` for hermitian lattices over $E/K$,
 return their orthogonal sum. It corresponds to the global genus symbol of the
 orthogonal sum of respective representatives of `G1` and `G2`.
 """
-function orthogonal_sum(G1::GenusHerm, G2::GenusHerm)
+function orthogonal_sum(G1::HermGenus, G2::HermGenus)
   @req G1.E === G2.E "Genera must have same base field"
   E = G1.E
   LGS = local_genus_herm_type(G1.E)[]
@@ -1339,7 +1339,7 @@ function orthogonal_sum(G1::GenusHerm, G2::GenusHerm)
   return genus(LGS, g3)
 end
 
-Base.:(+)(G1::GenusHerm, G2::GenusHerm) = orthogonal_sum(G1, G2)
+Base.:(+)(G1::HermGenus, G2::HermGenus) = orthogonal_sum(G1, G2)
 
 ################################################################################
 #
@@ -1348,11 +1348,11 @@ Base.:(+)(G1::GenusHerm, G2::GenusHerm) = orthogonal_sum(G1, G2)
 ################################################################################
 
 @doc Markdown.doc"""
-    in(L::HermLat, G::GenusHerm) -> Bool
+    in(L::HermLat, G::HermGenus) -> Bool
 
 Return whether `G` and the global genus symbol of the hermitian lattice `L` agree.
 """
-Base.in(L::HermLat, G::GenusHerm) = genus(L) == G
+Base.in(L::HermLat, G::HermGenus) = genus(L) == G
 
 # This could be made more efficient
 
@@ -1363,7 +1363,7 @@ Base.in(L::HermLat, G::GenusHerm) = genus(L) == G
 ################################################################################
 
 @doc Markdown.doc"""
-    genus(S::Vector{LocalGenusHerm}, signatures) -> GenusHerm
+    genus(S::Vector{HermLocalGenus}, signatures) -> HermGenus
 
 Given a set of local genus symbols `S`  and a set of signatures `signatures`,
 return the corresponding global genus symbol `G`. Note that the local genus symbols
@@ -1375,9 +1375,9 @@ that the local invariants respect the product formula for Hilbert symbols.
 `signatures` can be a dictionary with keys infinite places and values the
 corresponding signatures, or a list of tuples $(::InfPlc, ::Int)$.
 """
-genus(S::Vector{LocalGenusHerm}, signatures)
+genus(S::Vector{HermLocalGenus}, signatures)
 
-function genus(L::Vector{<:LocalGenusHerm}, signatures::Dict{<:InfPlc, Int})
+function genus(L::Vector{<:HermLocalGenus}, signatures::Dict{<:InfPlc, Int})
   @assert !isempty(L)
   @assert all(N >= 0 for (_, N) in signatures)
   if !_check_global_genus(L, signatures)
@@ -1389,7 +1389,7 @@ function genus(L::Vector{<:LocalGenusHerm}, signatures::Dict{<:InfPlc, Int})
   @req all(g -> base_field(g) == E, L) "Local genus symbols must be defined over the same extension E/K"
   bd = union(support(2*maximal_order(base_field(E))), support(discriminant(maximal_order(E))))
   filter!(g -> (prime(g) in bd) || (scales(g) != Int[0]), L)
-  return GenusHerm(E, r, L, signatures)
+  return HermGenus(E, r, L, signatures)
 end
 
 function genus(L::Vector, signatures::Vector{Tuple{T, Int}}) where {T <: InfPlc}
@@ -1397,7 +1397,7 @@ function genus(L::Vector, signatures::Vector{Tuple{T, Int}}) where {T <: InfPlc}
 end
 
 @doc Markdown.doc"""
-    genus(L::HermLat) -> GenusHerm
+    genus(L::HermLat) -> HermGenus
 
 Return the global genus symbol `G` of the hermitian lattice `L`. `G` satisfies:
 - its local genus symbols correspond to those of the completions of `L` at the bad
@@ -1447,7 +1447,7 @@ end
 #
 ################################################################################
 
-function _non_norm_primes(LGS::Vector{LocalGenusHerm{S, T}}; ignore_split = false) where {S, T}
+function _non_norm_primes(LGS::Vector{HermLocalGenus{S, T}}; ignore_split = false) where {S, T}
   z = T[]
   for g in LGS
     if ignore_split && is_split(g)
@@ -1468,7 +1468,7 @@ end
 #
 ################################################################################
 
-function Base.getindex(G::GenusHerm, P::NfOrdIdl)
+function Base.getindex(G::HermGenus, P::NfOrdIdl)
   @req is_prime(P) "Ideal must be prime"
   E = base_field(G)
   i = findfirst(isequal(P), G.primes)
@@ -1547,12 +1547,12 @@ function _hermitian_form_invariants(M)
 end
 
 @doc Markdown.doc"""
-    representative(G::GenusHerm) -> HermLat
+    representative(G::HermGenus) -> HermLat
 
 Given a global genus symbol `G` for hermitian lattices over $E/K$, return a hermitian
 lattice over $E/K$ which admits `G` as global genus symbol.
 """
-function representative(G::GenusHerm)
+function representative(G::HermGenus)
   if !is_integral(G)
     s = denominator(_scale(G))
     L = representative(rescale(G, s))
@@ -1582,9 +1582,9 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    local_genera_hermitian(E::NumField, p::NfOrdIdl, rank::Int,
+    hermitian_local_genera(E::NumField, p::NfOrdIdl, rank::Int,
                            det_val::Int, min_scale::Int, max_scale::Int)
-                                                      -> Vector{LocalGenusHerm}
+                                                      -> Vector{HermLocalGenus}
 
 Return all local genus symbols for hermitian lattices over the algebra `E`, with base
 field $K$, at the prime ideal`p` of $\mathcal O_K$. Each of them has rank equal to
@@ -1592,7 +1592,7 @@ field $K$, at the prime ideal`p` of $\mathcal O_K$. Each of them has rank equal 
 and determinant `p`-valuations equal to `det_val`, where $\mathfrak P$ is a prime
 ideal of $\mathcal O_E$ lying above `p`.
 """
-function local_genera_hermitian(E, p, rank::Int, det_val::Int, min_scale::Int, max_scale::Int)
+function hermitian_local_genera(E, p, rank::Int, det_val::Int, min_scale::Int, max_scale::Int)
   is_ramified = Hecke.is_ramified(maximal_order(E), p)
   is_inert = !is_ramified && length(prime_decomposition(maximal_order(E), p)) == 1
   is_split = !is_ramified && !is_inert
@@ -1626,7 +1626,7 @@ function local_genera_hermitian(E, p, rank::Int, det_val::Int, min_scale::Int, m
 
   if !is_ramified
     # I add the 0 to make the compiler happy
-    symbols = Vector{LocalGenusHerm{typeof(E), typeof(p)}}(undef, length(scales_rks))
+    symbols = Vector{HermLocalGenus{typeof(E), typeof(p)}}(undef, length(scales_rks))
     for i in 1:length(scales_rks)
       g = scales_rks[i]
       z = Tuple{Int, Int, Int}[]
@@ -1646,7 +1646,7 @@ function local_genera_hermitian(E, p, rank::Int, det_val::Int, min_scale::Int, m
 
   scales_rks = Vector{Tuple{Int, Int}}[g for g in scales_rks if all((mod(b[1]*b[2], 2) == 0) for b in g)]
 
-  symbols = LocalGenusHerm{typeof(E), typeof(p)}[]
+  symbols = HermLocalGenus{typeof(E), typeof(p)}[]
   #hyperbolic_det = hilbert_symbol(K(-1), gen(K)^2//4 - 1, p)
   hyperbolic_det = is_local_norm(E, K(-1), p) ? 1 : -1
   if !is_dyadic(p) # non-dyadic
@@ -1724,12 +1724,12 @@ function local_genera_hermitian(E, p, rank::Int, det_val::Int, min_scale::Int, m
 end
 
 @doc Markdown.doc"""
-    genera_hermitian(E::NumField, rank::Int,
+    hermitian_genera(E::NumField, rank::Int,
                                   signatures::Dict{InfPlc, Int},
                                   determinant::Union{Hecke.NfRelOrdIdl, Hecke.NfRelOrdFracIdl};
                                   min_scale::Union{Hecke.NfRelOrdIdl, Hecke.NfRelOrdFracIdl} = is_integral(determinant) ? inv(1*order(determinant)) : determinant,
                                   max_scale::Union{Hecke.NfRelOrdIdl, Hecke.NfRelOrdFracIdl} = is_integral(determinant) ? determinant : inv(1*order(determinant)))
-                                                                                                                 -> Vector{GenusHerm}
+                                                                                                                 -> Vector{HermGenus}
 
 Return all global genus symbols for hermitian lattices over the algebra`E` with rank
 `rank`, signatures given by `signatures`, scale bounded by `max_scale` and determinant
@@ -1737,7 +1737,7 @@ class equal to `determinant`.
 
 If `max_scale == nothing`, it is set to be equal to `determinant`.
 """
-function genera_hermitian(E::Hecke.NfRel, rank::Int, signatures::Dict{<: InfPlc, Int},
+function hermitian_genera(E::Hecke.NfRel, rank::Int, signatures::Dict{<: InfPlc, Int},
                           determinant::Union{Hecke.NfRelOrdIdl, Hecke.NfRelOrdFracIdl};
                           min_scale::Union{Hecke.NfRelOrdIdl, Hecke.NfRelOrdFracIdl} = is_integral(determinant) ? 1*order(determinant) : determinant,
                           max_scale::Union{Hecke.NfRelOrdIdl, Hecke.NfRelOrdFracIdl} = is_integral(determinant) ? determinant : 1*order(determinant))
@@ -1771,7 +1771,7 @@ function genera_hermitian(E::Hecke.NfRel, rank::Int, signatures::Dict{<: InfPlc,
       minscale_p = div(minscale_p, 2)
       maxscale_p = div(maxscale_p, 2)
     end
-    lgh = local_genera_hermitian(E, p, rank, det_val, minscale_p, maxscale_p)
+    lgh = hermitian_local_genera(E, p, rank, det_val, minscale_p, maxscale_p)
     !isempty(lgh) && push!(local_symbols, lgh)
   end
 
@@ -1782,7 +1782,7 @@ function genera_hermitian(E::Hecke.NfRel, rank::Int, signatures::Dict{<: InfPlc,
     b = _check_global_genus(c, signatures)
     if b
       filter!(g -> (prime(g) in bd) || (scales(g) != Int[0]), c)
-      push!(res, GenusHerm(E, rank, c, signatures))
+      push!(res, HermGenus(E, rank, c, signatures))
     end
   end
 
@@ -1798,27 +1798,27 @@ end
 # TODO: this is not efficient, should be done by working with valuations
 # directly on the symbols of g
 @doc Markdown.doc"""
-    rescale(g::LocalGenusHerm, a::Union{FieldElem, RationalUnion})
-                                                              -> LocalGenusHerm
+    rescale(g::HermLocalGenus, a::Union{FieldElem, RationalUnion})
+                                                              -> HermLocalGenus
 
 Given a local genus symbol `G` of hermitian lattices and an element `a` lying
 in the base field `E` of `g`, return the local genus symbol at the prime ideal `p`
 associated to `g` of any representative of `g` rescaled by `a`.
 """
-function rescale(g::LocalGenusHerm, a::Union{FieldElem, RationalUnion})
+function rescale(g::HermLocalGenus, a::Union{FieldElem, RationalUnion})
   L = representative(g)
   L = rescale(L, a)
   return genus(L, prime(g))
 end
 
 @doc Markdown.doc"""
-    rescale(G::GenusHerm, a::Union{FieldElem, RationalUnion}) -> GenusHerm
+    rescale(G::HermGenus, a::Union{FieldElem, RationalUnion}) -> HermGenus
 
 Given a global genus symbol `G` of hermitian lattices and an element `a` lying
 in the base field `E` of `G`, return the global genus symbol of any representative
 of `G` rescaled by `a`.
 """
-function rescale(G::GenusHerm, a::Union{FieldElem, RationalUnion})
+function rescale(G::HermGenus, a::Union{FieldElem, RationalUnion})
   @req typeof(a) <: RationalUnion || parent(a) === base_field(base_field(G)) "a must be a fixed element in the base field of G under the associated involution"
   E = base_field(G)
   K = base_field(E)
@@ -1835,6 +1835,6 @@ function rescale(G::GenusHerm, a::Union{FieldElem, RationalUnion})
     end
     sig[p] = r-sig[p]
   end
-  return GenusHerm(E, r, LGS, sig)
+  return HermGenus(E, r, LGS, sig)
 end
 

--- a/src/QuadForm/Herm/GenusRep.jl
+++ b/src/QuadForm/Herm/GenusRep.jl
@@ -701,12 +701,12 @@ function genus_representatives(L::HermLat; max = inf, use_auto::Bool = true,
 end
 
 @doc Markdown.doc"""
-    representatives(G::GenusHerm) -> Vector{HermLat}
+    representatives(G::HermGenus) -> Vector{HermLat}
 
 Given a global genus symbol `G` for hermitian lattices, return representatives
 for the isometry classes of hermitian lattices in `G`.
 """
-function representatives(G::GenusHerm)
+function representatives(G::HermGenus)
   return genus_representatives(representative(G))
 end
 

--- a/src/QuadForm/Herm/Types.jl
+++ b/src/QuadForm/Herm/Types.jl
@@ -1,5 +1,5 @@
 # Hermitian lattices
-@attributes mutable struct HermLat{S, T, U, V, W} <: AbsLat{S}
+@attributes mutable struct HermLat{S, T, U, V, W} <: AbstractLat{S}
   space::HermSpace{S, T, U, W}
   pmat::V
   gram::U

--- a/src/QuadForm/IO.jl
+++ b/src/QuadForm/IO.jl
@@ -5,11 +5,11 @@
 ################################################################################
 
 # This is helpful to construct code for the tests.
-function to_hecke(L::AbsLat; target = "L", skip_field = false)
+function to_hecke(L::AbstractLat; target = "L", skip_field = false)
   return to_hecke(stdout, L, target = target, skip_field = skip_field)
 end
 
-function to_hecke_string(L::AbsLat; target = "L", skip_field = false)
+function to_hecke_string(L::AbstractLat; target = "L", skip_field = false)
   b = IOBuffer()
   to_hecke(b, L, target = target, skip_field = skip_field)
   return String(take!(b))
@@ -88,11 +88,11 @@ end
 #
 ################################################################################
 
-function to_magma(L::AbsLat; target = "L")
+function to_magma(L::AbstractLat; target = "L")
   return to_magma(stdout, L, target = target)
 end
 
-function to_magma_string(L::AbsLat; target = "L")
+function to_magma_string(L::AbstractLat; target = "L")
   b = IOBuffer()
   to_magma(b, L, target = target)
   return String(take!(b))
@@ -207,11 +207,11 @@ function to_magma(io::IO, L::ZLat; target = "L")
   println(io, target, " := ", "LatticeWithBasis(B, G);")
 end
 
-function to_sage(L::AbsLat; target = "L")
+function to_sage(L::AbstractLat; target = "L")
   return to_sage(stdout, L, target = target)
 end
 
-function to_sage_string(L::AbsLat; target = "L")
+function to_sage_string(L::AbstractLat; target = "L")
   b = IOBuffer()
   to_sage(b, L, target = target)
   return String(take!(b))

--- a/src/QuadForm/Lattices.jl
+++ b/src/QuadForm/Lattices.jl
@@ -15,14 +15,14 @@ export *, +, absolute_basis, absolute_basis_matrix, ambient_space,
 export HermLat, QuadLat
 
 # aliases for deprecation
-is_equivalent(U::AbsLat, V::AbsLat) = is_isometric(U, V)
-is_equivalent(U::AbsLat, V::AbsLat, p) = is_isometric(U, V, p)
-is_rationally_equivalent(U::AbsLat, V::AbsLat) = is_rationally_isometric(U, V)
-is_rationally_equivalent(U::AbsLat, V::AbsLat, p) = is_rationally_isometric(U, V, p)
-is_equivalent(U::AbsSpace, V::AbsSpace) = is_isometric(U, V)
-is_equivalent(U::AbsSpace, V::AbsSpace, p) = is_isometric(U, V, p)
-is_equivalent_with_isometry(U::AbsLat, V::AbsLat) = is_isometric_with_isometry(U, V)
-is_equivalent_with_isometry(U::AbsSpace, V::AbsSpace) = is_isometric_with_isometry(U, V)
+is_equivalent(U::AbstractLat, V::AbstractLat) = is_isometric(U, V)
+is_equivalent(U::AbstractLat, V::AbstractLat, p) = is_isometric(U, V, p)
+is_rationally_equivalent(U::AbstractLat, V::AbstractLat) = is_rationally_isometric(U, V)
+is_rationally_equivalent(U::AbstractLat, V::AbstractLat, p) = is_rationally_isometric(U, V, p)
+is_equivalent(U::AbstractSpace, V::AbstractSpace) = is_isometric(U, V)
+is_equivalent(U::AbstractSpace, V::AbstractSpace, p) = is_isometric(U, V, p)
+is_equivalent_with_isometry(U::AbstractLat, V::AbstractLat) = is_isometric_with_isometry(U, V)
+is_equivalent_with_isometry(U::AbstractSpace, V::AbstractSpace) = is_isometric_with_isometry(U, V)
 
 ################################################################################
 #
@@ -41,21 +41,21 @@ add_assert_scope(:Lattice)
 ################################################################################
 
 @doc Markdown.doc"""
-    has_ambient_space(L::AbsLat) -> Bool
+    has_ambient_space(L::AbstractLat) -> Bool
 
 Return whether the ambient space of the lattice `L` is set.
 """
-function has_ambient_space(L::AbsLat)
+function has_ambient_space(L::AbstractLat)
   return isdefined(L, :space)
 end
 
 @doc Markdown.doc"""
-    ambient_space(L::AbsLat) -> AbsSpace
+    ambient_space(L::AbstractLat) -> AbstractSpace
 
 Return the ambient space of the lattice `L`. If the ambient space is not known, an
 error is raised.
 """
-function ambient_space(L::AbsLat)
+function ambient_space(L::AbstractLat)
   if !has_ambient_space(L)
     B = matrix(pseudo_matrix(L))
     @assert isone(B)
@@ -71,11 +71,11 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    rational_span(L::AbsLat) -> AbsSpace
+    rational_span(L::AbstractLat) -> AbstractSpace
 
 Return the rational span of the lattice `L`.
 """
-rational_span(::AbsLat)
+rational_span(::AbstractLat)
 
 ################################################################################
 #
@@ -84,11 +84,11 @@ rational_span(::AbsLat)
 ################################################################################
 
 @doc Markdown.doc"""
-    diagonal_of_rational_span(L::AbsLat) -> Vector
+    diagonal_of_rational_span(L::AbstractLat) -> Vector
 
 Return the diagonal of the rational span of the lattice `L`.
 """
-function diagonal_of_rational_span(L::AbsLat)
+function diagonal_of_rational_span(L::AbstractLat)
   D, _ = _gram_schmidt(gram_matrix_of_rational_span(L), involution(L))
   return diagonal(D)
 end
@@ -100,18 +100,18 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    pseudo_matrix(L::AbsLat) -> PMat
+    pseudo_matrix(L::AbstractLat) -> PMat
 
 Return a basis pseudo-matrix of the lattice `L`.
 """
-pseudo_matrix(L::AbsLat) = L.pmat
+pseudo_matrix(L::AbstractLat) = L.pmat
 
 @doc Markdown.doc"""
-    pseudo_basis(L::AbsLat) -> Vector{Tuple{Vector, Ideal}}
+    pseudo_basis(L::AbstractLat) -> Vector{Tuple{Vector, Ideal}}
 
 Return a pseudo-basis of the lattice `L`.
 """
-function pseudo_basis(L::AbsLat)
+function pseudo_basis(L::AbstractLat)
   M = matrix(pseudo_matrix(L))
   LpM = pseudo_matrix(L)
   O = base_ring(LpM)
@@ -124,67 +124,67 @@ function pseudo_basis(L::AbsLat)
 end
 
 @doc Markdown.doc"""
-    coefficient_ideals(L::AbsLat) -> Vector{NfOrdIdl}
+    coefficient_ideals(L::AbstractLat) -> Vector{NfOrdIdl}
 
 Return the coefficient ideals of a pseudo-basis of the lattice `L`.
 """
-coefficient_ideals(L::AbsLat) = coefficient_ideals(pseudo_matrix(L))
+coefficient_ideals(L::AbstractLat) = coefficient_ideals(pseudo_matrix(L))
 
 @doc Markdown.doc"""
-    basis_matrix_of_rational_span(L::AbsLat) -> MatElem
+    basis_matrix_of_rational_span(L::AbstractLat) -> MatElem
 
 Return a basis matrix of the rational span of the lattice `L`.
 """
-basis_matrix_of_rational_span(L::AbsLat) = matrix(pseudo_matrix(L))
+basis_matrix_of_rational_span(L::AbstractLat) = matrix(pseudo_matrix(L))
 
 @doc Markdown.doc"""
-    base_field(L::AbsLat) -> Field
+    base_field(L::AbstractLat) -> Field
 
 Return the algebra over which the rational span of the lattice `L` is defined.
 """
-base_field(L::AbsLat) = L.base_algebra
+base_field(L::AbstractLat) = L.base_algebra
 
 @doc Markdown.doc"""
-    base_ring(L::AbsLat) -> Ring
+    base_ring(L::AbstractLat) -> Ring
 
 Return the order over which the lattice `L` is defined.
 """
-base_ring(L::AbsLat) = base_ring(L.pmat)
+base_ring(L::AbstractLat) = base_ring(L.pmat)
 
 @doc Markdown.doc"""
-    fixed_field(L::AbsLat) -> Field
+    fixed_field(L::AbstractLat) -> Field
 
 Returns the fixed field of the involution of the lattice `L`.
 """
-fixed_field(L::AbsLat) = fixed_field(rational_span(L))
+fixed_field(L::AbstractLat) = fixed_field(rational_span(L))
 
 @doc Markdown.doc"""
-    fixed_ring(L::AbsLat) -> Ring
+    fixed_ring(L::AbstractLat) -> Ring
 
 Return the maximal order in the fixed field of the lattice `L`.
 """
-fixed_ring(L::AbsLat) = maximal_order(fixed_field(L))
+fixed_ring(L::AbstractLat) = maximal_order(fixed_field(L))
 
 @doc Markdown.doc"""
-    involution(L::AbsLat) -> Map
+    involution(L::AbstractLat) -> Map
 
 Return the involution of the rational span of the lattice `L`.
 """
-involution(::AbsLat)
+involution(::AbstractLat)
 
 @doc Markdown.doc"""
-    rank(L::AbsLat) -> Int
+    rank(L::AbstractLat) -> Int
 
 Return the rank of the underlying module of the lattice `L`.
 """
-rank(L::AbsLat) = dim(rational_span(L))
+rank(L::AbstractLat) = dim(rational_span(L))
 
 @doc Markdown.doc"""
-    degree(L::AbsLat) -> Int
+    degree(L::AbstractLat) -> Int
 
 Return the dimension of the ambient space of the lattice `L`.
 """
-function degree(L::AbsLat)
+function degree(L::AbstractLat)
   if isdefined(L, :space)
     return dim(L.space)
   else
@@ -193,11 +193,11 @@ function degree(L::AbsLat)
 end
 
 @doc Markdown.doc"""
-    is_sublattice(L::AbsLat, M::AbsLat) -> Bool
+    is_sublattice(L::AbstractLat, M::AbstractLat) -> Bool
 
 Return whether `M` is a sublattice of the lattice `L`.
 """
-function is_sublattice(L::AbsLat, M::AbsLat)
+function is_sublattice(L::AbstractLat, M::AbstractLat)
   if L === M
     return true
   end
@@ -210,11 +210,11 @@ function is_sublattice(L::AbsLat, M::AbsLat)
 end
 
 @doc Markdown.doc"""
-    issubset(M::AbsLat, L::AbsLat) -> Bool
+    issubset(M::AbstractLat, L::AbstractLat) -> Bool
 
 Return whether `M` is a subset of the lattice `L`.
 """
-Base.issubset(M::AbsLat, L::AbsLat) = is_sublattice(L, M)
+Base.issubset(M::AbstractLat, L::AbstractLat) = is_sublattice(L, M)
 
 ################################################################################
 #
@@ -223,7 +223,7 @@ Base.issubset(M::AbsLat, L::AbsLat) = is_sublattice(L, M)
 ################################################################################
 
 # Return a lowerleft pseudo hnf
-function _pseudo_hnf(L::AbsLat)
+function _pseudo_hnf(L::AbstractLat)
   get_attribute!(L, :pseudo_hnf) do
     pseudo_hnf(pseudo_matrix(L), :lowerleft)
   end::typeof(L.pmat)
@@ -235,7 +235,7 @@ end
 #
 ################################################################################
 
-function Base.:(==)(L::AbsLat, M::AbsLat)
+function Base.:(==)(L::AbstractLat, M::AbstractLat)
   if L === M
     return true
   end
@@ -253,11 +253,11 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    gram_matrix_of_rational_span(L::AbsLat) -> MatElem
+    gram_matrix_of_rational_span(L::AbstractLat) -> MatElem
 
 Return the Gram matrix of the rational span of the lattice `L`.
 """
-function gram_matrix_of_rational_span(L::AbsLat)
+function gram_matrix_of_rational_span(L::AbstractLat)
   if isdefined(L, :gram)
     return L.gram
   else
@@ -275,14 +275,14 @@ end
 # Steinitz form is not pretty
 
 @doc Markdown.doc"""
-    generators(L::AbsLat; minimal = false) -> Vector{Vector}
+    generators(L::AbstractLat; minimal = false) -> Vector{Vector}
 
 Return a set of generators of the lattice `L` over the base ring of `L`.
 
 If `minimal == true`, the number of generators is minimal. Note that computing
 minimal generators is expensive.
 """
-function generators(L::AbsLat; minimal::Bool = false)
+function generators(L::AbstractLat; minimal::Bool = false)
   K = nf(base_ring(L))
   T = elem_type(K)
   if !minimal
@@ -355,7 +355,7 @@ end
 ###############################################################################
 
 @doc Markdown.doc"""
-    lattice(V::AbsSpace, B::PMat ; check::Bool = true) -> AbsLat
+    lattice(V::AbstractSpace, B::PMat ; check::Bool = true) -> AbstractLat
 
 Given an ambient space `V` and a pseudo-matrix `B`, return the lattice spanned
 by the pseudo-matrix `B` inside `V`. If `V` is hermitian (resp. quadratic) then
@@ -364,10 +364,10 @@ the output is a hermitian (resp. quadratic) lattice.
 By default, `B` is checked to be of full rank. This test can be disabled by setting
 `check` to false.
 """
-lattice(V::AbsSpace, B::PMat ; check::Bool = true)
+lattice(V::AbstractSpace, B::PMat ; check::Bool = true)
 
 @doc Markdown.doc"""
-    lattice(V::AbsSpace, basis::MatElem ; check::Bool = true) -> AbsLat
+    lattice(V::AbstractSpace, basis::MatElem ; check::Bool = true) -> AbstractLat
 
 Given an ambient space `V` and a matrix `basis`, return the lattice spanned
 by the rows of `basis` inside `V`. If `V` is hermitian (resp. quadratic) then
@@ -376,10 +376,10 @@ the output is a hermitian (resp. quadratic) lattice.
 By default, `basis` is checked to be of full rank. This test can be disabled by setting
 `check` to false.
 """
-lattice(V::AbsSpace, basis::MatElem ; check::Bool = true) = lattice(V, pseudo_matrix(basis), check = check)
+lattice(V::AbstractSpace, basis::MatElem ; check::Bool = true) = lattice(V, pseudo_matrix(basis), check = check)
 
 @doc Markdown.doc"""
-    lattice(V::AbsSpace, gens::Vector) -> AbsLat
+    lattice(V::AbstractSpace, gens::Vector) -> AbstractLat
 
 Given an ambient space `V` and a list of generators `gens`, return the lattice
 spanned by `gens` in `V`. If `V` is hermitian (resp. quadratic) then the output
@@ -387,7 +387,7 @@ is a hermitian (resp. quadratic) lattice.
 
 If `gens` is empty, the function returns the zero lattice in `V`.
 """
-function lattice(V::Hecke.AbsSpace, gens::Vector)
+function lattice(V::Hecke.AbstractSpace, gens::Vector)
   if length(gens) == 0
     pm = pseudo_matrix(matrix(base_ring(V), 0, dim(V), []))
     return lattice(V, pm, check = false)
@@ -415,13 +415,13 @@ function lattice(V::Hecke.AbsSpace, gens::Vector)
 end
 
 @doc Markdown.doc"""
-    lattice(V::AbsSpace) -> AbsLat
+    lattice(V::AbstractSpace) -> AbstractLat
 
 Given an ambient space `V`, return the lattice with the standard basis
 matrix. If `V` is hermitian (resp. quadratic) then the output is a hermitian
 (resp. quadratic) lattice.
 """
-lattice(V::AbsSpace) = lattice(V, identity_matrix(base_ring(V), rank(V)), check = false)
+lattice(V::AbstractSpace) = lattice(V, identity_matrix(base_ring(V), rank(V)), check = false)
 
 ################################################################################
 #
@@ -430,14 +430,14 @@ lattice(V::AbsSpace) = lattice(V, identity_matrix(base_ring(V), rank(V)), check 
 ################################################################################
 
 @doc Markdown.doc"""
-    gram_matrix_of_generators(L::AbsLat; minimal::Bool = false) -> MatElem
+    gram_matrix_of_generators(L::AbstractLat; minimal::Bool = false) -> MatElem
 
 Return the Gram matrix of a generating set of the lattice `L`.
 
 If `minimal == true`, then a minimal generating set is used. Note that computing
 minimal generators is expensive.
 """
-function gram_matrix_of_generators(L::AbsLat; minimal::Bool = false)
+function gram_matrix_of_generators(L::AbstractLat; minimal::Bool = false)
   m = generators(L, minimal = minimal)
   M = matrix(nf(base_ring(L)), m)
   return gram_matrix(ambient_space(L), M)
@@ -450,12 +450,12 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    discriminant(L::AbsLat) -> NfOrdFracIdl
+    discriminant(L::AbstractLat) -> NfOrdFracIdl
 
 Return the discriminant of the lattice `L`, that is, the generalized index ideal
 $[L^\# : L]$.
 """
-function discriminant(L::AbsLat)
+function discriminant(L::AbstractLat)
   d = det(gram_matrix_of_rational_span(L))
   v = involution(L)
   C = coefficient_ideals(L)
@@ -470,20 +470,20 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    hasse_invariant(L::AbsLat, p::Union{InfPlc, NfOrdIdl}) -> Int
+    hasse_invariant(L::AbstractLat, p::Union{InfPlc, NfOrdIdl}) -> Int
 
 Return the Hasse invariant of the rational span of the lattice `L` at the place `p`.
 The lattice must be quadratic.
 """
-hasse_invariant(L::AbsLat, p)
+hasse_invariant(L::AbstractLat, p)
 
 @doc Markdown.doc"""
-    witt_invariant(L::AbsLat, p::Union{InfPlc, NfOrdIdl}) -> Int
+    witt_invariant(L::AbstractLat, p::Union{InfPlc, NfOrdIdl}) -> Int
 
 Return the Witt invariant of the rational span of the lattice `L` at the place `p`.
 The lattice must be quadratic.
 """
-witt_invariant(L::AbsLat, p)
+witt_invariant(L::AbstractLat, p)
 
 ################################################################################
 #
@@ -492,28 +492,28 @@ witt_invariant(L::AbsLat, p)
 ################################################################################
 
 @doc Markdown.doc"""
-    is_rationally_isometric(L::AbsLat, M::AbsLat, p::Union{InfPlc, NfAbsOrdIdl})
+    is_rationally_isometric(L::AbstractLat, M::AbstractLat, p::Union{InfPlc, NfAbsOrdIdl})
                                                                          -> Bool
 
 Return whether the rational spans of the lattices `L` and `M` are isometric over
 the completion at the place `p`.
 """
-is_rationally_isometric(::AbsLat, ::AbsLat, ::NfAbsOrdIdl)
+is_rationally_isometric(::AbstractLat, ::AbstractLat, ::NfAbsOrdIdl)
 
-function is_rationally_isometric(L::AbsLat, M::AbsLat, p::NfAbsOrdIdl)
+function is_rationally_isometric(L::AbstractLat, M::AbstractLat, p::NfAbsOrdIdl)
   return is_isometric(rational_span(L), rational_span(M), p)
 end
 
-function is_rationally_isometric(L::AbsLat, M::AbsLat, p::InfPlc)
+function is_rationally_isometric(L::AbstractLat, M::AbstractLat, p::InfPlc)
   return is_isometric(rational_span(L), rational_span(M), p)
 end
 
 @doc Markdown.doc"""
-    is_rationally_isometric(L::AbsLat, M::AbsLat) -> Bool
+    is_rationally_isometric(L::AbstractLat, M::AbstractLat) -> Bool
 
 Return whether the rational spans of the lattices `L` and `M` are isometric.
 """
-function is_rationally_isometric(L::AbsLat, M::AbsLat)
+function is_rationally_isometric(L::AbstractLat, M::AbstractLat)
   return is_isometric(rational_span(L), rational_span(M))
 end
 
@@ -524,33 +524,33 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    is_positive_definite(L::AbsLat) -> Bool
+    is_positive_definite(L::AbstractLat) -> Bool
 
 Return whether the rational span of the lattice `L` is positive definite.
 """
-is_positive_definite(L::AbsLat) = is_positive_definite(rational_span(L))
+is_positive_definite(L::AbstractLat) = is_positive_definite(rational_span(L))
 
 @doc Markdown.doc"""
-    is_negative_definite(L::AbsLat) -> Bool
+    is_negative_definite(L::AbstractLat) -> Bool
 
 Return whether the rational span of the lattice `L` is negative definite.
 """
-is_negative_definite(L::AbsLat) = is_negative_definite(rational_span(L))
+is_negative_definite(L::AbstractLat) = is_negative_definite(rational_span(L))
 
 @doc Markdown.doc"""
-    is_definite(L::AbsLat) -> Bool
+    is_definite(L::AbstractLat) -> Bool
 
 Return whether the rational span of the lattice `L` is definite.
 """
-@attr Bool is_definite(L::AbsLat) = is_definite(rational_span(L))
+@attr Bool is_definite(L::AbstractLat) = is_definite(rational_span(L))
 
 @doc Markdown.doc"""
-    can_scale_totally_positive(L::AbsLat) -> Bool, NumFieldElem
+    can_scale_totally_positive(L::AbstractLat) -> Bool, NumFieldElem
 
 Return whether there is a totally positive rescaled lattice of the lattice `L`.
 If so, the second returned value is an element $a$ such that $L^a$ is totally positive.
 """
-function can_scale_totally_positive(L::AbsLat)
+function can_scale_totally_positive(L::AbstractLat)
   a = _isdefinite(rational_span(L))
   if iszero(a)
     return false, a
@@ -568,15 +568,15 @@ end
 # Some of these assertions can be relaxed, in particular in the scaling
 
 @doc Markdown.doc"""
-    +(L::AbsLat, M::AbsLat) -> AbsLat
+    +(L::AbstractLat, M::AbstractLat) -> AbstractLat
 
 Return the sum of the lattices `L` and `M`.
 
 The lattices `L` and `M` must have the same ambient space.
 """
-Base.:(+)(::AbsLat, ::AbsLat)
+Base.:(+)(::AbstractLat, ::AbstractLat)
 
-function Base.:(+)(L::T, M::T) where {T <: AbsLat}
+function Base.:(+)(L::T, M::T) where {T <: AbstractLat}
   @assert has_ambient_space(L) && has_ambient_space(M)
   @assert ambient_space(L) === ambient_space(M)
   V = ambient_space(L)
@@ -592,15 +592,15 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    intersect(L::AbsLat, M::AbsLat) -> AbsLat
+    intersect(L::AbstractLat, M::AbstractLat) -> AbstractLat
 
 Return the intersection of the lattices `L` and `M`.
 
 The lattices `L` and `M` must have the same ambient space.
 """
-intersect(::AbsLat, ::AbsLat)
+intersect(::AbstractLat, ::AbstractLat)
 
-function intersect(L::T, M::T) where T <: AbsLat
+function intersect(L::T, M::T) where T <: AbstractLat
   @assert has_ambient_space(L) && has_ambient_space(M)
   @req ambient_space(L) === ambient_space(M) "Lattices must be in the same ambient space"
   V = ambient_space(L)
@@ -612,7 +612,7 @@ function intersect(L::T, M::T) where T <: AbsLat
   return lattice_in_same_ambient_space(L, m)
 end
 
-function _intersect_via_restriction_of_scalars(L::AbsLat, M::AbsLat)
+function _intersect_via_restriction_of_scalars(L::AbstractLat, M::AbstractLat)
   @assert has_ambient_space(L) && has_ambient_space(M)
   @assert ambient_space(L) === ambient_space(M)
   @assert !(L isa ZLat)
@@ -631,11 +631,11 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    *(a::NumFieldElem, L::AbsLat) -> AbsLat
+    *(a::NumFieldElem, L::AbstractLat) -> AbstractLat
 
 Return the lattice $aL$ inside the ambient space of the lattice `L`.
 """
-function Base.:(*)(a::NumFieldElem, L::AbsLat)
+function Base.:(*)(a::NumFieldElem, L::AbstractLat)
   @assert has_ambient_space(L)
   O = maximal_order(parent(a))
   m = _module_scale_ideal(a*O, pseudo_matrix(L))
@@ -647,26 +647,26 @@ function Base.:(*)(L::QuadLat, a)
 end
 
 @doc Markdown.doc"""
-    *(a::NumFieldOrdIdl, L::AbsLat) -> AbsLat
+    *(a::NumFieldOrdIdl, L::AbstractLat) -> AbstractLat
 
 Return the lattice $aL$ inside the ambient space of the lattice `L`.
 """
-Base.:(*)(::NumFieldOrdIdl, ::AbsLat)
+Base.:(*)(::NumFieldOrdIdl, ::AbstractLat)
 
-function Base.:(*)(a::Union{NfRelOrdIdl, NfAbsOrdIdl}, L::AbsLat)
+function Base.:(*)(a::Union{NfRelOrdIdl, NfAbsOrdIdl}, L::AbstractLat)
   @assert has_ambient_space(L)
   m = _module_scale_ideal(a, pseudo_matrix(L))
   return lattice_in_same_ambient_space(L, m)
 end
 
 @doc Markdown.doc"""
-    *(a::NumFieldOrdFracIdl, L::AbsLat) -> AbsLat
+    *(a::NumFieldOrdFracIdl, L::AbstractLat) -> AbstractLat
 
 Return the lattice $aL$ inside the ambient space of the lattice `L`.
 """
-Base.:(*)(::NumFieldOrdFracIdl, ::AbsLat)
+Base.:(*)(::NumFieldOrdFracIdl, ::AbstractLat)
 
-function Base.:(*)(a::Union{NfRelOrdFracIdl, NfAbsOrdFracIdl}, L::AbsLat)
+function Base.:(*)(a::Union{NfRelOrdFracIdl, NfAbsOrdFracIdl}, L::AbstractLat)
   @assert has_ambient_space(L)
   m = _module_scale_ideal(a, pseudo_matrix(L))
   return lattice_in_same_ambient_space(L, m)
@@ -679,11 +679,11 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    absolute_basis(L::AbsLat) -> Vector
+    absolute_basis(L::AbstractLat) -> Vector
 
 Return a $\mathbf{Z}$-basis of the lattice `L`.
 """
-function absolute_basis(L::AbsLat)
+function absolute_basis(L::AbstractLat)
   pb = pseudo_basis(L)
   z = Vector{Vector{elem_type(base_field(L))}}()
   for (v, a) in pb
@@ -702,11 +702,11 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    absolute_basis_matrix(L::AbsLat) -> MatElem
+    absolute_basis_matrix(L::AbstractLat) -> MatElem
 
 Return a $\mathbf{Z}$-basis matrix of the lattice `L`.
 """
-function absolute_basis_matrix(L::AbsLat)
+function absolute_basis_matrix(L::AbstractLat)
   pb = pseudo_basis(L)
   E = base_field(L)
   c = ncols(matrix(pseudo_matrix(L)))
@@ -730,12 +730,12 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    norm(L::AbsLat) -> NfOrdFracIdl
+    norm(L::AbstractLat) -> NfOrdFracIdl
 
 Return the norm of the lattice `L`. This is a fractional ideal of the fixed field
 of `L`.
 """
-norm(::AbsLat)
+norm(::AbstractLat)
 
 ################################################################################
 #
@@ -744,11 +744,11 @@ norm(::AbsLat)
 ################################################################################
 
 @doc Markdown.doc"""
-    scale(L::AbsLat) -> NfOrdFracIdl
+    scale(L::AbstractLat) -> NfOrdFracIdl
 
 Return the scale of the lattice `L`.
 """
-scale(L::AbsLat)
+scale(L::AbstractLat)
 
 ################################################################################
 #
@@ -757,14 +757,14 @@ scale(L::AbsLat)
 ################################################################################
 
 @doc Markdown.doc"""
-    rescale(L::AbsLat, a::NumFieldElem) -> AbsLat
+    rescale(L::AbstractLat, a::NumFieldElem) -> AbstractLat
 
 Return the rescaled lattice $L^a$. Note that this has a different ambient
 space than the lattice `L`.
 """
-rescale(::AbsLat, ::NumFieldElem)
+rescale(::AbstractLat, ::NumFieldElem)
 
-Base.:(^)(L::AbsLat, a::RingElement) = rescale(L, a)
+Base.:(^)(L::AbstractLat, a::RingElement) = rescale(L, a)
 
 ################################################################################
 #
@@ -773,11 +773,11 @@ Base.:(^)(L::AbsLat, a::RingElement) = rescale(L, a)
 ################################################################################
 
 @doc Markdown.doc"""
-    is_integral(L::AbsLat) -> Bool
+    is_integral(L::AbstractLat) -> Bool
 
 Return whether the lattice `L` is integral.
 """
-function is_integral(L::AbsLat)
+function is_integral(L::AbstractLat)
   return is_integral(scale(L))
 end
 
@@ -788,11 +788,11 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    dual(L::AbsLat) -> AbsLat
+    dual(L::AbstractLat) -> AbstractLat
 
 Return the dual lattice of the lattice `L`.
 """
-dual(::AbsLat)
+dual(::AbstractLat)
 
 ################################################################################
 #
@@ -801,11 +801,11 @@ dual(::AbsLat)
 ################################################################################
 
 @doc Markdown.doc"""
-    volume(L::AbsLat) -> NfOrdFracIdl
+    volume(L::AbstractLat) -> NfOrdFracIdl
 
 Return the volume of the lattice `L`.
 """
-function volume(L::AbsLat)
+function volume(L::AbstractLat)
   return discriminant(L)
 end
 
@@ -816,13 +816,13 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    is_modular(L::AbsLat) -> Bool, NfOrdFracIdl
+    is_modular(L::AbstractLat) -> Bool, NfOrdFracIdl
 
 Return whether the lattice `L` is modular. In this case, the second returned value
 is a fractional ideal $\mathfrak a$ of the base algebra of `L` such that
 $\mathfrak a L^\# = L$, where $L^\#$ is the dual of `L`.
 """
-function is_modular(L::AbsLat)
+function is_modular(L::AbstractLat)
   a = scale(L)
   if volume(L) == a^rank(L)
     return true, a
@@ -832,15 +832,15 @@ function is_modular(L::AbsLat)
 end
 
 @doc Markdown.doc"""
-    is_modular(L::AbsLat, p::NfOrdIdl) -> Bool, Int
+    is_modular(L::AbstractLat, p::NfOrdIdl) -> Bool, Int
 
 Return whether the completion $L_{p}$ of the lattice `L` at the prime ideal `p`
 is modular. If it is the case the second returned value is an integer `v` such
 that $L_{p}$ is $p^v$-modular.
 """
-is_modular(::AbsLat, p)
+is_modular(::AbstractLat, p)
 
-function is_modular(L::AbsLat{<: NumField}, p)
+function is_modular(L::AbstractLat{<: NumField}, p)
   a = scale(L)
   if base_ring(L) == order(p)
     v = valuation(a, p)
@@ -868,7 +868,7 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    local_basis_matrix(L::AbsLat, p::NfOrdIdl; type = :any) -> MatElem
+    local_basis_matrix(L::AbstractLat, p::NfOrdIdl; type = :any) -> MatElem
 
 Given a prime ideal `p` and a lattice `L`, return a basis matrix of a lattice
 `M` such that $M_{p} = L_{p}$. Note that if `p` is an ideal in the base ring of
@@ -880,7 +880,7 @@ base ring of the order of `p`).
 - If `type == :any`, there may not be any containment relation between `M` and
   `L`.
 """
-function local_basis_matrix(L::AbsLat, p; type::Symbol = :any)
+function local_basis_matrix(L::AbstractLat, p; type::Symbol = :any)
   R = base_ring(L)
   S = order(p)
   if R === S
@@ -918,7 +918,7 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    jordan_decomposition(L::AbsLat, p::NfOrdIdl)
+    jordan_decomposition(L::AbstractLat, p::NfOrdIdl)
                                 -> Vector{MatElem}, Vector{MatElem}, Vector{Int}
 
 Return a Jordan decomposition of the completion of the lattice `L` at a prime
@@ -929,7 +929,7 @@ the same length $r$. The completions of the row spans of the matrices $M_i$
 yield a Jordan decomposition of $L_{p}$ into modular sublattices
 $L_i$ with Gram matrices $G_i$ and scale of $p$-adic valuation $s_i$.
 """
-jordan_decomposition(L::AbsLat, p::NfOrdIdl)
+jordan_decomposition(L::AbstractLat, p::NfOrdIdl)
 
 ################################################################################
 #
@@ -938,12 +938,12 @@ jordan_decomposition(L::AbsLat, p::NfOrdIdl)
 ################################################################################
 
 @doc Markdown.doc"""
-    is_locally_isometric(L::AbsLat, M::AbsLat, p::NfOrdIdl) -> Bool
+    is_locally_isometric(L::AbstractLat, M::AbstractLat, p::NfOrdIdl) -> Bool
 
 Return whether the completions of the lattices `L` and `M` at the prime ideal
 `p` are isometric.
 """
-is_locally_isometric(::AbsLat, ::AbsLat, ::NfOrdIdl)
+is_locally_isometric(::AbstractLat, ::AbstractLat, ::NfOrdIdl)
 
 ################################################################################
 #
@@ -952,12 +952,12 @@ is_locally_isometric(::AbsLat, ::AbsLat, ::NfOrdIdl)
 ################################################################################
 
 @doc Markdown.doc"""
-    is_isotropic(L::AbsLat, p::Union{NfOrdIdl, InfPlc}) -> Bool
+    is_isotropic(L::AbstractLat, p::Union{NfOrdIdl, InfPlc}) -> Bool
 
 Return whether the completion of the lattice `L` at the place `p` is
 isotropic.
 """
-is_isotropic(L::AbsLat, p) = is_isotropic(rational_span(L), p)
+is_isotropic(L::AbstractLat, p) = is_isotropic(rational_span(L), p)
 
 ################################################################################
 #
@@ -966,7 +966,7 @@ is_isotropic(L::AbsLat, p) = is_isotropic(rational_span(L), p)
 ################################################################################
 
 @doc Markdown.doc"""
-    restrict_scalars(L::AbsLat, K::FlintRationalField,
+    restrict_scalars(L::AbstractLat, K::FlintRationalField,
                                 alpha::FieldElem = one(base_field(L))) -> ZLat
 
 Given a lattice `L` in a space $(V, \Phi)$, return the $\mathcal O_K$-lattice
@@ -975,7 +975,7 @@ The rescaling factor $\alpha$ is set to 1 by default.
 
 Note that for now one can only restrict scalars to $\mathbb Q$.
 """
-function restrict_scalars(L::AbsLat, K::FlintRationalField,
+function restrict_scalars(L::AbstractLat, K::FlintRationalField,
                                      alpha::FieldElem = one(base_field(L)))
   V = ambient_space(L)
   Vabs, f = restrict_scalars(V, K, alpha)
@@ -991,7 +991,7 @@ function restrict_scalars(L::AbsLat, K::FlintRationalField,
 end
 
 @doc Markdown.doc"""
-    restrict_scalars_with_map(L::AbsLat, K::FlintRationalField,
+    restrict_scalars_with_map(L::AbstractLat, K::FlintRationalField,
                                          alpha::FieldElem = one(base_field(L)))
                                                         -> Tuple{ZLat, SpaceRes}
 
@@ -1002,7 +1002,7 @@ The rescaling factor $\alpha$ is set to 1 by default.
 
 Note that for now one can only restrict scalars to $\mathbb Q$.
 """
-function restrict_scalars_with_map(L::AbsLat, K::FlintRationalField,
+function restrict_scalars_with_map(L::AbstractLat, K::FlintRationalField,
                                               alpha::FieldElem = one(base_field(L)))
   V = ambient_space(L)
   Vabs, f = restrict_scalars(V, K, alpha)
@@ -1018,7 +1018,7 @@ function restrict_scalars_with_map(L::AbsLat, K::FlintRationalField,
 end
 
 @doc Markdown.doc"""
-    restrict_scalars(L::AbsLat, f::SpaceRes) -> ZLat
+    restrict_scalars(L::AbstractLat, f::SpaceRes) -> ZLat
 
 Given a lattice `L` in a space $(V, \Phi)$ and a map `f` for restricting the
 scalars of $(V, \alpha\Phi)$ to a number field `K`, where $\alpha$ is in the
@@ -1027,7 +1027,7 @@ base algebra of `L`, return the associated $\mathcal O_K$-lattice obtained from
 
 Note that for now one can only restrict scalars to $\mathbb Q$.
 """
-function restrict_scalars(L::AbsLat, f::SpaceRes)
+function restrict_scalars(L::AbstractLat, f::SpaceRes)
   @req ambient_space(L) === codomain(f) "Incompatible arguments: ambient space of L must be the same as the codomain of f"
   Vabs = domain(f)
   Babs = absolute_basis(L)
@@ -1050,11 +1050,11 @@ end
 # Determine the gram matrices of the bilinear forms
 # V x V -> Q, (x, y) -> Tr_K/Q(a*B(x, y))
 # with respect to an absolute basis of L, for all a in generators.
-function Zforms(L::AbsLat{<: NumField}, generators)
+function Zforms(L::AbstractLat{<: NumField}, generators)
   return _Zforms(L, generators)
 end
 
-function Zforms(L::AbsLat{<: NumField})
+function Zforms(L::AbstractLat{<: NumField})
   E = base_ring(ambient_space(L))
   if degree(E) > 1
     generators = elem_type(E)[E(1), absolute_primitive_element(E)]
@@ -1064,7 +1064,7 @@ function Zforms(L::AbsLat{<: NumField})
   return _Zforms(L, generators)
 end
 
-function _Zforms(L::AbsLat{<: NumField}, generators::Vector)
+function _Zforms(L::AbstractLat{<: NumField}, generators::Vector)
   V = ambient_space(L)
   E = base_ring(V)
   Babs = absolute_basis(L)
@@ -1088,7 +1088,7 @@ end
 # per default, the are given with respect to the basis of the ambient space
 # if ambient_representation = true, they are given with respect to the coordinate
 # space/ambient space
-function assert_has_automorphisms(L::AbsLat{<: NumField}; redo::Bool = false)
+function assert_has_automorphisms(L::AbstractLat{<: NumField}; redo::Bool = false)
 
   if !redo && isdefined(L, :automorphism_group_generators)
     return nothing
@@ -1198,7 +1198,7 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    automorphism_group_generators(L::AbsLat; ambient_representation::Bool = true)
+    automorphism_group_generators(L::AbstractLat; ambient_representation::Bool = true)
                                                           -> Vector{MatElem}
 
 Given a definite lattice `L`, return generators for the automorphism group of `L`.
@@ -1206,9 +1206,9 @@ If `ambient_representation == true` (the default), the transformations are repre
 with respect to the ambient space of `L`. Otherwise, the transformations are represented
 with respect to the (pseudo-)basis of `L`.
 """
-automorphism_group_generators(L::AbsLat; ambient_representation::Bool = true)
+automorphism_group_generators(L::AbstractLat; ambient_representation::Bool = true)
 
-function automorphism_group_generators(L::AbsLat; ambient_representation::Bool = true, check = false)
+function automorphism_group_generators(L::AbstractLat; ambient_representation::Bool = true, check = false)
 
   assert_has_automorphisms(L)
 
@@ -1247,13 +1247,13 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    automorphism_group_order(L::AbsLat) -> Int
+    automorphism_group_order(L::AbstractLat) -> Int
 
 Given a definite lattice `L`, return the order of the automorphism group of `L`.
 """
-automorphism_group_order(L::AbsLat; redo::Bool = false)
+automorphism_group_order(L::AbstractLat; redo::Bool = false)
 
-function automorphism_group_order(L::AbsLat; redo::Bool = false)
+function automorphism_group_order(L::AbstractLat; redo::Bool = false)
   assert_has_automorphisms(L, redo = redo)
   return L.automorphism_group_order
 end
@@ -1265,15 +1265,15 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    is_isometric(L::AbsLat, M::AbsLat) -> Bool
+    is_isometric(L::AbstractLat, M::AbstractLat) -> Bool
 
 Return whether the lattices `L` and `M` are isometric.
 """
-is_isometric(L::AbsLat, M::AbsLat) = is_isometric_with_isometry(L, M, ambient_representation=false)[1]
+is_isometric(L::AbstractLat, M::AbstractLat) = is_isometric_with_isometry(L, M, ambient_representation=false)[1]
 
 
 @doc Markdown.doc"""
-    is_isometric_with_isometry(L::AbsLat, M::AbsLat; ambient_representation::Bool = true)
+    is_isometric_with_isometry(L::AbstractLat, M::AbstractLat; ambient_representation::Bool = true)
                                                               -> (Bool, MatElem)
 
 Return whether the lattices `L` and `M` are isometric. If this is the case, the
@@ -1287,10 +1287,10 @@ to the (pseudo-)bases of `L` and `M`, that is, $T G_M T^t = G_L$ where $G_M$
 and $G_L$ are the Gram matrices of the (pseudo-)bases of `L` and `M`
 respectively.
 """
-is_isometric_with_isometry(L::AbsLat, M::AbsLat; ambient_representation::Bool = true) = throw(NotImplemented())
+is_isometric_with_isometry(L::AbstractLat, M::AbstractLat; ambient_representation::Bool = true) = throw(NotImplemented())
 
 
-function is_isometric_with_isometry(L::AbsLat{<: NumField}, M::AbsLat{<: NumField};
+function is_isometric_with_isometry(L::AbstractLat{<: NumField}, M::AbstractLat{<: NumField};
                                             ambient_representation::Bool = true)
   V = ambient_space(L)
   W = ambient_space(M)
@@ -1365,7 +1365,7 @@ end
 #
 ################################################################################
 
-function maximal_sublattices(L::AbsLat, p; use_auto::Bool = false,
+function maximal_sublattices(L::AbstractLat, p; use_auto::Bool = false,
                                            callback = false, max = inf)
   @req base_ring(L) == order(p) "Incompatible arguments: p must be an ideal in the base ring of L"
 
@@ -1428,7 +1428,7 @@ end
 #
 ################################################################################
 
-function minimal_superlattices(L::AbsLat, p; use_auto::Bool = false,
+function minimal_superlattices(L::AbstractLat, p; use_auto::Bool = false,
                                              callback = false, max = inf)
   @req base_ring(L) == order(p) "Incompatible arguments: p must be an ideal in the base ring of L"
 
@@ -1491,7 +1491,7 @@ end
 ################################################################################
 
 # TODO: Make this a proper coproduct with injections?
-function orthogonal_sum(M::T, N::T) where {T <: AbsLat}
+function orthogonal_sum(M::T, N::T) where {T <: AbstractLat}
   @req base_ring(M) === base_ring(N) "Base rings must be equal"
   U = ambient_space(M)
   V = ambient_space(N)
@@ -1515,11 +1515,11 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    orthogonal_submodule(L::AbsLat, M::AbsLat) -> AbsLat
+    orthogonal_submodule(L::AbstractLat, M::AbstractLat) -> AbstractLat
 
 Return the largest submodule of `L` orthogonal to `M`.
 """
-function orthogonal_submodule(L::AbsLat, M::AbsLat)
+function orthogonal_submodule(L::AbstractLat, M::AbstractLat)
   @req ambient_space(M) == ambient_space(L) "Lattices must be in the same ambient space"
   V = ambient_space(L)
   EM = basis_matrix_of_rational_span(M)
@@ -1530,7 +1530,7 @@ function orthogonal_submodule(L::AbsLat, M::AbsLat)
 end
 
 # does not seem to work either
-function _orthogonal_complement(v::Vector, L::AbsLat)
+function _orthogonal_complement(v::Vector, L::AbstractLat)
   V = ambient_space(L)
   M = matrix(base_ring(V), 1, length(v), v)
   ge = generators(L)
@@ -1558,25 +1558,25 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    is_maximal_integral(L::AbsLat, p::NfOrdIdl) -> Bool, AbsLat
+    is_maximal_integral(L::AbstractLat, p::NfOrdIdl) -> Bool, AbstractLat
 
 Given a lattice `L` and a prime ideal `p` of the fixed ring $\mathcal O_K$ of
 `L`, return whether the completion of `L` at `p` is maximal integral. If it is
 not the case, the second returned value is a lattice in the ambient space of `L`
 whose completion at `p` is a minimal overlattice of $L_p$.
 """
-is_maximal_integral(::AbsLat, p)
+is_maximal_integral(::AbstractLat, p)
 
 @doc Markdown.doc"""
-    is_maximal_integral(L::AbsLat) -> Bool, AbsLat
+    is_maximal_integral(L::AbstractLat) -> Bool, AbstractLat
 
 Given a lattice `L`, return whether `L` is maximal integral. If it is not,
 the second returned value is a minimal overlattice of `L` with integral norm.
 """
-is_maximal_integral(::AbsLat)
+is_maximal_integral(::AbstractLat)
 
 @doc Markdown.doc"""
-    is_maximal(L::AbsLat, p::NfOrdIdl) -> Bool, AbsLat
+    is_maximal(L::AbstractLat, p::NfOrdIdl) -> Bool, AbstractLat
 
 Given a lattice `L` and a prime ideal `p` in the fixed ring $\mathcal O_K$ of
 `L`, check whether the norm of $L_p$ is integral and return whether `L` is maximal
@@ -1584,32 +1584,32 @@ at `p`. If it is locally integral but not locally maximal, the second returned v
 is a lattice in the same ambient space of `L` whose completion at `p` has integral norm
 and is a proper overlattice of $L_p$.
 """
-is_maximal(::AbsLat, p)
+is_maximal(::AbstractLat, p)
 
 @doc Markdown.doc"""
-    maximal_integral_lattice(L::AbsLat, p::NfOrdIdl) -> AbsLat
+    maximal_integral_lattice(L::AbstractLat, p::NfOrdIdl) -> AbstractLat
 
 Given a lattice `L` and a prime ideal `p` of the fixed ring $\mathcal O_K$ of
 `L`, return a lattice `M` in the ambient space of `L` which is maximal integral
 at `p` and which agrees with `L` locally at all the places different from `p`.
 """
-maximal_integral_lattice(::AbsLat, p)
+maximal_integral_lattice(::AbstractLat, p)
 
 @doc Markdown.doc"""
-    maximal_integral_lattice(L::AbsLat) -> AbsLat
+    maximal_integral_lattice(L::AbstractLat) -> AbstractLat
 
 Given a lattice `L`, return a lattice `M` in the ambient space of `L` which
 is maximal integral and which contains `L`.
 """
-maximal_integral_lattice(::AbsLat)
+maximal_integral_lattice(::AbstractLat)
 
 @doc Markdown.doc"""
-    maximal_integral_lattice(V::AbsSpace) -> AbsLat
+    maximal_integral_lattice(V::AbstractSpace) -> AbstractLat
 
 Given a space `V`, return a lattice in `V` with integral norm
 and which is maximal in `V` satisfying this property.
 """
-maximal_integral_lattice(::AbsSpace)
+maximal_integral_lattice(::AbstractSpace)
 
 ################################################################################
 #
@@ -1618,7 +1618,7 @@ maximal_integral_lattice(::AbsSpace)
 ################################################################################
 
 @doc Markdown.doc"""
-    primitive_closure(M::AbsLat, N::AbsLat) -> AbsLat
+    primitive_closure(M::AbstractLat, N::AbstractLat) -> AbstractLat
 
 Given two lattices `M` and `N` defined over a number field `E`, with
 $N \subseteq E\otimes M$, return the primitive closure $M \cap E\otimes N$
@@ -1626,7 +1626,7 @@ of `N` in `M`.
 
 One can also use the alias `saturate(L, M)`.
 """
-function primitive_closure(M::AbsLat, N::AbsLat)
+function primitive_closure(M::AbstractLat, N::AbstractLat)
   @assert has_ambient_space(N) && has_ambient_space(M)
   @req ambient_space(N) === ambient_space(M) "Lattices must be in the same ambient space"
   Mres, f = restrict_scalars_with_map(M, FlintQQ)
@@ -1638,8 +1638,8 @@ function primitive_closure(M::AbsLat, N::AbsLat)
 end
 
 @doc Markdown.doc"""
-    saturate(L::AbsLat, M::AbsLat) -> AbsLat
+    saturate(L::AbstractLat, M::AbstractLat) -> AbstractLat
 
 Alias for `primitive_closure`.
 """
-saturate(L::AbsLat, M::AbsLat) = primitive_closure(L::AbsLat, M::AbsLat)
+saturate(L::AbstractLat, M::AbstractLat) = primitive_closure(L::AbstractLat, M::AbstractLat)

--- a/src/QuadForm/Quad/Genus.jl
+++ b/src/QuadForm/Quad/Genus.jl
@@ -254,7 +254,7 @@ function lattice(J::JorDec)
 end
 
 @doc Markdown.doc"""
-    genus(J::JorDec) -> LocalGenusQuad
+    genus(J::JorDec) -> QuadLocalGenus
 
 Given an abstract Jordan decomposition, return the local genus to which the
 corresponding matrix belongs.
@@ -493,7 +493,7 @@ end
 # - determinant (classes) of L^(s_i)
 # - Witt invariants of L_i
 
-mutable struct LocalGenusQuad{S, T, U}
+mutable struct QuadLocalGenus{S, T, U}
   K::S
   p::T
   is_dyadic::Bool
@@ -519,7 +519,7 @@ mutable struct LocalGenusQuad{S, T, U}
   # Sometimes we know a jordan decomposition
   jordec::JorDec{S, T, U}
 
-  function LocalGenusQuad{S, T, U}() where {S, T, U}
+  function QuadLocalGenus{S, T, U}() where {S, T, U}
     z = new{S, T, U}()
     z.rank = 0
     z.witt_inv = 0
@@ -528,36 +528,36 @@ mutable struct LocalGenusQuad{S, T, U}
   end
 end
 
-local_genus_quad_type(K) = LocalGenusQuad{typeof(K), ideal_type(order_type(K)), elem_type(K)}
+local_genus_quad_type(K) = QuadLocalGenus{typeof(K), ideal_type(order_type(K)), elem_type(K)}
 
-function in(L::QuadLat, G::LocalGenusQuad)
+function in(L::QuadLat, G::QuadLocalGenus)
   return genus(L, prime(G)) == G
 end
 
 function local_quadratic_genus_type(K)
-  return LocalGenusQuad{typeof(K),
+  return QuadLocalGenus{typeof(K),
                         ideal_type(order_type(K)),
                         elem_type(K)}
 end
 
 # Access
-prime(G::LocalGenusQuad) = G.p
+prime(G::QuadLocalGenus) = G.p
 
-length(G::LocalGenusQuad) = length(G.ranks)
+length(G::QuadLocalGenus) = length(G.ranks)
 
-scales(G::LocalGenusQuad) = G.scales
+scales(G::QuadLocalGenus) = G.scales
 
-ranks(G::LocalGenusQuad) = G.ranks
+ranks(G::QuadLocalGenus) = G.ranks
 
-dets(G::LocalGenusQuad) = G.detclasses
+dets(G::QuadLocalGenus) = G.detclasses
 
-weights(G::LocalGenusQuad) = G.weights
+weights(G::QuadLocalGenus) = G.weights
 
-scale(G::LocalGenusQuad, i::Int) = scales(G)[i]
+scale(G::QuadLocalGenus, i::Int) = scales(G)[i]
 
-rank(G::LocalGenusQuad, i::Int) = ranks(G)[i]
+rank(G::QuadLocalGenus, i::Int) = ranks(G)[i]
 
-function witt_invariant(G::LocalGenusQuad)
+function witt_invariant(G::QuadLocalGenus)
   if G.witt_inv != 0
     return G.witt_inv
   end
@@ -577,7 +577,7 @@ function witt_invariant(G::LocalGenusQuad)
   return w
 end
 
-function rank(G::LocalGenusQuad)
+function rank(G::QuadLocalGenus)
   if G.rank != 0
     return G.rank
   end
@@ -588,7 +588,7 @@ function rank(G::LocalGenusQuad)
   return rk
 end
 
-function det(G::LocalGenusQuad)
+function det(G::QuadLocalGenus)
   if isdefined(G, :det)
     return G.det
   end
@@ -604,7 +604,7 @@ function det(G::LocalGenusQuad)
   return d
 end
 
-function det(G::LocalGenusQuad, i::Int)
+function det(G::QuadLocalGenus, i::Int)
   #if is_dyadic(G)
     return G.dets[i]
   #else
@@ -613,7 +613,7 @@ function det(G::LocalGenusQuad, i::Int)
   #end
 end
 
-function hasse_invariant(G::LocalGenusQuad)
+function hasse_invariant(G::QuadLocalGenus)
   if rank(G) == 0
     return 1
   end
@@ -636,19 +636,19 @@ function hasse_invariant(G::LocalGenusQuad)
   end
 end
 
-function uniformizer(G::LocalGenusQuad)
+function uniformizer(G::QuadLocalGenus)
   @req !is_dyadic(G) "Genus symbol must not be dyadic"
   return G.uniformizer
 end
 
-is_dyadic(G::LocalGenusQuad) = G.is_dyadic
+is_dyadic(G::QuadLocalGenus) = G.is_dyadic
 
-function norm_generators(G::LocalGenusQuad)
+function norm_generators(G::QuadLocalGenus)
   @req is_dyadic(G) "Genus symbol must be dyadic"
   return G.normgens
 end
 
-function norms(G::LocalGenusQuad)
+function norms(G::QuadLocalGenus)
   @req is_dyadic(G) "Genus symbol must be dyadic"
   if !isdefined(G, :norms)
     p = prime(G)
@@ -659,7 +659,7 @@ function norms(G::LocalGenusQuad)
   end
 end
 
-function jordan_decomposition(g::LocalGenusQuad)
+function jordan_decomposition(g::QuadLocalGenus)
   if isdefined(g,:jordec)
     j = g.jordec
   elseif rank(g) == 0
@@ -684,7 +684,7 @@ function jordan_decomposition(g::LocalGenusQuad)
   return j
 end
 
-function Base.show(io::IO, G::LocalGenusQuad{S, T, U}) where {S, T, U}
+function Base.show(io::IO, G::QuadLocalGenus{S, T, U}) where {S, T, U}
   if !is_dyadic(G)
     for i in 1:length(G)
       print(io, "(", G.scales[i], ", ", G.ranks[i], ", ", G.detclasses[i], ")")
@@ -696,7 +696,7 @@ function Base.show(io::IO, G::LocalGenusQuad{S, T, U}) where {S, T, U}
   end
 end
 
-function Base.show(io::IO, ::MIME"text/plain", G::LocalGenusQuad{S, T, U}) where {S, T, U}
+function Base.show(io::IO, ::MIME"text/plain", G::QuadLocalGenus{S, T, U}) where {S, T, U}
   p = prime(G)
   if !get(io, :compact, false)
     print(io, "Local quadratic genus for prime ")
@@ -732,7 +732,7 @@ function genus(::Type{QuadLat}, p, pi::nf_elem, ranks::Vector{Int},
                                                 normclass::Vector{Int})
   @req !is_dyadic(p) "Prime ideal must not be dyadic"
   K = nf(order(p))
-  z = LocalGenusQuad{typeof(K), typeof(p), elem_type(K)}()
+  z = QuadLocalGenus{typeof(K), typeof(p), elem_type(K)}()
   z.p = p
   z.uniformizer = pi
   z.is_dyadic = false
@@ -750,7 +750,7 @@ function genus(::Type{QuadLat}, p, ranks::Vector{Int}, scales::Vector{Int},
                                    f::Vector{Int}) where {T}
   @req is_dyadic(p) "Prime ideal must be dyadic"
   K = nf(order(p))
-  z = LocalGenusQuad{typeof(K), typeof(p), elem_type(K)}()
+  z = QuadLocalGenus{typeof(K), typeof(p), elem_type(K)}()
   z.is_dyadic = true
   z.p = p
   z.ranks = ranks
@@ -770,7 +770,7 @@ function genus(::Type{QuadLat}, p, ranks::Vector{Int}, scales::Vector{Int},
                                    witt::Vector{Int}) where {T}
   @req is_dyadic(p) "Prime ideal must be dyadic"
   K = nf(order(p))
-  z = LocalGenusQuad{typeof(K), typeof(p), elem_type(K)}()
+  z = QuadLocalGenus{typeof(K), typeof(p), elem_type(K)}()
   z.is_dyadic = true
   z.p = p
   z.ranks = ranks
@@ -811,7 +811,7 @@ end
 #
 ################################################################################
 
-function Base.:(==)(G1::LocalGenusQuad, G2::LocalGenusQuad)
+function Base.:(==)(G1::QuadLocalGenus, G2::QuadLocalGenus)
   if G1 === G2
     return true
   end
@@ -1081,7 +1081,7 @@ end
 #
 ################################################################################
 
-function orthogonal_sum(G1::LocalGenusQuad, G2::LocalGenusQuad)
+function orthogonal_sum(G1::QuadLocalGenus, G2::QuadLocalGenus)
   @req prime(G1) === prime(G2) "Local genera must have the same prime ideal"
   if !G1.is_dyadic
     p = prime(G1)
@@ -1119,7 +1119,7 @@ function orthogonal_sum(G1::LocalGenusQuad, G2::LocalGenusQuad)
   return G3
 end
 
-function _direct_sum_easy(G1::LocalGenusQuad, G2::LocalGenusQuad, detclassesG2 = G2.detclasses)
+function _direct_sum_easy(G1::QuadLocalGenus, G2::QuadLocalGenus, detclassesG2 = G2.detclasses)
   # We do a merge sort
   i1 = 1
   i2 = 1
@@ -1161,7 +1161,7 @@ function _direct_sum_easy(G1::LocalGenusQuad, G2::LocalGenusQuad, detclassesG2 =
   return genus(QuadLat, prime(G1), uniformizer(G1), _rk, _sca, _detclass)
 end
 
-Base.:(+)(G1::LocalGenusQuad, G2::LocalGenusQuad) = orthogonal_sum(G1, G2)
+Base.:(+)(G1::QuadLocalGenus, G2::QuadLocalGenus) = orthogonal_sum(G1, G2)
 
 ################################################################################
 #
@@ -1186,7 +1186,7 @@ function _non_square(K, p)
   return u
 end
 
-function representative(G::LocalGenusQuad)
+function representative(G::QuadLocalGenus)
   K = nf(order(G.p))
   return lattice(quadratic_space(K, gram_matrix(jordan_decomposition(G))))
 end
@@ -1600,7 +1600,7 @@ function _local_jordan_decompositions_dyadic!(res, E, p, scalerank)
 end
 
 
-function local_genera_quadratic(K, p; rank::Int, det_val::Int, max_scale = nothing)
+function quadratic_local_genera(K, p; rank::Int, det_val::Int, max_scale = nothing)
   J = local_jordan_decompositions(K, p, rank = rank, det_val = det_val, max_scale = max_scale)
   res = local_quadratic_genus_type(K)[]
   for j in J
@@ -1618,25 +1618,25 @@ end
 #
 ################################################################################
 
-mutable struct GenusQuad{S, T, U}
+mutable struct QuadGenus{S, T, U}
   K::S
   primes::Vector{T}
-  LGS::Vector{LocalGenusQuad{S, T, U}}
+  LGS::Vector{QuadLocalGenus{S, T, U}}
   rank::Int
   signatures::Dict{InfPlc{AnticNumberField, NumFieldEmbNfAbs}, Int}
   d::U
   space
 
-  function GenusQuad{S, T, U}(K) where {S, T, U}
+  function QuadGenus{S, T, U}(K) where {S, T, U}
     z = new{typeof(K), ideal_type(order_type(K)), elem_type(K)}()
     z.rank = -1
     return z
   end
 end
 
-genus_quad_type(K) = GenusQuad{typeof(K), ideal_type(order_type(K)), elem_type(K)}
+genus_quad_type(K) = QuadGenus{typeof(K), ideal_type(order_type(K)), elem_type(K)}
 
-function GenusQuad(K, d, LGS, signatures)
+function QuadGenus(K, d, LGS, signatures)
   z = genus_quad_type(K)(K)
   z.LGS = LGS
   z.signatures = signatures
@@ -1653,12 +1653,12 @@ function genus(L::QuadLat{})
     S = real_places(base_field(L))
     D = diagonal(rational_span(L))
     signatures = Dict{InfPlc{AnticNumberField, NumFieldEmbNfAbs}, Int}(s => count(d -> is_negative(d, _embedding(s)), D) for s in S)
-    G = GenusQuad(base_field(L), prod(D), [genus(L, p) for p in bad], signatures)
+    G = QuadGenus(base_field(L), prod(D), [genus(L, p) for p in bad], signatures)
     return G::genus_quad_type(base_field(L))
   end
 end
 
-function Base.:(==)(G1::GenusQuad, G2::GenusQuad)
+function Base.:(==)(G1::QuadGenus, G2::QuadGenus)
   if G1.K != G2.K
     return false
   end
@@ -1692,9 +1692,9 @@ function Base.:(==)(G1::GenusQuad, G2::GenusQuad)
   return true
 end
 
-primes(G::GenusQuad) = G.primes
+primes(G::QuadGenus) = G.primes
 
-function genera_quadratic(K; rank::Int, signatures, det)
+function quadratic_genera(K; rank::Int, signatures, det)
   OK = maximal_order(K)
 
   _max_scale = 2 * det
@@ -1708,7 +1708,7 @@ function genera_quadratic(K; rank::Int, signatures, det)
   for p in primes
     det_val = valuation(ds, p)
     mscale_val = valuation(ms, p)
-    push!(local_symbols, local_genera_quadratic(K, p, rank = rank, det_val = det_val, max_scale = mscale_val))
+    push!(local_symbols, quadratic_local_genera(K, p, rank = rank, det_val = det_val, max_scale = mscale_val))
   end
 
   res = genus_quad_type(K)[]
@@ -1719,7 +1719,7 @@ function genera_quadratic(K; rank::Int, signatures, det)
     for d in de
       b = _check_global_quadratic_genus(c, d, signatures)
       if b
-        push!(res, GenusQuad(K, d, c, signatures))
+        push!(res, QuadGenus(K, d, c, signatures))
       end
     end
   end
@@ -1836,7 +1836,7 @@ function _possible_determinants(K, local_symbols, signatures)
   return dets
 end
 
-function quadratic_space(G::GenusQuad)
+function quadratic_space(G::QuadGenus)
   if isdefined(G, :space)
     return G.space::quadratic_space_type(G.K)
   end
@@ -1857,7 +1857,7 @@ end
 #
 ################################################################################
 
-function representative(G::GenusQuad)
+function representative(G::QuadGenus)
   K = G.K
   OK = order(primes(G)[1])
   # Let's follow the Lorch paper. This is also how we do it in the Hermitian case.
@@ -1909,7 +1909,7 @@ function locally_isometric_sublattice(M::QuadLat, L::QuadLat, p)
   return LL
 end
 
-function representatives(G::GenusQuad)
+function representatives(G::QuadGenus)
   return genus_representatives(representative(G))
 end
 
@@ -1919,7 +1919,7 @@ end
 #
 ################################################################################
 
-function orthogonal_sum(G1::GenusQuad{S, T, U}, G2::GenusQuad{S, T, U}) where {S, T, U}
+function orthogonal_sum(G1::QuadGenus{S, T, U}, G2::QuadGenus{S, T, U}) where {S, T, U}
   @req G1.K === G2.K "Global genus symbols must be defined over the same field"
   K = G1.K
   LGS = local_genus_quad_type(K)[]
@@ -1952,10 +1952,10 @@ function orthogonal_sum(G1::GenusQuad{S, T, U}, G2::GenusQuad{S, T, U}) where {S
   sig2 = G2.signatures
   sig3 = merge(+, sig1, sig2)
 
-  return GenusQuad(K, G1.d * G2.d, LGS, sig3)
+  return QuadGenus(K, G1.d * G2.d, LGS, sig3)
 end
 
-Base.:(+)(G1::GenusQuad, G2::GenusQuad) = orthogonal_sum(G1, G2)
+Base.:(+)(G1::QuadGenus, G2::QuadGenus) = orthogonal_sum(G1, G2)
 
 ################################################################################
 #
@@ -1964,10 +1964,10 @@ Base.:(+)(G1::GenusQuad, G2::GenusQuad) = orthogonal_sum(G1, G2)
 ################################################################################
 
 @doc Markdown.doc"""
-    in(L::QuadLat, G::GenusQuad) -> Bool
+    in(L::QuadLat, G::QuadGenus) -> Bool
 
 Test if the lattice $L$ is contained in the genus $G$.
 """
-Base.in(L::QuadLat, G::GenusQuad) = genus(L) == G
+Base.in(L::QuadLat, G::QuadGenus) = genus(L) == G
 
 

--- a/src/QuadForm/Quad/Types.jl
+++ b/src/QuadForm/Quad/Types.jl
@@ -1,6 +1,6 @@
 export ZLat
 
-@attributes mutable struct ZLat <: AbsLat{FlintRationalField}
+@attributes mutable struct ZLat <: AbstractLat{FlintRationalField}
   space::QuadSpace{FlintRationalField, fmpq_mat}
   rational_span::QuadSpace{FlintRationalField, fmpq_mat}
   basis_matrix::fmpq_mat
@@ -23,7 +23,7 @@ export ZLat
   end
 end
 
-@attributes mutable struct QuadLat{S, T, U} <: AbsLat{S}
+@attributes mutable struct QuadLat{S, T, U} <: AbstractLat{S}
   space::QuadSpace{S, T}
   pmat::U
   gram::T                        # gram matrix of the matrix part of pmat

--- a/src/QuadForm/Quad/ZGenus.jl
+++ b/src/QuadForm/Quad/ZGenus.jl
@@ -1462,7 +1462,7 @@ Return the quadratic space defined by this genus.
 rational_representative(G::ZGenus) = quadratic_space(G)
 
 @doc Markdown.doc"""
-    discriminant_group(G::ZGenus) -> TorQuadMod
+    discriminant_group(G::ZGenus) -> TorQuadModule
 
 Return the discriminant form associated to this genus.
 """
@@ -1477,7 +1477,7 @@ function discriminant_group(G::ZGenus)
     end
   end
   q = diagonal_matrix(qL)
-  return TorQuadMod(q)
+  return TorQuadModule(q)
 end
 
 @doc Markdown.doc"""

--- a/src/QuadForm/Quad/ZGenus.jl
+++ b/src/QuadForm/Quad/ZGenus.jl
@@ -1,6 +1,6 @@
 export genus, rank, det, dim, prime, symbol, representative, signature,
-       oddity, excess, level, genera, scale, norm, mass, orthogonal_sum,
-       quadratic_space,hasse_invariant, genera, local_symbol, local_symbols,
+       oddity, excess, level, Zgenera, scale, norm, mass, orthogonal_sum,
+       quadratic_space,hasse_invariant, local_symbol, local_symbols,
        ZGenus, ZpGenus, representatives, is_elementary, is_primary, is_unimodular,
        is_primary_with_prime, is_elementary_with_prime, automorphous_numbers,
        is_automorphous, bad_primes, signature_pair, signature_tuple
@@ -540,7 +540,7 @@ direct_sum(S1::ZGenus, S2::ZGenus) = orthogonal_sum(S1, S2)
 ###############################################################################
 
 @doc Markdown.doc"""
-    genera(sig_pair::Vector{Int}, determinant::RationalUnion;
+    Zgenera(sig_pair::Vector{Int}, determinant::RationalUnion;
            min_scale::RationalUnion = min(one(QQ), QQ(abs(determinant))),
            max_scale::RationalUnion = max(one(QQ), QQ(abs(determinant))),
            even=false)                                         -> Vector{ZGenus}
@@ -557,7 +557,7 @@ $\mathbb Z$-lattices are also supported.
   integer multiple of the scale (default: `max(one(QQ), QQ(abs(determinant)))`)
 - `even`: boolean; if set to true, return only the even genera (default: `false`)
 """
-function genera(sig_pair::Tuple{Int,Int}, determinant::RationalUnion;
+function Zgenera(sig_pair::Tuple{Int,Int}, determinant::RationalUnion;
                 min_scale::RationalUnion = min(one(QQ), QQ(abs(determinant))),
                 max_scale::RationalUnion = max(one(QQ), QQ(abs(determinant))),
                 even=false)
@@ -1917,7 +1917,7 @@ function is_unimodular(g::ZpGenus)
 end
 
 @doc Markdown.doc"""
-  bad_primes(g::ZGenus) -> Vector{fmpz}
+    bad_primes(g::ZGenus) -> Vector{fmpz}
 
 Return `2` and the primes at which `g` is not unimodular.
 """
@@ -2638,12 +2638,12 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-  embed(S::ZLat, G::Genus, primitive=true) -> Bool, embedding
+    embed(S::ZLat, G::Genus, primitive=true) -> Bool, embedding
 
 Return a (primitive) embedding of the integral lattice `S` into some lattice in the genus of `G`.
 
 ```jldoctest
-julia> G = genera((8,0), 1, even=true)[1];
+julia> G = Zgenera((8,0), 1, even=true)[1];
 
 julia> L, S, i = embed(root_lattice(:A,5), G);
 

--- a/src/QuadForm/Quad/ZLattices.jl
+++ b/src/QuadForm/Quad/ZLattices.jl
@@ -227,8 +227,8 @@ function _orthogonal_sum_with_injections_and_projections(x::Vector{ZLat})
 end
 
 @doc Markdown.doc"""
-    direct_sum(x::Vararg{ZLat}) -> ZLat, Vector{AbsSpaceMor}, Vector{AbsSpaceMor}
-    direct_sum(x::Vector{ZLat}) -> ZLat, Vector{AbsSpaceMor}, Vector{AbsSpaceMor}
+    direct_sum(x::Vararg{ZLat}) -> ZLat, Vector{AbstractSpaceMor}, Vector{AbstractSpaceMor}
+    direct_sum(x::Vector{ZLat}) -> ZLat, Vector{AbstractSpaceMor}, Vector{AbstractSpaceMor}
 
 Given a collection of $\mathbb Z$-lattices $L_1, \ldots, L_n$,
 return their complete direct sum $L := L_1 \oplus \ldots \oplus L_n$,
@@ -1915,7 +1915,7 @@ end
 
 @doc Markdown.doc"""
     glue_map(L::ZLat, S::ZLat, R::ZLat; check=true)
-                           -> Tuple{TorQuadModMor, TorQuadModMor, TorQuadModMor}
+                           -> Tuple{TorQuadModuleMor, TorQuadModuleMor, TorQuadModuleMor}
 
 Given three integral $\mathbb Z$-lattices `L`, `S` and `R`, with `S` and `R`
 primitive sublattices of `L` and such that the sum of the ranks of `S` and `R`
@@ -1947,22 +1947,22 @@ julia> glue, iS, iR = glue_map(M, S, R)
 (Map with following data
 Domain:
 =======
-TorQuadMod [4//3 0; 0 4//3]
+TorQuadModule [4//3 0; 0 4//3]
 Codomain:
 =========
-TorQuadMod [2//3 0; 0 2//3], Map with following data
+TorQuadModule [2//3 0; 0 2//3], Map with following data
 Domain:
 =======
-TorQuadMod [4//3 0; 0 4//3]
+TorQuadModule [4//3 0; 0 4//3]
 Codomain:
 =========
-TorQuadMod [4//3 2//3; 2//3 2//3], Map with following data
+TorQuadModule [4//3 2//3; 2//3 2//3], Map with following data
 Domain:
 =======
-TorQuadMod [2//3 0; 0 2//3]
+TorQuadModule [2//3 0; 0 2//3]
 Codomain:
 =========
-TorQuadMod [2//3 1//3; 1//3 4//3])
+TorQuadModule [2//3 1//3; 1//3 4//3])
 
 julia> is_bijective(glue)
 true
@@ -1987,8 +1987,8 @@ function glue_map(L::ZLat, S::ZLat, R::ZLat; check=true)
   bL = basis_matrix(L)
   DS = discriminant_group(S)
   DR = discriminant_group(R)
-  gens = TorQuadModElem[]
-  imgs = TorQuadModElem[]
+  gens = TorQuadModuleElem[]
+  imgs = TorQuadModuleElem[]
   for i in 1:rank(L)
     d = bL[i,:]
     g = DS(vec(collect(d * prS)))
@@ -2007,7 +2007,7 @@ function glue_map(L::ZLat, S::ZLat, R::ZLat; check=true)
 end
 
 @doc Markdown.doc"""
-    overlattice(glue_map::TorQuadModMor) -> ZLat
+    overlattice(glue_map::TorQuadModuleMor) -> ZLat
 
 Given the glue map of a primitive extension of $\mathbb Z$-lattices
 $S+R \subseteq L$, return `L`.
@@ -2038,7 +2038,7 @@ julia> overlattice(glue) == M
 true
 ```
 """
-function overlattice(glue_map::TorQuadModMor)
+function overlattice(glue_map::TorQuadModuleMor)
   S = relations(domain(glue_map))
   R = relations(codomain(glue_map))
   glue = [lift(g) + lift(glue_map(g)) for g in gens(domain(glue_map))]

--- a/src/QuadForm/Spaces.jl
+++ b/src/QuadForm/Spaces.jl
@@ -9,11 +9,11 @@ export ambient_space, rank, gram_matrix, inner_product, involution, ishermitian,
 #
 ################################################################################
 
-@attributes mutable struct AbsSpaceMor{D, T} <: Map{D, D, HeckeMap, AbsSpaceMor}
+@attributes mutable struct AbstractSpaceMor{D, T} <: Map{D, D, HeckeMap, AbstractSpaceMor}
   header::MapHeader{D, D}
   matrix::T
 
-  function AbsSpaceMor(V::D, W::D, B::T) where {D, T}
+  function AbstractSpaceMor(V::D, W::D, B::T) where {D, T}
     z = new{D, T}()
     z.header = MapHeader{D, D}(V, W)
     z.matrix = B
@@ -21,7 +21,7 @@ export ambient_space, rank, gram_matrix, inner_product, involution, ishermitian,
   end
 end
 
-function hom(V::AbsSpace, W::AbsSpace, B::MatElem; check::Bool = false)
+function hom(V::AbstractSpace, W::AbstractSpace, B::MatElem; check::Bool = false)
   @req base_ring(V) == base_ring(W) "Spaces must have the same base field"
   @req nrows(B) == dim(V) && ncols(B) == dim(W) """
   Dimension mismatch. Matrix ($(nrows(B))x$(ncols(B))) must be of
@@ -35,20 +35,20 @@ function hom(V::AbsSpace, W::AbsSpace, B::MatElem; check::Bool = false)
       error("Matrix does not define a morphism of spaces")
     end
   end
-  return AbsSpaceMor(V, W, B)
+  return AbstractSpaceMor(V, W, B)
 end
 
-function image(f::AbsSpaceMor, v::Vector)
+function image(f::AbstractSpaceMor, v::Vector)
   V = domain(f)
   w = matrix(base_ring(V), 1, length(v), v) * f.matrix
   return vec(collect(w))
 end
 
-@attr Bool function is_injective(f::AbsSpaceMor)
+@attr Bool function is_injective(f::AbstractSpaceMor)
   return rank(f.matrix) == nrows(f.matrix)
 end
 
-function image(f::AbsSpaceMor, L::AbsLat)
+function image(f::AbstractSpaceMor, L::AbstractLat)
   V = domain(f)
   @req V==ambient_space(L) "L not in domain"
   W = codomain(f)
@@ -62,7 +62,7 @@ function image(f::AbsSpaceMor, L::AbsLat)
   end
 end
 
-function image(f::AbsSpaceMor, L::ZLat)
+function image(f::AbstractSpaceMor, L::ZLat)
   V = domain(f)
   @req V==ambient_space(L) "L not in domain"
   W = codomain(f)
@@ -71,7 +71,7 @@ function image(f::AbsSpaceMor, L::ZLat)
   return lattice(W, B, isbasis=isbasis, check=false)
 end
 
-function preimage(f::AbsSpaceMor, L::ZLat)
+function preimage(f::AbstractSpaceMor, L::ZLat)
   V = domain(f)
   W = codomain(f)
   @req W==ambient_space(L) "L not in codomain"
@@ -86,7 +86,7 @@ function preimage(f::AbsSpaceMor, L::ZLat)
   return lattice(V, B)
 end
 
-function compose(f::AbsSpaceMor, g::AbsSpaceMor)
+function compose(f::AbstractSpaceMor, g::AbstractSpaceMor)
   @req codomain(f) === domain(g) "incompatible morphisms"
   return hom(domain(f), codomain(g), f.matrix * g.matrix)
 end
@@ -98,11 +98,11 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    rescale(q::AbsSpace, r) -> AbsSpace
+    rescale(q::AbstractSpace, r) -> AbstractSpace
 
 For $q=(V,\Phi)$ return the space $(V, r \Phi)$.
 """
-rescale(q::AbsSpace, r)
+rescale(q::AbstractSpace, r)
 
 
 ################################################################################
@@ -112,48 +112,48 @@ rescale(q::AbsSpace, r)
 ################################################################################
 
 @doc Markdown.doc"""
-    rank(V::AbsSpace) -> Int
+    rank(V::AbstractSpace) -> Int
 
 Return the rank of the space `V`.
 """
-@attr Int rank(L::AbsSpace) = rank(L.gram)
+@attr Int rank(L::AbstractSpace) = rank(L.gram)
 
 @doc Markdown.doc"""
-    dim(V::AbsSpace) -> Int
+    dim(V::AbstractSpace) -> Int
 
 Return the dimension of the space `V`.
 """
-dim(V::AbsSpace) = nrows(V.gram)
+dim(V::AbstractSpace) = nrows(V.gram)
 
 @doc Markdown.doc"""
-    gram_matrix(V::AbsSpace) -> MatElem
+    gram_matrix(V::AbstractSpace) -> MatElem
 
 Return the Gram matrix of the space `V`.
 """
-gram_matrix(V::AbsSpace) = V.gram
+gram_matrix(V::AbstractSpace) = V.gram
 
 # Once we have quaternion spaces the following makes more sense
 
 @doc Markdown.doc"""
-    base_ring(V::AbsSpace) -> NumField
+    base_ring(V::AbstractSpace) -> NumField
 
 Return the algebra over which the space `V` is defined.
 """
-base_ring(V::AbsSpace) = _base_algebra(V)
+base_ring(V::AbstractSpace) = _base_algebra(V)
 
 @doc Markdown.doc"""
-    fixed_field(V::AbsSpace) -> NumField
+    fixed_field(V::AbstractSpace) -> NumField
 
 Return the fixed field of the space `V`.
 """
-fixed_field(::AbsSpace)
+fixed_field(::AbstractSpace)
 
 @doc Markdown.doc"""
-    involution(V::AbsSpace) -> NumField
+    involution(V::AbstractSpace) -> NumField
 
 Return the involution of the space `V`.
 """
-involution(V::AbsSpace)
+involution(V::AbstractSpace)
 
 ################################################################################
 #
@@ -162,28 +162,28 @@ involution(V::AbsSpace)
 ################################################################################
 
 @doc Markdown.doc"""
-    is_regular(V::AbsSpace) -> Bool
+    is_regular(V::AbstractSpace) -> Bool
 
 Return whether the space `V` is regular, that is, if the Gram matrix
 has full rank.
 """
-function is_regular(V::AbsSpace)
+function is_regular(V::AbstractSpace)
   return rank(V) == dim(V)
 end
 
 @doc Markdown.doc"""
-    is_quadratic(V::AbsSpace) -> Bool
+    is_quadratic(V::AbstractSpace) -> Bool
 
 Return whether the space `V` is quadratic.
 """
-is_quadratic(::AbsSpace)
+is_quadratic(::AbstractSpace)
 
 @doc Markdown.doc"""
-    ishermitian(V::AbsSpace) -> Bool
+    ishermitian(V::AbstractSpace) -> Bool
 
 Return whether the space `V` is hermitian.
 """
-ishermitian(::AbsSpace)
+ishermitian(::AbstractSpace)
 
 ################################################################################
 #
@@ -191,24 +191,24 @@ ishermitian(::AbsSpace)
 #
 ################################################################################
 
-@attr elem_type(fixed_field(V)) function det(V::AbsSpace{S}) where S
+@attr elem_type(fixed_field(V)) function det(V::AbstractSpace{S}) where S
   d = det(gram_matrix(V))
   return fixed_field(V)(d)
 end
 
 @doc Markdown.doc"""
-    det(V::AbsSpace) -> FieldElem
+    det(V::AbstractSpace) -> FieldElem
 
 Return the determinant of the space `V` as an element of its fixed field.
 """
-det(::AbsSpace)
+det(::AbstractSpace)
 
 @doc Markdown.doc"""
-    discriminant(V::AbsSpace) -> FieldElem
+    discriminant(V::AbstractSpace) -> FieldElem
 
 Return the discriminant of the space `V` as an element of its fixed field.
 """
-function discriminant(V::AbsSpace)
+function discriminant(V::AbstractSpace)
   d = det(V)
   n = mod(rank(V), 4)
   if n == 0 || n == 1
@@ -235,11 +235,11 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    gram_matrix(V::AbsSpace, M::MatElem) -> MatElem
+    gram_matrix(V::AbstractSpace, M::MatElem) -> MatElem
 
 Return the Gram matrix of the rows of `M` with respect to the Gram matrix of the space `V`.
 """
-function gram_matrix(V::AbsSpace{T}, M::MatElem{S}) where {S, T}
+function gram_matrix(V::AbstractSpace{T}, M::MatElem{S}) where {S, T}
   @req ncols(M) == dim(V) "Matrix must have $(dim(V)) columns ($(ncols(M)))"
   if S === elem_type(T)
     return M * gram_matrix(V) * transpose(_map(M, involution(V)))
@@ -250,11 +250,11 @@ function gram_matrix(V::AbsSpace{T}, M::MatElem{S}) where {S, T}
 end
 
 @doc Markdown.doc"""
-    gram_matrix(V::AbsSpace, S::Vector{Vector}) -> MatElem
+    gram_matrix(V::AbstractSpace, S::Vector{Vector}) -> MatElem
 
 Return the Gram matrix of the sequence `S` with respect to the Gram matrix of the space `V`.
 """
-function gram_matrix(V::AbsSpace{T}, S::Vector{Vector{U}}) where {T, U}
+function gram_matrix(V::AbstractSpace{T}, S::Vector{Vector{U}}) where {T, U}
   m = zero_matrix(base_ring(V), length(S), rank(V))
   for i in 1:length(S)
     if length(S[i]) != rank(V)
@@ -268,20 +268,20 @@ function gram_matrix(V::AbsSpace{T}, S::Vector{Vector{U}}) where {T, U}
 end
 
 @doc Markdown.doc"""
-    inner_product(V::AbsSpace, v::Vector, w::Vector) -> FieldElem
+    inner_product(V::AbstractSpace, v::Vector, w::Vector) -> FieldElem
 
 Return the inner product of `v` and `w` with respect to the bilinear form of the space `V`.
 """
-inner_product(V::AbsSpace, v::Vector, w::Vector)
+inner_product(V::AbstractSpace, v::Vector, w::Vector)
 
 @doc Markdown.doc"""
-    inner_product(V::AbsSpace, v::MatElem, w::MatElem) -> MatElem
+    inner_product(V::AbstractSpace, v::MatElem, w::MatElem) -> MatElem
 
 Shortcut for `v * gram_matrix(V) * adjoint(w)`.
 """
-inner_product(V::AbsSpace, v::MatElem, w::MatElem)
+inner_product(V::AbstractSpace, v::MatElem, w::MatElem)
 
-_inner_product(L::AbsLat, v, w) = inner_product(ambient_space(L), v, w)
+_inner_product(L::AbstractLat, v, w) = inner_product(ambient_space(L), v, w)
 
 ################################################################################
 #
@@ -290,11 +290,11 @@ _inner_product(L::AbsLat, v, w) = inner_product(ambient_space(L), v, w)
 ################################################################################
 
 @doc Markdown.doc"""
-    orthogonal_basis(V::AbsSpace) -> MatElem
+    orthogonal_basis(V::AbstractSpace) -> MatElem
 
 Return a matrix `M`, such that the rows of `M` form an orthogonal basis of the space `V`.
 """
-function orthogonal_basis(V::AbsSpace)
+function orthogonal_basis(V::AbstractSpace)
   G = gram_matrix(V)
   r, Rad = left_kernel(G)
   if r > 0
@@ -311,14 +311,14 @@ function orthogonal_basis(V::AbsSpace)
 end
 
 @doc Markdown.doc"""
-    diagonal(V::AbsSpace) -> Vector{FieldElem}
+    diagonal(V::AbstractSpace) -> Vector{FieldElem}
 
 Return a vector of elements $a_1,\dotsc,a_n$ such that the space `V` is isometric to
 the diagonal space $\langle a_1,\dotsc,a_n \rangle$.
 
 The elements are contained in the fixed field of `V`.
 """
-diagonal(V::AbsSpace)
+diagonal(V::AbstractSpace)
 
 ################################################################################
 #
@@ -409,11 +409,11 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    is_isometric(L::AbsSpace, M::AbsSpace, p::Union{InfPlc, NfOrdIdl}) -> Bool
+    is_isometric(L::AbstractSpace, M::AbstractSpace, p::Union{InfPlc, NfOrdIdl}) -> Bool
 
 Return whether the spaces `L` and `M` are isometric over the completion at `p`.
 """
-is_isometric(L::AbsSpace, M::AbsSpace, p)
+is_isometric(L::AbstractSpace, M::AbstractSpace, p)
 
 ################################################################################
 #
@@ -422,11 +422,11 @@ is_isometric(L::AbsSpace, M::AbsSpace, p)
 ################################################################################
 
 @doc Markdown.doc"""
-    is_isometric(L::AbsSpace, M::AbsSpace) -> Bool
+    is_isometric(L::AbstractSpace, M::AbstractSpace) -> Bool
 
 Return whether the spaces `L` and `M` are isometric.
 """
-is_isometric(L::AbsSpace, M::AbsSpace)
+is_isometric(L::AbstractSpace, M::AbstractSpace)
 
 ################################################################################
 #
@@ -437,7 +437,7 @@ is_isometric(L::AbsSpace, M::AbsSpace)
 # Returns 0 if V is not definite
 # Returns an element a != 0 such that a * canonical_basis of V has
 # positive Gram matrix
-function _isdefinite(V::AbsSpace)
+function _isdefinite(V::AbstractSpace)
   E = base_ring(V)
   K = fixed_field(V)
   if (!is_totally_real(K)) || (ishermitian(V) && !is_totally_complex(E))
@@ -461,11 +461,11 @@ function _isdefinite(V::AbsSpace)
 end
 
 @doc Markdown.doc"""
-    is_positive_definite(V::AbsSpace) -> Bool
+    is_positive_definite(V::AbstractSpace) -> Bool
 
 Return whether the space `V` is positive definite.
 """
-function is_positive_definite(V::AbsSpace)
+function is_positive_definite(V::AbstractSpace)
   E = base_ring(V)
   K = fixed_field(V)
   if (!is_totally_real(K)) || (ishermitian(V) && !is_totally_complex(E))
@@ -481,11 +481,11 @@ function is_positive_definite(V::AbsSpace)
 end
 
 @doc Markdown.doc"""
-    is_negative_definite(V::AbsSpace) -> Bool
+    is_negative_definite(V::AbstractSpace) -> Bool
 
 Return whether the space `V` is negative definite.
 """
-function is_negative_definite(V::AbsSpace)
+function is_negative_definite(V::AbstractSpace)
   E = base_ring(V)
   K = fixed_field(V)
   if (!is_totally_real(K)) || (ishermitian(V) && !is_totally_complex(E))
@@ -501,11 +501,11 @@ function is_negative_definite(V::AbsSpace)
 end
 
 @doc Markdown.doc"""
-    is_definite(V::AbsSpace) -> Bool
+    is_definite(V::AbstractSpace) -> Bool
 
 Return whether the space `V` is definite.
 """
-function is_definite(V::AbsSpace)
+function is_definite(V::AbstractSpace)
   return is_positive_definite(V) || is_negative_definite(V)
 end
 
@@ -516,31 +516,31 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    is_isotropic(V::AbsSpace) -> Bool
+    is_isotropic(V::AbstractSpace) -> Bool
 
 Return if the space `V` is isotropic.
 
 A space $(V, \Phi)$ is called isotropic if there is a non-zero $v \in V$
 with $\Phi(v,v) = 0$.
 """
-is_isotropic(::AbsSpace)
+is_isotropic(::AbstractSpace)
 
 @doc Markdown.doc"""
-    is_isotropic_with_vector(V::AbsSpace) -> Bool, Vector
+    is_isotropic_with_vector(V::AbstractSpace) -> Bool, Vector
 
 Return if the space `V` is isotropic and an isotropic vector.
 """
-is_isotropic_with_vector(::AbsSpace)
+is_isotropic_with_vector(::AbstractSpace)
 
 @doc Markdown.doc"""
-    is_isotropic(V::AbsSpace, p::Union{NfOrdIdl, InfPlc}) -> Bool
+    is_isotropic(V::AbstractSpace, p::Union{NfOrdIdl, InfPlc}) -> Bool
 
 Given a space `V` and a place `p` in the fixed field `K` of `V`, return
 whether the completion of `V` at `p` is isotropic.
 """
-is_isotropic(::AbsSpace, p)
+is_isotropic(::AbstractSpace, p)
 
-is_isotropic(V::AbsSpace, p::InfPlc) = _isisotropic(V, p)
+is_isotropic(V::AbstractSpace, p::InfPlc) = _isisotropic(V, p)
 
 function _isisotropic(D::Vector{fmpq}, p::PosInf)
   n = length(D)
@@ -567,7 +567,7 @@ function _isisotropic(D::Vector, p::InfPlc)
 end
 
 # this looks wrong
-function _isisotropic(V::AbsSpace, p::InfPlc)
+function _isisotropic(V::AbstractSpace, p::InfPlc)
   n = rank(V)
   d = det(V)
   if dim(V) != rank(V) # degenerate
@@ -591,7 +591,7 @@ end
 # TODO: Change VecSpaceRes/SpaceRes to allow restriction of scalars
 # to non rational subfields
 @doc Markdown.doc"""
-    restrict_scalars(V::AbsSpace, K::FlintRationalField,
+    restrict_scalars(V::AbstractSpace, K::FlintRationalField,
                                   alpha::FieldElem = one(base_ring(V)))
                                                           -> QuadSpace, SpaceRes
 
@@ -603,7 +603,7 @@ The rescaling factor $\alpha$ is set to 1 by default.
 
 Note that for now one can only restrict scalars to $\mathbb Q$.
 """
-function restrict_scalars(V::AbsSpace, K::FlintRationalField,
+function restrict_scalars(V::AbstractSpace, K::FlintRationalField,
                                        alpha::FieldElem = one(base_ring(V)))
   E = base_ring(V)
   n = rank(V)
@@ -642,12 +642,12 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    orthogonal_complement(V::AbsSpace, M::T) where T <: MatElem -> T
+    orthogonal_complement(V::AbstractSpace, M::T) where T <: MatElem -> T
 
 Given a space `V` and a subspace `W` with basis matrix `M`, return a basis
 matrix of the orthogonal complement of `W` inside `V`.
 """
-function orthogonal_complement(V::AbsSpace, M::MatElem)
+function orthogonal_complement(V::AbstractSpace, M::MatElem)
   N = gram_matrix(V) * _map(transpose(M), involution(V))
   r, K = left_kernel(N)
   @assert r == nrows(K)
@@ -655,13 +655,13 @@ function orthogonal_complement(V::AbsSpace, M::MatElem)
 end
 
 @doc Markdown.doc"""
-    orthogonal_projection(V::AbsSpace, M::T) where T <: MatElem -> AbsSpaceMor
+    orthogonal_projection(V::AbstractSpace, M::T) where T <: MatElem -> AbstractSpaceMor
 
 Given a space `V` and a non-degenerate subspace `W` with basis matrix `M`,
 return the endomorphism of `V` corresponding to the projection onto the
 complement of `W` in `V`.
 """
-function orthogonal_projection(V::AbsSpace, M::MatElem)
+function orthogonal_projection(V::AbstractSpace, M::MatElem)
   _Q = inner_product(V, M, M)
   @req rank(_Q) == nrows(_Q) "Subspace must be non-degenerate for the inner product on V"
   U = orthogonal_complement(V, M)
@@ -677,7 +677,7 @@ end
 #
 ################################################################################
 
-function _orthogonal_sum(V::AbsSpace, W::AbsSpace)
+function _orthogonal_sum(V::AbstractSpace, W::AbstractSpace)
   K = base_ring(V)
   G = diagonal_matrix(gram_matrix(V), gram_matrix(W))
   n = dim(V) + dim(W)
@@ -693,13 +693,13 @@ function _orthogonal_sum(V::AbsSpace, W::AbsSpace)
 end
 
 @doc Markdown.doc"""
-    orthogonal_sum(V::AbsSpace, W::AbsSpace) -> AbsSpace, AbsSpaceMor, AbsSpaceMor
+    orthogonal_sum(V::AbstractSpace, W::AbstractSpace) -> AbstractSpace, AbstractSpaceMor, AbstractSpaceMor
 
 Given two spaces `V` and `W` of the same kind (either both hermitian or both quadratic)
 and defined over the same algebra, return their orthogonal sum $V \oplus W$. It is given with
 the two natural embeddings $V \to V\oplus W$ and $W \to V\oplus W$.
 """
-orthogonal_sum(V::AbsSpace, W::AbsSpace)
+orthogonal_sum(V::AbstractSpace, W::AbstractSpace)
 
 function orthogonal_sum(V::QuadSpace, W::QuadSpace)
   @req base_ring(V) === base_ring(W) "Base algebra must be equal"
@@ -726,8 +726,8 @@ function _orthogonal_sum_with_injections_and_projections(x::Vector{<:QuadSpace})
   G = diagonal_matrix(gram_matrix.(x))
   V = quadratic_space(K, G)
   n = sum(dim.(x))
-  inj = AbsSpaceMor[]
-  proj = AbsSpaceMor[]
+  inj = AbstractSpaceMor[]
+  proj = AbstractSpaceMor[]
   dec = 0
   for W in x
     iW = zero_matrix(K, dim(W), n)
@@ -747,8 +747,8 @@ function _orthogonal_sum_with_injections_and_projections(x::Vector{<:QuadSpace})
 end
 
 @doc Markdown.doc"""
-    direct_sum(x::Vararg{QuadSpace}) -> QuadSpace, Vector{AbsSpaceMor}, Vector{AbsSpaceMor}
-    direct_sum(x::Vector{QuadSpace}) -> QuadSpace, Vector{AbsSpaceMor}, Vector{AbsSpaceMor}
+    direct_sum(x::Vararg{QuadSpace}) -> QuadSpace, Vector{AbstractSpaceMor}, Vector{AbstractSpaceMor}
+    direct_sum(x::Vector{QuadSpace}) -> QuadSpace, Vector{AbstractSpaceMor}, Vector{AbstractSpaceMor}
 
 Given a collection of quadratic spaces $V_1, \ldots, V_n$,
 return their complete direct sum $V := V_1 \oplus \ldots \oplus V_n$,
@@ -769,19 +769,19 @@ direct_sum(x::Vector{<:QuadSpace}) = _orthogonal_sum_with_injections_and_project
 ################################################################################
 
 @doc Markdown.doc"""
-    is_locally_represented_by(U::T, V::T, p::NfOrdIdl) where T <: AbsSpace -> Bool
+    is_locally_represented_by(U::T, V::T, p::NfOrdIdl) where T <: AbstractSpace -> Bool
 
 Given two spaces `U` and `V` over the same algebra `E`, and a prime ideal `p` in
 the maximal order $\mathcal O_K$ of their fixed field `K`, return whether `U` is
 represented by `V` locally at `p`, i.e. whether $U_p$ embeds in $V_p$.
 """
-is_locally_represented_by(::AbsSpace, ::AbsSpace, p)
+is_locally_represented_by(::AbstractSpace, ::AbstractSpace, p)
 
 @doc Markdown.doc"""
-    is_represented_by(U::T, V::T) where T <: AbsSpace -> Bool
+    is_represented_by(U::T, V::T) where T <: AbstractSpace -> Bool
 
 Given two spaces `U` and `V` over the same algebra `E`, return whether `U` is
 represented by `V`, i.e. whether `U` embeds in `V`.
 """
-is_represented_by(::AbsSpace, ::AbsSpace)
+is_represented_by(::AbstractSpace, ::AbstractSpace)
 

--- a/src/QuadForm/Torsion.jl
+++ b/src/QuadForm/Torsion.jl
@@ -1,11 +1,11 @@
 export discriminant_group, torsion_quadratic_module, normal_form, genus, is_genus,
-       is_degenerate, cover, relations, orthogonal_submodule, brown_invariant, TorQuadMod,
+       is_degenerate, cover, relations, orthogonal_submodule, brown_invariant,
        modulus_bilinear_form, modulus_quadratic_form, is_isometric_with_isometry,
        is_anti_isometric_with_anti_isometry, has_complement, radical_bilinear,
        radical_quadratic, is_semi_regular
 
 @doc Markdown.doc"""
-    TorQuadMod
+    TorQuadModule
 
 # Example:
 ```jldoctest
@@ -61,7 +61,7 @@ elements of the ambient vector space. Thus if `v::Vector` is such an element
 then the coordinates with respec to the basis of `M` are given by
 `solve_left(basis_matrix(M), v)`.
 """
-@attributes mutable struct TorQuadMod
+@attributes mutable struct TorQuadModule
   ab_grp::GrpAbFinGen             # underlying abelian group
   cover::ZLat                     # ZLat -> ab_grp, x -> x * proj
   rels::ZLat
@@ -74,11 +74,12 @@ then the coordinates with respec to the basis of `M` are given by
   value_module_qf::QmodnZ
   gram_matrix_bilinear::fmpq_mat
   gram_matrix_quadratic::fmpq_mat
-  gens
+  gens 
   is_normal::Bool
 
-  TorQuadMod() = new()
+  TorQuadModule() = new()
 end
+export TorQuadModule
 
 ################################################################################
 #
@@ -92,7 +93,7 @@ end
     torsion_quadratic_module(M::ZLat, N::ZLat; gens::Union{Nothing, Vector{<:Vector}} = nothing,
                                                     snf::Bool = true,
                                                     modulus::fmpq = fmpq(0),
-                                                    check::Bool = true)
+                                                    check::Bool = true) -> TorQuadModule
 
 Given a Z-lattice $M$ and a sublattice $N$ of $M$, return the torsion quadratic
 module $M/N$.
@@ -161,7 +162,7 @@ function torsion_quadratic_module(M::ZLat, N::ZLat; gens::Union{Nothing, Vector{
     modulus_qf = modulus_qf
   end
 
-  T = TorQuadMod()
+  T = TorQuadModule()
   T.cover = M
   T.rels = N
   T.ab_grp = S
@@ -177,7 +178,7 @@ function torsion_quadratic_module(M::ZLat, N::ZLat; gens::Union{Nothing, Vector{
 end
 
 @doc Markdown.doc"""
-    discriminant_group(L::ZLat) -> TorQuadMod
+    discriminant_group(L::ZLat) -> TorQuadModule
 
 Return the discriminant group of `L`.
 
@@ -191,7 +192,7 @@ $$D \times D \to \Q / \Z \qquad (x,y) \mapsto \Phi(x,y) + \Z.$$
 If `L` is even, then the discriminant group is equipped with the discriminant
 quadratic form $D \to \Q / 2 \Z, x \mapsto \Phi(x,x) + 2\Z$.
 """
-@attr function discriminant_group(L::ZLat)::TorQuadMod
+@attr function discriminant_group(L::ZLat)::TorQuadModule
   @req is_integral(L) "The lattice must be integral"
   if rank(L) == 0
     T = torsion_quadratic_module(dual(L), L, modulus = one(QQ), modulus_qf = QQ(2))
@@ -203,29 +204,29 @@ quadratic form $D \to \Q / 2 \Z, x \mapsto \Phi(x,x) + 2\Z$.
 end
 
 @doc Markdown.doc"""
-    order(T::TorQuadMod) -> fmpz
+    order(T::TorQuadModule) -> fmpz
 
 Return the order of `T`
 """
-function order(T::TorQuadMod)
+function order(T::TorQuadModule)
   return order(abelian_group(T))
 end
 
 @doc Markdown.doc"""
-    exponent(T::TorQuadMod) -> fmpz
+    exponent(T::TorQuadModule) -> fmpz
 
 Return the exponent of `T`
 """
-function exponent(T::TorQuadMod)
+function exponent(T::TorQuadModule)
   return exponent(abelian_group(T))
 end
 
 @doc Markdown.doc"""
-    elementary_divisors(T::TorQuadMod) -> Vector{fmpz}
+    elementary_divisors(T::TorQuadModule) -> Vector{fmpz}
 
 Return the elementary divisors of underlying abelian group of `T`.
 """
-function elementary_divisors(T::TorQuadMod)
+function elementary_divisors(T::TorQuadModule)
   return elementary_divisors(abelian_group(T))
 end
 
@@ -236,53 +237,53 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    abelian_group(T::TorQuadMod) -> GrpAbFinGen
+    abelian_group(T::TorQuadModule) -> GrpAbFinGen
 
 Return the underlying abelian group of `T`.
 """
-abelian_group(T::TorQuadMod) = T.ab_grp
+abelian_group(T::TorQuadModule) = T.ab_grp
 
 @doc Markdown.doc"""
-    cover(T::TorQuadMod) -> ZLat
+    cover(T::TorQuadModule) -> ZLat
 
 For $T=M/N$ this returns $M$.
 """
-cover(T::TorQuadMod) = T.cover
+cover(T::TorQuadModule) = T.cover
 
 @doc Markdown.doc"""
-    relations(T::TorQuadMod) -> ZLat
+    relations(T::TorQuadModule) -> ZLat
 
 For $T=M/N$ this returns $N$.
 """
-relations(T::TorQuadMod) = T.rels
+relations(T::TorQuadModule) = T.rels
 
 @doc Markdown.doc"""
-    value_module(T::TorQuadMod)
+    value_module(T::TorQuadModule)
 
 Return the value module `Q/nZ` of the bilinear form of `T`.
 """
-value_module(T::TorQuadMod) = T.value_module
+value_module(T::TorQuadModule) = T.value_module
 
 @doc Markdown.doc"""
-    value_module_quadratic_form(T::TorQuadMod)
+    value_module_quadratic_form(T::TorQuadModule)
 
 Return the value module `Q/mZ` of the quadratic form of `T`.
 """
-value_module_quadratic_form(T::TorQuadMod) = T.value_module_qf
+value_module_quadratic_form(T::TorQuadModule) = T.value_module_qf
 
 @doc Markdown.doc"""
-    modulus_bilinear_form(T::TorQuadMod) -> fmpq
+    modulus_bilinear_form(T::TorQuadModule) -> fmpq
 
 Return the modulus of the value module of the bilinear form of`T`.
 """
-modulus_bilinear_form(T::TorQuadMod) = T.modulus
+modulus_bilinear_form(T::TorQuadModule) = T.modulus
 
 @doc Markdown.doc"""
-    modulus_quadratic_form(T::TorQuadMod) -> fmpq
+    modulus_quadratic_form(T::TorQuadModule) -> fmpq
 
 Return the modulus of the value module of the quadratic form of `T`.
 """
-modulus_quadratic_form(T::TorQuadMod) = T.modulus_qf
+modulus_quadratic_form(T::TorQuadModule) = T.modulus_qf
 
 ################################################################################
 #
@@ -291,11 +292,11 @@ modulus_quadratic_form(T::TorQuadMod) = T.modulus_qf
 ################################################################################
 
 @doc Markdown.doc"""
-    gram_matrix_bilinear(T::TorQuadMod) -> fmpq_mat
+    gram_matrix_bilinear(T::TorQuadModule) -> fmpq_mat
 
 Return the gram matrix of the bilinear form of `T`.
 """
-function gram_matrix_bilinear(T::TorQuadMod)
+function gram_matrix_bilinear(T::TorQuadModule)
   if isdefined(T, :gram_matrix_bilinear)
     return T.gram_matrix_bilinear
   end
@@ -311,14 +312,14 @@ function gram_matrix_bilinear(T::TorQuadMod)
 end
 
 @doc Markdown.doc"""
-    gram_matrix_quadratic(T::TorQuadMod) -> fmpq_mat
+    gram_matrix_quadratic(T::TorQuadModule) -> fmpq_mat
 
 Return the 'gram matrix' of the quadratic form of `T`.
 
 The off diagonal entries are given by the bilinear form whereas the
 diagonal entries are given by the quadratic form.
 """
-function gram_matrix_quadratic(T::TorQuadMod)
+function gram_matrix_quadratic(T::TorQuadModule)
   if isdefined(T, :gram_matrix_quadratic)
     return T.gram_matrix_quadratic
   end
@@ -342,7 +343,7 @@ end
 ################################################################################
 
 # TODO: Print like abelian group
-function Base.show(io::IO, ::MIME"text/plain" , T::TorQuadMod)
+function Base.show(io::IO, ::MIME"text/plain" , T::TorQuadModule)
   @show_name(io, T)
   print(io, "Finite quadratic module over Integer Ring with underlying abelian group\n")
   println(io, abelian_group(T))
@@ -351,17 +352,17 @@ function Base.show(io::IO, ::MIME"text/plain" , T::TorQuadMod)
   show(io,MIME"text/plain"(), gram_matrix_quadratic(T))
 end
 
-function Base.show(io::IO, T::TorQuadMod)
+function Base.show(io::IO, T::TorQuadModule)
   compact = get(io, :compact, false)
   if compact
     name = get_attribute(T,:name)
     if name !== nothing
       print(io, name)
     else
-      print(io, "TorQuadMod ", gram_matrix_quadratic(T))
+      print(io, "TorQuadModule ", gram_matrix_quadratic(T))
     end
   else
-    print(io, "TorQuadMod: ")
+    print(io, "TorQuadModule: ")
     A = abelian_group(T)
     if is_snf(A)
       show_snf_structure(io, abelian_group(T))
@@ -377,15 +378,15 @@ end
 #
 ################################################################################
 
-mutable struct TorQuadModElem
+mutable struct TorQuadModuleElem                                                                                                                                                                                                                                                                                                                                            
   data::GrpAbFinGenElem
-  parent::TorQuadMod
+  parent::TorQuadModule
 
-  TorQuadModElem(T::TorQuadMod, a::GrpAbFinGenElem) = new(a, T)
+  TorQuadModuleElem(T::TorQuadModule, a::GrpAbFinGenElem) = new(a, T)
 end
-export TorQuadModElem
+export TorQuadModuleElem
 
-elem_type(::Type{TorQuadMod}) = TorQuadModElem
+elem_type(::Type{TorQuadModule}) = TorQuadModuleElem
 
 ################################################################################
 #
@@ -394,7 +395,7 @@ elem_type(::Type{TorQuadMod}) = TorQuadModElem
 ################################################################################
 
 @doc Markdown.doc"""
-    (T::TorQuadMod)(a::GrpAbFinGenElem) -> TorQuadModElem
+    (T::TorQuadModule)(a::GrpAbFinGenElem) -> TorQuadModuleElem
 
 Coerce `a` to `T`.
 
@@ -409,21 +410,21 @@ GrpAb: (Z/2)^2 x (Z/4)^2
 julia> A(T(a))==a
 true
 """
-function (T::TorQuadMod)(a::GrpAbFinGenElem)
+function (T::TorQuadModule)(a::GrpAbFinGenElem)
   @req abelian_group(T) === parent(a) "Parents do not match"
-  return TorQuadModElem(T, a)
+  return TorQuadModuleElem(T, a)
 end
 
 # Coerces an element of the ambient space of cover(T) to T
 @doc Markdown.doc"""
-    (T::TorQuadMod)(v::Vector) -> TorQuadModElem
+    (T::TorQuadModule)(v::Vector) -> TorQuadModuleElem
 
 Coerce `v` to `T`.
 
 For `T = M/N` this assumes that `v` lives in the ambient space of `M`
 and $v \in M$.
 """
-function (T::TorQuadMod)(v::Vector)
+function (T::TorQuadModule)(v::Vector)
   @req length(v) == dim(ambient_space(cover(T))) "Vector of wrong length"
   vv = map(FlintQQ, v)
   if eltype(vv) != fmpq
@@ -432,7 +433,7 @@ function (T::TorQuadMod)(v::Vector)
   return T(vv::Vector{fmpq})
 end
 
-function (T::TorQuadMod)(v::Vector{fmpq})
+function (T::TorQuadModule)(v::Vector{fmpq})
   @req length(v) == degree(cover(T)) "Vector of wrong length"
   vv = matrix(FlintQQ, 1, length(v), v)
   vv = change_base_ring(FlintZZ, solve_left(basis_matrix(cover(T)), vv))
@@ -445,7 +446,7 @@ end
 #
 ################################################################################
 
-function Base.show(io::IO, a::TorQuadModElem)
+function Base.show(io::IO, a::TorQuadModuleElem)
   v = a.data.coeff
   print(io, "[")
   for i in 1:length(v)
@@ -464,7 +465,7 @@ end
 #
 ################################################################################
 
-function Base.:(==)(a::TorQuadModElem, b::TorQuadModElem)
+function Base.:(==)(a::TorQuadModuleElem, b::TorQuadModuleElem)
   if parent(a) !== parent(b)
     return false
   else
@@ -472,7 +473,7 @@ function Base.:(==)(a::TorQuadModElem, b::TorQuadModElem)
   end
 end
 
-iszero(a::TorQuadModElem) = iszero(a.data)
+iszero(a::TorQuadModuleElem) = iszero(a.data)
 
 ################################################################################
 #
@@ -480,21 +481,21 @@ iszero(a::TorQuadModElem) = iszero(a.data)
 #
 ################################################################################
 
-function gens(T::TorQuadMod)
+function gens(T::TorQuadModule)
   if isdefined(T, :gens)
-    return T.gens::Vector{TorQuadModElem}
+    return T.gens::Vector{TorQuadModuleElem}
   else
-    _gens = TorQuadModElem[T(g) for g in gens(abelian_group(T))]
+    _gens = TorQuadModuleElem[T(g) for g in gens(abelian_group(T))]
     T.gens = _gens
     return _gens
   end
 end
 
-ngens(T::TorQuadMod) = length(T.gens_lift)
+ngens(T::TorQuadModule) = length(T.gens_lift)
 
 
 @doc Markdown.doc"""
-    getindex(T::TorQuadMod, i::Int) -> TorQuadModElem
+    getindex(T::TorQuadModule, i::Int) -> TorQuadModuleElem
 
 Return the `i`-th generator of `T`.
 
@@ -513,24 +514,24 @@ julia> D[2]
 [0, 1, 0, 0]
 ```
 """
-function getindex(T::TorQuadMod, i::Int)
+function getindex(T::TorQuadModule, i::Int)
   if isdefined(T, :gens)
     return gens(T)[i]
   end
   return T(abelian_group(T)[i])
 end
 
-parent(a::TorQuadModElem) = a.parent
+parent(a::TorQuadModuleElem) = a.parent
 
 @doc Markdown.doc"""
-    data(a::TorQuadModElem) -> GrpAbFinGenElem
+    data(a::TorQuadModuleElem) -> GrpAbFinGenElem
 
 Return `a` as an element of the underlying abelian group.
 """
-data(a::TorQuadModElem) = a.data
+data(a::TorQuadModuleElem) = a.data
 
 @doc Markdown.doc"""
-    (A::GrpAbFinGen)(a::TorQuadModElem)
+    (A::GrpAbFinGen)(a::TorQuadModuleElem)
 
 Return `a` as an element of the underlying abelian group.
 
@@ -550,7 +551,7 @@ julia> d == D(A(d))
 true
 ```
 """
-function (A::GrpAbFinGen)(a::TorQuadModElem)
+function (A::GrpAbFinGen)(a::TorQuadModuleElem)
   @req A === abelian_group(parent(a)) "Parents do not match"
   return a.data
 end
@@ -561,33 +562,33 @@ end
 #
 ################################################################################
 
-function Base.:(+)(a::TorQuadModElem, b::TorQuadModElem)
+function Base.:(+)(a::TorQuadModuleElem, b::TorQuadModuleElem)
   @req parent(a) === parent(b) "Parents do not match"
   T = parent(a)
   return T(a.data + b.data)
 end
 
-function Base.:(-)(a::TorQuadModElem)
+function Base.:(-)(a::TorQuadModuleElem)
   T = parent(a)
   return T(-a.data)
 end
 
-function Base.:(-)(a::TorQuadModElem, b::TorQuadModElem)
+function Base.:(-)(a::TorQuadModuleElem, b::TorQuadModuleElem)
   @req parent(a) === parent(b) "Parents do not match"
   T = parent(a)
   return T(a.data - b.data)
 end
 
-function Base.:(*)(a::TorQuadModElem, b::fmpz)
+function Base.:(*)(a::TorQuadModuleElem, b::fmpz)
   T = parent(a)
   return T(a.data * b)
 end
 
-Base.:(*)(a::fmpz, b::TorQuadModElem) = b * a
+Base.:(*)(a::fmpz, b::TorQuadModuleElem) = b * a
 
-Base.:(*)(a::Integer, b::TorQuadModElem) = fmpz(a) * b
+Base.:(*)(a::Integer, b::TorQuadModuleElem) = fmpz(a) * b
 
-Base.:(*)(a::TorQuadModElem, b::Integer) = b * a
+Base.:(*)(a::TorQuadModuleElem, b::Integer) = b * a
 
 ################################################################################
 #
@@ -595,18 +596,18 @@ Base.:(*)(a::TorQuadModElem, b::Integer) = b * a
 #
 ################################################################################
 
-function Base.:(*)(a::TorQuadModElem, b::TorQuadModElem)
+function Base.:(*)(a::TorQuadModuleElem, b::TorQuadModuleElem)
   T = parent(a)
   z = inner_product(ambient_space(cover(T)), lift(a), lift(b))
   return value_module(T)(z)
 end
 
 @doc Markdown.doc"""
-    inner_product(a::TorQuadModElem, b::TorQuadModElem)
+    inner_product(a::TorQuadModuleElem, b::TorQuadModuleElem)
 
 Return the inner product of `a` and `b`.
 """
-inner_product(a::TorQuadModElem, b::TorQuadModElem)=(a*b)
+inner_product(a::TorQuadModuleElem, b::TorQuadModuleElem)=(a*b)
 
 ################################################################################
 #
@@ -615,7 +616,7 @@ inner_product(a::TorQuadModElem, b::TorQuadModElem)=(a*b)
 ################################################################################
 
 @doc Markdown.doc"""
-    quadratic_product(a::TorQuadModElem)
+    quadratic_product(a::TorQuadModuleElem)
 
 Return the quadratic product of `a`.
 
@@ -623,7 +624,7 @@ It is defined in terms of a representative:
 for $b + M \in M/N=T$ this returns
 $\Phi(b,b) + n \Z$..
 """
-function quadratic_product(a::TorQuadModElem)
+function quadratic_product(a::TorQuadModuleElem)
   T = parent(a)
   al = lift(a)
   z = inner_product(ambient_space(cover(T)), al, al)
@@ -636,7 +637,7 @@ end
 #
 ################################################################################
 
-order(a::TorQuadModElem) = order(a.data)
+order(a::TorQuadModuleElem) = order(a.data)
 
 ################################################################################
 #
@@ -645,25 +646,25 @@ order(a::TorQuadModElem) = order(a.data)
 ################################################################################
 
 @doc Markdown.doc"""
-    lift(a::TorQuadModElem) -> Vector{fmpq}
+    lift(a::TorQuadModuleElem) -> Vector{fmpq}
 
 Lift `a` to the ambient space of `cover(parent(a))`.
 
 For $a + N \in M/N$ this returns the representative $a$.
 """
-function lift(a::TorQuadModElem)
+function lift(a::TorQuadModuleElem)
   T = parent(a)
   z = change_base_ring(FlintQQ, a.data.coeff) * T.gens_lift_mat
   return fmpq[z[1, i] for i in 1:ncols(z)]
 end
 
 @doc Markdown.doc"""
-    representative(a::TorQuadModElem) -> Vector{fmpq}
+    representative(a::TorQuadModuleElem) -> Vector{fmpq}
 
 For $a + N \in M/N$ this returns the representative $a$.
 An alias for `lift(a)`.
 """
-representative(x::TorQuadModElem) = lift(x)
+representative(x::TorQuadModuleElem) = lift(x)
 
 ################################################################################
 #
@@ -671,18 +672,18 @@ representative(x::TorQuadModElem) = lift(x)
 #
 ################################################################################
 
-Base.length(T::TorQuadMod) = Int(order(T))
+Base.length(T::TorQuadModule) = Int(order(T))
 
-Base.IteratorSize(::Type{TorQuadMod}) = Base.HasLength()
+Base.IteratorSize(::Type{TorQuadModule}) = Base.HasLength()
 
-Base.eltype(::Type{TorQuadMod}) = TorQuadModElem
+Base.eltype(::Type{TorQuadModule}) = TorQuadModuleElem
 
-function Base.iterate(T::TorQuadMod)
+function Base.iterate(T::TorQuadModule)
   a, st = iterate(abelian_group(T))
   return T(a), st
 end
 
-function Base.iterate(T::TorQuadMod, st::UInt)
+function Base.iterate(T::TorQuadModule, st::UInt)
   st >= order(T) && return nothing
   a, st = iterate(abelian_group(T), st)
   return T(a), st
@@ -690,35 +691,35 @@ end
 
 ################################################################################
 #
-#  Maps between torsion quadratic modules
+#  Map between torsion quadratic modules
 #
 ################################################################################
 
-mutable struct TorQuadModMor <: Map{TorQuadMod, TorQuadMod, HeckeMap, TorQuadModMor}
-  header::MapHeader{TorQuadMod, TorQuadMod}
+mutable struct TorQuadModuleMor <: Map{TorQuadModule, TorQuadModule, HeckeMap, TorQuadModuleMor}                                                                                                                                                                                                                                                                            
+  header::MapHeader{TorQuadModule, TorQuadModule}
   map_ab::GrpAbFinGenMap
 
-  function TorQuadModMor(T::TorQuadMod, S::TorQuadMod, m::GrpAbFinGenMap)
+  function TorQuadModuleMor(T::TorQuadModule, S::TorQuadModule, m::GrpAbFinGenMap)
     z = new()
     z.header = MapHeader(T, S)
     z.map_ab = m
     return z
   end
 end
-export TorQuadModMor
+export TorQuadModuleMor
 
 ################################################################################
 #
-#  User constructors
+#  User constructores
 #
 ################################################################################
 
-function hom(T::TorQuadMod, S::TorQuadMod, M::fmpz_mat)
+function hom(T::TorQuadModule, S::TorQuadModule, M::fmpz_mat)
   map_ab = hom(abelian_group(T), abelian_group(S), M)
-  return TorQuadModMor(T, S, map_ab)
+  return TorQuadModuleMor(T, S, map_ab)
 end
 
-function hom(T::TorQuadMod, S::TorQuadMod, img::Vector{TorQuadModElem})
+function hom(T::TorQuadModule, S::TorQuadModule, img::Vector{TorQuadModuleElem})
   _img = GrpAbFinGenElem[]
   @req length(img) == ngens(T) "Wrong number of elements"
   for g in img
@@ -726,72 +727,72 @@ function hom(T::TorQuadMod, S::TorQuadMod, img::Vector{TorQuadModElem})
     push!(_img, abelian_group(S)(g))
   end
   map_ab = hom(abelian_group(T), abelian_group(S), _img)
-  return TorQuadModMor(T, S, map_ab)
+  return TorQuadModuleMor(T, S, map_ab)
 end
 
-function identity_map(T::TorQuadMod)
+function identity_map(T::TorQuadModule)
   map_ab = id_hom(abelian_group(T))
-  return TorQuadModMor(T, T, map_ab)
+  return TorQuadModuleMor(T, T, map_ab)
 end
 
-id_hom(T::TorQuadMod) = identity_map(T)
+id_hom(T::TorQuadModule) = identity_map(T)
 
-function inv(f::TorQuadModMor)
+function inv(f::TorQuadModuleMor)
   map_ab = inv(f.map_ab)
-  return TorQuadModMor(codomain(f),domain(f),map_ab)
+  return TorQuadModuleMor(codomain(f),domain(f),map_ab)
 end
 
-function compose(f::TorQuadModMor, g::TorQuadModMor)
+function compose(f::TorQuadModuleMor, g::TorQuadModuleMor)
   codomain(f) == domain(g) || error("incompatible (co)domains")
   map_ab = compose(f.map_ab, g.map_ab)
-  return TorQuadModMor(domain(f), codomain(g), map_ab)
+  return TorQuadModuleMor(domain(f), codomain(g), map_ab)
 end
 
-function image(f::TorQuadModMor, a::TorQuadModElem)
+function image(f::TorQuadModuleMor, a::TorQuadModuleElem)
   A = abelian_group(domain(f))
   return codomain(f)(f.map_ab(A(a)))
 end
 
-function preimage(f::TorQuadModMor, a::TorQuadModElem)
+function preimage(f::TorQuadModuleMor, a::TorQuadModuleElem)
   A = abelian_group(codomain(f))
   return domain(f)(f.map_ab\(A(a)))
 end
 
 @doc Markdown.doc"""
-    is_bijective(f::TorQuadModMor) -> Bool
+    is_bijective(f::TorQuadModuleMor) -> Bool
 
 Return whether `f` is bijective.
 """
-is_bijective(f::TorQuadModMor) = is_bijective(f.map_ab)
+is_bijective(f::TorQuadModuleMor) = is_bijective(f.map_ab)
 
 @doc Markdown.doc"""
-    is_surjective(f::TorQuadModMor) -> Bool
+    is_surjective(f::TorQuadModuleMor) -> Bool
 
 Return whether `f` is surjective.
 """
-is_surjective(f::TorQuadModMor) = is_surjective(f.map_ab)
+is_surjective(f::TorQuadModuleMor) = is_surjective(f.map_ab)
 
 @doc Markdown.doc"""
-    is_injective(f::TorQuadModMor) -> Bool
+    is_injective(f::TorQuadModuleMor) -> Bool
 
 Return whether `f` is injective.
 """
-is_injective(f::TorQuadModMor) = is_injective(f.map_ab)
+is_injective(f::TorQuadModuleMor) = is_injective(f.map_ab)
 
 # Rely on the algorithm implemeted for GrpAbFinGenMap
 @doc Markdown.doc"""
-    has_complement(i::TorQuadModMor) -> Bool, TorQuadModMor
+    has_complement(i::TorQuadModuleMor) -> Bool, TorQuadModuleMor
 
 Given a map representing the injection of a submodule $W$ of a torsion
 quadratic module $T$, return whether $W$ has an orthogonal complement
 $U$ in $T$. If yes, it returns an injection $U \to T$.
 """
-function has_complement(i::TorQuadModMor)
+function has_complement(i::TorQuadModuleMor)
   @req is_injective(i) "i must be injective"
   T = codomain(i)
   bool, jab = Hecke.has_complement(i.map_ab)
   if !bool
-    return (false, sub(T, TorQuadModElem[])[2])
+    return (false, sub(T, TorQuadModuleElem[])[2])
   end
   Qab = domain(jab)
   Q, j = sub(T, [T(jab(a)) for a in gens(Qab)])
@@ -806,7 +807,7 @@ end
 
 # we test isometry in the semi-regular case: we compare the gram matrices of the
 # quadratic forms associated to the respective normal forms.
-function _isometry_semiregular(T::TorQuadMod, U::TorQuadMod)
+function _isometry_semiregular(T::TorQuadModule, U::TorQuadModule)
   # the zero map for default output
   hz = hom(T, U, zero_matrix(ZZ, ngens(T), ngens(U)))
   NT, TtoNT = normal_form(T)
@@ -828,7 +829,7 @@ end
 # "Not yet implemented". If yes, we compare the normal forms of the respective complements
 # which are semi-regular, and if the radicals have the same elementary divisors, we
 # complete the isometry by adding the identity matrix from one radical to the other one.
-function _isometry_degenerate(T::TorQuadMod, U::TorQuadMod)
+function _isometry_degenerate(T::TorQuadModule, U::TorQuadModule)
   # the zero map for default output
   hz = hom(T, U, zero_matrix(ZZ, ngens(T), ngens(U)))
   rqT, rqTtoT = radical_quadratic(T)
@@ -854,10 +855,10 @@ function _isometry_degenerate(T::TorQuadMod, U::TorQuadMod)
   # now we know that there is an isometry, just need to put everything together
   # we first tidy the generators of the radicals up
   AT, ATtoab = snf(abelian_group(rqT))
-  geneT = TorQuadModElem[rqT(a) for a in ATtoab.(gens(AT))]
+  geneT = TorQuadModuleElem[rqT(a) for a in ATtoab.(gens(AT))]
   @assert sort(order.(geneT)) == sort(elementary_divisors(rqT))
   AU, AUtoab = snf(abelian_group(rqU))
-  geneU = TorQuadModElem[rqU(a) for a in AUtoab.(gens(AU))]
+  geneU = TorQuadModuleElem[rqU(a) for a in AUtoab.(gens(AU))]
   @assert sort(order.(geneU)) == sort(elementary_divisors(rqU))
   # we map generators of the radical and its complement in the module
   # to obtain an isomorphic module with a nicer basis
@@ -885,11 +886,11 @@ end
 
 # This is a fallback function to cover the case where T and U are not semiregular
 # and they both do not split their radical quadratic.
-function _isometry_non_split_degenerate(T::TorQuadMod, U::TorQuadMod)
+function _isometry_non_split_degenerate(T::TorQuadModule, U::TorQuadModule)
   Ts, TstoT = snf(T)
   n = ngens(Ts)
   u_cand = [[u for u in U if quadratic_product(u) == quadratic_product(t) && order(u) == order(t)] for t in gens(Ts)]
-  waiting = Vector{TorQuadModElem}[[]]
+  waiting = Vector{TorQuadModuleElem}[[]]
   while !isempty(waiting)
     f = pop!(waiting)
     i = length(f)
@@ -913,8 +914,8 @@ function _isometry_non_split_degenerate(T::TorQuadMod, U::TorQuadMod)
 end
 
 @doc Markdown.doc"""
-    is_isometric_with_isometry(T::TorQuadMod, U::TorQuadMod)
-                                                   -> Bool, TorQuadModMor
+    is_isometric_with_isometry(T::TorQuadModule, U::TorQuadModule)
+                                                   -> Bool, TorQuadModuleMor
 
 Return whether the torsion quadratic modules `T` and `U` are isometric.
 If yes, it also returns an isometry $T \to U$.
@@ -960,46 +961,46 @@ julia> bool, phi = is_isometric_with_isometry(T,U)
 (true, Map with following data
 Domain:
 =======
-TorQuadMod [2//3 2//3 0 0 0; 2//3 2//3 2//3 0 2//3; 0 2//3 2//3 2//3 0; 0 0 2//3 2//3 0; 0 2//3 0 0 2//3]
+TorQuadModule [2//3 2//3 0 0 0; 2//3 2//3 2//3 0 2//3; 0 2//3 2//3 2//3 0; 0 0 2//3 2//3 0; 0 2//3 0 0 2//3]
 Codomain:
 =========
-TorQuadMod [4//3 0 0 0 0; 0 4//3 0 0 0; 0 0 4//3 0 0; 0 0 0 4//3 0; 0 0 0 0 4//3])
+TorQuadModule [4//3 0 0 0 0; 0 4//3 0 0 0; 0 0 4//3 0 0; 0 0 0 4//3 0; 0 0 0 0 4//3])
 
 julia> is_bijective(phi)
 true
 
 julia> T2, _ = sub(T, [-T[4], T[2]+T[3]+T[5]])
-(TorQuadMod: (Z/3)^2 [2//3 1//3; 1//3 2//3], Map with following data
+(TorQuadModule: (Z/3)^2 [2//3 1//3; 1//3 2//3], Map with following data
 Domain:
 =======
-TorQuadMod [2//3 1//3; 1//3 2//3]
+TorQuadModule [2//3 1//3; 1//3 2//3]
 Codomain:
 =========
-TorQuadMod [2//3 2//3 0 0 0; 2//3 2//3 2//3 0 2//3; 0 2//3 2//3 2//3 0; 0 0 2//3 2//3 0; 0 2//3 0 0 2//3])
+TorQuadModule [2//3 2//3 0 0 0; 2//3 2//3 2//3 0 2//3; 0 2//3 2//3 2//3 0; 0 0 2//3 2//3 0; 0 2//3 0 0 2//3])
 
 julia> U2, _ = sub(T, [T[4], T[2]+T[3]+T[5]])
-(TorQuadMod: (Z/3)^2 [2//3 2//3; 2//3 2//3], Map with following data
+(TorQuadModule: (Z/3)^2 [2//3 2//3; 2//3 2//3], Map with following data
 Domain:
 =======
-TorQuadMod [2//3 2//3; 2//3 2//3]
+TorQuadModule [2//3 2//3; 2//3 2//3]
 Codomain:
 =========
-TorQuadMod [2//3 2//3 0 0 0; 2//3 2//3 2//3 0 2//3; 0 2//3 2//3 2//3 0; 0 0 2//3 2//3 0; 0 2//3 0 0 2//3])
+TorQuadModule [2//3 2//3 0 0 0; 2//3 2//3 2//3 0 2//3; 0 2//3 2//3 2//3 0; 0 0 2//3 2//3 0; 0 2//3 0 0 2//3])
 
 julia> bool, phi = is_isometric_with_isometry(U2, T2)
 (true, Map with following data
 Domain:
 =======
-TorQuadMod [2//3 2//3; 2//3 2//3]
+TorQuadModule [2//3 2//3; 2//3 2//3]
 Codomain:
 =========
-TorQuadMod [2//3 1//3; 1//3 2//3])
+TorQuadModule [2//3 1//3; 1//3 2//3])
 
 julia> is_bijective(phi)
 true
 ```
 """
-function is_isometric_with_isometry(T::TorQuadMod, U::TorQuadMod)
+function is_isometric_with_isometry(T::TorQuadModule, U::TorQuadModule)
   if T === U
     return (true, id_hom(T))
   end
@@ -1042,8 +1043,8 @@ function is_isometric_with_isometry(T::TorQuadMod, U::TorQuadMod)
 end
 
 @doc Markdown.doc"""
-    is_anti_isometric_with_anti_isometry(T::TorQuadMod, U::TorQuadMod)
-                                                     -> Bool, TorQuadModMor
+    is_anti_isometric_with_anti_isometry(T::TorQuadModule, U::TorQuadModule)
+                                                     -> Bool, TorQuadModuleMor
 
 Return whether there exists an anti-isometry between the torsion quadratic
 modules `T` and `U`. If yes, it returns such an anti-isometry $T \to U$.
@@ -1067,10 +1068,10 @@ julia> bool, phi = is_anti_isometric_with_anti_isometry(T, T)
 (true, Map with following data
 Domain:
 =======
-TorQuadMod [4//5]
+TorQuadModule [4//5]
 Codomain:
 =========
-TorQuadMod [4//5])
+TorQuadModule [4//5])
 
 julia> a = gens(T)[1];
 
@@ -1115,10 +1116,10 @@ julia> bool, phi = is_anti_isometric_with_anti_isometry(T,T)
 (true, Map with following data
 Domain:
 =======
-TorQuadMod [3//5]
+TorQuadModule [3//5]
 Codomain:
 =========
-TorQuadMod [3//5])
+TorQuadModule [3//5])
 
 julia> a = gens(T)[1];
 
@@ -1126,7 +1127,7 @@ julia> a*a == -phi(a)*phi(a)
 true
 ```
 """
-function is_anti_isometric_with_anti_isometry(T::TorQuadMod, U::TorQuadMod)
+function is_anti_isometric_with_anti_isometry(T::TorQuadModule, U::TorQuadModule)
   # the zero map for default output
   hz = hom(T, U, zero_matrix(ZZ, ngens(T), ngens(U)))
   if order(T) != order(U)
@@ -1180,12 +1181,12 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    sub(T::TorQuadMod, generators::Vector{TorQuadModElem})
-                                                    -> TorQuadMod, TorQuadModMor
+    sub(T::TorQuadModule, generators::Vector{TorQuadModuleElem})
+                                                    -> TorQuadModule, TorQuadModuleMor
 
 Return the submodule of `T` defined by `generators` and the inclusion morphism.
 """
-function sub(T::TorQuadMod, gens::Vector{TorQuadModElem})
+function sub(T::TorQuadModule, gens::Vector{TorQuadModuleElem})
   @req all(parent(x)===T for x in gens) "generators must lie in T"
   if length(gens) > 0
     _gens = [lift(g) for g in gens]
@@ -1205,7 +1206,7 @@ function sub(T::TorQuadMod, gens::Vector{TorQuadModElem})
 end
 
 @doc Markdown.doc"""
-    torsion_quadratic_module(q::fmpq_mat) -> TorQuadMod
+    torsion_quadratic_module(q::fmpq_mat) -> TorQuadModule
 
 Return a torsion quadratic module with gram matrix given by `q` and
 value module `Q/Z`.
@@ -1254,28 +1255,28 @@ function torsion_quadratic_module(q::fmpq_mat)
   return torsion_quadratic_module(L, LL, modulus = fmpq(1))
 end
 
-TorQuadMod(q::fmpq_mat) = torsion_quadratic_module(q)
+TorQuadModule(q::fmpq_mat) = torsion_quadratic_module(q)
 
 @doc Markdown.doc"""
-    primary_part(T::TorQuadMod, m::fmpz)-> Tuple{TorQuadMod, TorQuadModMor}
+    primary_part(T::TorQuadModule, m::fmpz)-> Tuple{TorQuadModule, TorQuadModuleMor}
 
 Return the primary part of `T` as a submodule.
 """
-function primary_part(T::TorQuadMod, m::fmpz)
+function primary_part(T::TorQuadModule, m::fmpz)
   S, i = primary_part(T.ab_grp, m, false)
   genprimary = [i(s) for s in gens(S)]
   submod = sub(T, [T(a) for a in genprimary])
   return submod
 end
 
-primary_part(T::TorQuadMod,m::Int) = primary_part(T,ZZ(m))
+primary_part(T::TorQuadModule,m::Int) = primary_part(T,ZZ(m))
 
 @doc Markdown.doc"""
-    orthogonal_submodule(T::TorQuadMod, S::TorQuadMod)-> TorQuadMod
+    orthogonal_submodule(T::TorQuadModule, S::TorQuadModule)-> TorQuadModule
 
 Return the orthogonal submodule to the submodule `S` of `T`.
 """
-function orthogonal_submodule(T::TorQuadMod, S::TorQuadMod)
+function orthogonal_submodule(T::TorQuadModule, S::TorQuadModule)
   @assert is_sublattice(cover(T), cover(S)) "The second argument is not a submodule of the first argument"
   V = ambient_space(cover(T))
   G = gram_matrix(V)
@@ -1296,40 +1297,40 @@ function orthogonal_submodule(T::TorQuadMod, S::TorQuadMod)
 end
 
 @doc Markdown.doc"""
-    is_degenerate(T::TorQuadMod) -> Bool
+    is_degenerate(T::TorQuadModule) -> Bool
 
 Return true if the underlying bilinear form is degenerate.
 """
-function is_degenerate(T::TorQuadMod)
+function is_degenerate(T::TorQuadModule)
   return get_attribute!(T,:is_degenerate) do
     return order(orthogonal_submodule(T,T)[1]) != 1
   end
 end
 
 @doc Markdown.doc"""
-    is_semi_regular(T::TorQuadMod) -> Bool
+    is_semi_regular(T::TorQuadModule) -> Bool
 
 Return whether `T` is semi-regular, that is its quadratic radical is trivial
 (see [`radical_quadratic`](@ref)).
 """
-is_semi_regular(T::TorQuadMod) = is_trivial(abelian_group(radical_quadratic(T)[1]))
+is_semi_regular(T::TorQuadModule) = is_trivial(abelian_group(radical_quadratic(T)[1]))
 
 @doc Markdown.doc"""
-    radical_bilinear(T::TorQuadMod) -> TorQuadMod, TorQuadModMor
+    radical_bilinear(T::TorQuadModule) -> TorQuadModule, TorQuadModuleMor
 
 Return the radical `\{x \in T | b(x,T) = 0\}` of the bilinear form `b` on `T`.
 """
-function radical_bilinear(T::TorQuadMod)
+function radical_bilinear(T::TorQuadModule)
   return orthogonal_submodule(T,T)
 end
 
 @doc Markdown.doc"""
-    radical_quadratic(T::TorQuadMod) -> TorQuadMod, TorQuadModMor
+    radical_quadratic(T::TorQuadModule) -> TorQuadModule, TorQuadModuleMor
 
 Return the radical `\{x \in T | b(x,T) = 0 and q(x)=0\}` of the quadratic form
 `q` on `T`.
 """
-function radical_quadratic(T::TorQuadMod)
+function radical_quadratic(T::TorQuadModule)
   Kb, ib = radical_bilinear(T)
   G = gram_matrix_quadratic(Kb)*1//modulus_bilinear_form(Kb)
   F = GF(2, cached=false)
@@ -1338,21 +1339,21 @@ function radical_quadratic(T::TorQuadMod)
   kermat = lift(kermat[1:r,:])
   g = gens(Kb)
   n = length(g)
-  kergen = TorQuadModElem[sum(kermat[i,j]*g[j] for j in 1:n) for i in 1:r]
+  kergen = TorQuadModuleElem[sum(kermat[i,j]*g[j] for j in 1:n) for i in 1:r]
   Kq, iq = sub(Kb,kergen)
   @assert iszero(gram_matrix_quadratic(Kq))
   return Kq, compose(iq,ib)
 end
 
 @doc Markdown.doc"""
-    rescale(T::TorQuadMod, k::RingElement) -> TorQuadMod
+    rescale(T::TorQuadModule, k::RingElement) -> TorQuadModule
 
 Return the torsion quadratic module with quadratic form scaled by ``k``,
 where k is a non-zero rational number.
 If the old form was defined modulo `n`, then the new form is defined
 modulo `n k`.
 """
-function rescale(T::TorQuadMod, k::RingElement)
+function rescale(T::TorQuadModule, k::RingElement)
   @req !iszero(k) "Parameter ($k) must be non-zero"
   C = cover(T)
   V = rescale(ambient_space(C), k)
@@ -1365,7 +1366,7 @@ function rescale(T::TorQuadMod, k::RingElement)
 end
 
 @doc Markdown.doc"""
-    normal_form(T::TorQuadMod; partial=false) -> TorQuadMod, TorQuadModMor
+    normal_form(T::TorQuadModule; partial=false) -> TorQuadModule, TorQuadModuleMor
 
 Return the normal form `N` of the given torsion quadratic module `T` along
 with the projection `T -> N`.
@@ -1374,7 +1375,7 @@ Let `K` be the radical of the quadratic form of `T`. Then `N = T/K` is
 half-regular. Two half-regular torsion quadratic modules are isometric
 if and only if they have equal normal forms.
 """
-function normal_form(T::TorQuadMod; partial=false)
+function normal_form(T::TorQuadModule; partial=false)
   if T.is_normal
     return T, id_hom(T)
   end
@@ -1386,7 +1387,7 @@ function normal_form(T::TorQuadMod; partial=false)
     N = T
     i = identity_map(T)
   end
-  normal_gens = TorQuadModElem[]
+  normal_gens = TorQuadModuleElem[]
   prime_div = prime_divisors(exponent(N))
   for p in prime_div
     D_p, I_p = primary_part(N, p)
@@ -1491,7 +1492,7 @@ function _brown_indecomposable(q::MatElem, p::fmpz)
 end
 
 @doc Markdown.doc"""
-    brown_invariant(self::TorQuadMod) -> Nemo.nmod
+    brown_invariant(self::TorQuadModule) -> Nemo.nmod
 Return the Brown invariant of this torsion quadratic form.
 
 Let `(D,q)` be a torsion quadratic module with values in `Q / 2Z`.
@@ -1513,7 +1514,7 @@ julia> brown_invariant(T)
 4
 ```
 """
-function brown_invariant(T::TorQuadMod)
+function brown_invariant(T::TorQuadModule)
   @req modulus_quadratic_form(T) == 2 "the torsion quadratic form must have values in Q/2Z"
   @req !is_degenerate(T) "the torsion quadratic form must be non-degenerate"
   brown = ResidueRing(ZZ, 8)(0)
@@ -1529,7 +1530,7 @@ function brown_invariant(T::TorQuadMod)
 end
 
 @doc Markdown.doc"""
-    genus(T::TorQuadMod, signature_pair::Tuple{Int, Int}) -> ZGenus
+    genus(T::TorQuadModule, signature_pair::Tuple{Int, Int}) -> ZGenus
 
 Return the genus of an integer lattice with discriminant group `T` and the
 given `signature_pair`. If no such genus exists, raise an error.
@@ -1537,7 +1538,7 @@ given `signature_pair`. If no such genus exists, raise an error.
 # Reference
 [Nik79](@cite) Corollary 1.9.4 and 1.16.3.
 """
-function genus(T::TorQuadMod, signature_pair::Tuple{Int, Int})
+function genus(T::TorQuadModule, signature_pair::Tuple{Int, Int})
   s_plus = signature_pair[1]
   s_minus = signature_pair[2]
   rank = s_plus + s_minus
@@ -1679,11 +1680,11 @@ end
 
 
 @doc Markdown.doc"""
-    is_genus(T::TorQuadMod, signature_pair::Tuple{Int, Int}) -> Bool
+    is_genus(T::TorQuadModule, signature_pair::Tuple{Int, Int}) -> Bool
 
 Return if there is an integral lattice with this signature and discriminant form.
 """
-function is_genus(T::TorQuadMod, signature_pair::Tuple{Int, Int})
+function is_genus(T::TorQuadModule, signature_pair::Tuple{Int, Int})
   try
     genus(T,signature_pair)
     return true
@@ -1692,7 +1693,7 @@ function is_genus(T::TorQuadMod, signature_pair::Tuple{Int, Int})
   end
 end
 
-function _is_genus_brown(T::TorQuadMod, signature_pair::Tuple{Int, Int})
+function _is_genus_brown(T::TorQuadModule, signature_pair::Tuple{Int, Int})
   s_plus = signature_pair[1]
   s_minus = signature_pair[2]
   even = modulus_quadratic_form(T) == 2
@@ -1760,8 +1761,8 @@ end
 ###############################################################################
 
 @doc Markdown.doc"""
-    orthogonal_sum(T::TorQuadMod, U::TorQuadMod)
-                                    -> TorQuadMod, TorQuadModMor, TorQuadModMor
+    orthogonal_sum(T::TorQuadModule, U::TorQuadModule)
+                                    -> TorQuadModule, TorQuadModuleMor, TorQuadModuleMor
 
 Return the orthogonal direct sum `S` of `T` and `U` as a quotient of the direct
 sum of their respective covers.
@@ -1771,7 +1772,7 @@ It is given with the two injections $T \to S$ and $U \to S$.
 Note that `T` and `U` must have the same moduli, both bilinear and quadratic
 ones.
 """
-function orthogonal_sum(T::TorQuadMod, U::TorQuadMod)
+function orthogonal_sum(T::TorQuadModule, U::TorQuadModule)
   @req modulus_bilinear_form(T) == modulus_bilinear_form(U) "T and U must have the same bilinear modulus"
   @req modulus_quadratic_form(T) == modulus_quadratic_form(U) "T and U must have the same quadratic modulus"
   cT = cover(T)
@@ -1788,7 +1789,7 @@ function orthogonal_sum(T::TorQuadMod, U::TorQuadMod)
   return S, TinS, UinS
 end
 
-function _orthogonal_sum_with_injections_and_projections(x::Vector{TorQuadMod})
+function _orthogonal_sum_with_injections_and_projections(x::Vector{TorQuadModule})
   @req length(x) >= 2 "Input must contain at least two torsion quadratic modules"
   mbf = modulus_bilinear_form(x[1])
   mqf = modulus_quadratic_form(x[1])
@@ -1800,8 +1801,8 @@ function _orthogonal_sum_with_injections_and_projections(x::Vector{TorQuadMod})
   R = lattice(ambient_space(C), block_diagonal_matrix(basis_matrix.(rs)))
   gensinj = Vector{Vector{fmpq}}[]
   gensproj = Vector{Vector{fmpq}}[]
-  inj2 = TorQuadModMor[]
-  proj2 = TorQuadModMor[]
+  inj2 = TorQuadModuleMor[]
+  proj2 = TorQuadModuleMor[]
   for i in 1:length(x)
     gene = [inj[i](lift(a)) for a in gens(x[i])]
     push!(gensinj, gene)
@@ -1822,20 +1823,20 @@ function _orthogonal_sum_with_injections_and_projections(x::Vector{TorQuadMod})
 end
 
 @doc Markdown.doc"""
-    direct_sum(x::Vararg{TorQuadMod}) -> TorQuadMod, Vector{TorQuadModMor}, Vector{TorQuadModMor}
-    direct_sum(x::Vector{TorQuadMod}) -> TorQuadMod, Vector{TorQuadModMor}, Vector{TorQuadModMor}
+    direct_sum(x::Vararg{TorQuadModule}) -> TorQuadModule, Vector{TorQuadModuleMor}, Vector{TorQuadModuleMor}
+    direct_sum(x::Vector{TorQuadModule}) -> TorQuadModule, Vector{TorQuadModuleMor}, Vector{TorQuadModuleMor}
 
 Given a collection of torsion quadratic modules $T_1, \ldots, T_n$,
 return their complete direct sum $T := T_1 \oplus \ldots \oplus T_n$,
 together with the injections $T_i \to T$ and the projections $T \to T_i$.
 """
-function direct_sum(x::Vararg{TorQuadMod})
+function direct_sum(x::Vararg{TorQuadModule})
   x = collect(x)
   @req length(x) >= 2 "Input must consist of at least two torsion quadratic module"
   return _orthogonal_sum_with_injections_and_projections(x)
 end
 
-direct_sum(x::Vector{TorQuadMod}) = _orthogonal_sum_with_injections_and_projections(x)
+direct_sum(x::Vector{TorQuadModule}) = _orthogonal_sum_with_injections_and_projections(x)
 
 ###############################################################################
 #
@@ -1844,7 +1845,7 @@ direct_sum(x::Vector{TorQuadMod}) = _orthogonal_sum_with_injections_and_projecti
 ###############################################################################
 
 @doc Markdown.doc"""
-    is_primary_with_prime(T::TorQuadMod) -> Bool, fmpz
+    is_primary_with_prime(T::TorQuadModule) -> Bool, fmpz
 
 Given a torsion quadratic module `T`, return whether the underlying (finite)
 abelian group of `T` (see [`abelian_group`](@ref)) is a `p`-group for some prime
@@ -1853,7 +1854,7 @@ number `p`. In case it is, `p` is also returned as second output.
 Note that in the case of trivial groups, this function returns `(true, 1)`. If
 `T` is not primary, the second return value is `-1` by default.
 """
-function is_primary_with_prime(T::TorQuadMod)
+function is_primary_with_prime(T::TorQuadModule)
   @req !is_degenerate(T) "T must be non-degenerate"
   ed = elementary_divisors(T)
   if is_empty(ed)
@@ -1865,19 +1866,19 @@ function is_primary_with_prime(T::TorQuadMod)
 end
 
 @doc Markdown.doc"""
-    is_primary(T::TorQuadMod, p::Union{Integer, fmpz}) -> Bool
+    is_primary(T::TorQuadModule, p::Union{Integer, fmpz}) -> Bool
 
 Given a torsion quadratic module `T` and a prime number `p`, return whether
 the underlying (finite) abelian group of `T` (see [`abelian_group`](@ref)) is
 a `p`-group.
 """
-function is_primary(T::TorQuadMod, p::Union{Integer, fmpz})
+function is_primary(T::TorQuadModule, p::Union{Integer, fmpz})
   bool, q = is_primary_with_prime(T)
   return bool && q == p
 end
 
 @doc Markdown.doc"""
-    is_elementary_with_prime(T::TorQuadMod) -> Bool, fmpz
+    is_elementary_with_prime(T::TorQuadModule) -> Bool, fmpz
 
 Given a torsion quadratic module `T`, return whether the underlying (finite)
 abelian group of `T` (see [`abelian_group`](@ref)) is an elementary `p`-group,
@@ -1886,7 +1887,7 @@ for some prime number `p`. In case it is, `p` is also returned as second output.
 Note that in the case of trivial groups, this function returns `(true, 1)`. If
 `T` is not elementary, the second return value is `-1` by default.
 """
-function is_elementary_with_prime(T::TorQuadMod)
+function is_elementary_with_prime(T::TorQuadModule)
   bool, p = is_primary_with_prime(T)
   bool && p != 1 || return bool, p
   if p != elementary_divisors(T)[end]
@@ -1896,13 +1897,13 @@ function is_elementary_with_prime(T::TorQuadMod)
 end
 
 @doc Markdown.doc"""
-    is_elementary(T::TorQuadMod, p::Union{Integer, fmpz}) -> Bool
+    is_elementary(T::TorQuadModule, p::Union{Integer, fmpz}) -> Bool
 
 Given a torsion quadratic module `T` and a prime number `p`, return whether the
 underlying (finite) abelian group of `T` (see [`abelian_group`](@ref)) is an
 elementary `p`-group.
 """
-function is_elementary(T::TorQuadMod, p::Union{Integer, fmpz})
+function is_elementary(T::TorQuadModule, p::Union{Integer, fmpz})
   bool, q = is_elementary_with_prime(T)
   return bool && q == p
 end
@@ -1914,13 +1915,13 @@ end
 ###############################################################################
 
 @doc Markdown.doc"""
-    snf(T::TorQuadMod) -> TorQuadMod, TorQuadModMor
+    snf(T::TorQuadModule) -> TorQuadModule, TorQuadModuleMor
 
 Given a torsion quadratic module `T`, return a torsion quadratic module `S`,
 isometric to `T`, such that the underlying abelian group of `S` is in canonical
 Smith normal form. It comes with an isometry $f : S \to T$.
 """
-function snf(T::TorQuadMod)
+function snf(T::TorQuadModule)
   A = abelian_group(T)
   if is_snf(A)
     return T, id_hom(T)
@@ -1928,14 +1929,14 @@ function snf(T::TorQuadMod)
   G, f = snf(A)
   S, f = sub(T, [T(f(g)) for g in gens(G)])
   @assert is_bijective(f)
-  return (S, f)::Tuple{TorQuadMod, TorQuadModMor}
+  return (S, f)::Tuple{TorQuadModule, TorQuadModuleMor}
 end
 
 @doc Markdown.doc"""
-    is_snf(T::TorQuadMod) -> Bool
+    is_snf(T::TorQuadModule) -> Bool
 
 Given a torsion quadratic module `T`, return whether its
 underlying abelian group is in Smith normal form.
 """
-is_snf(T::TorQuadMod) = is_snf(abelian_group(T))
+is_snf(T::TorQuadModule) = is_snf(abelian_group(T))
 

--- a/src/QuadForm/Types.jl
+++ b/src/QuadForm/Types.jl
@@ -5,10 +5,10 @@
 ################################################################################
 
 # abstract spaces
-abstract type AbsSpace{S} end
+abstract type AbstractSpace{S} end
 
 # abstract lattices
-abstract type AbsLat{S} end
+abstract type AbstractLat{S} end
 
 ################################################################################
 #
@@ -30,7 +30,7 @@ end
 
 const QuadSpaceID = AbstractAlgebra.CacheDictType{Any, Any}()
 
-@attributes mutable struct QuadSpace{S, T} <: AbsSpace{S}
+@attributes mutable struct QuadSpace{S, T} <: AbstractSpace{S}
   K::S
   gram::T
   # Temporary variables for _inner_product
@@ -56,7 +56,7 @@ end
 
 const HermSpaceID = AbstractAlgebra.CacheDictType{Any, Any}()
 
-@attributes mutable struct HermSpace{S, T, U, W} <: AbsSpace{S}
+@attributes mutable struct HermSpace{S, T, U, W} <: AbstractSpace{S}
   E::S
   K::T
   gram::U

--- a/test/QuadForm/Genus.jl
+++ b/test/QuadForm/Genus.jl
@@ -34,11 +34,6 @@
   L = quadratic_lattice(K, gens, gram = D)
   @test length(genus_representatives(L)) == 2
 
-  K, a = NumberField(x - 1)
-  OK = maximal_order(K)
-  p = prime_decomposition(OK, 2)[1][1]
-  @test length(Hecke.local_genera_quadratic(K, p, rank = 2, det_val = 1)) == 8
-
   # Addition of genera
 
   Qx, x = PolynomialRing(FlintQQ, "x", cached = false)

--- a/test/QuadForm/Herm/Genus.jl
+++ b/test/QuadForm/Herm/Genus.jl
@@ -426,7 +426,7 @@
   L, b = number_field(t^2 - a * t + 1)
 
   p = prime_decomposition(maximal_order(K), 2)[1][1]
-  G = @inferred local_genera_hermitian(L, p, 4, 2, 0, 4)
+  G = @inferred hermitian_local_genera(L, p, 4, 2, 0, 4)
   @test length(G) == 15
   for i in 1:length(G)
     @test rank(G[i]) == 4
@@ -445,7 +445,7 @@
   @assert parent(u) == K
 
   p = prime_decomposition(maximal_order(K), 3)[1][1]
-  G = local_genera_hermitian(L, p, 4, 2, 0, 4)
+  G = hermitian_local_genera(L, p, 4, 2, 0, 4)
   for i in 1:10
     g1 = rand(G)
     g2 = rand(G)
@@ -454,7 +454,7 @@
   end
 
   p = prime_decomposition(maximal_order(K), 17)[1][1]
-  G = @inferred local_genera_hermitian(L, p, 5, 5, 0, 5)
+  G = @inferred hermitian_local_genera(L, p, 5, 5, 0, 5)
   @test length(G) == 7
   for i in 1:length(G)
     @test rank(G[i]) == 5
@@ -480,8 +480,8 @@
        [(0, 1, -1, 0), (1, 2, 1, 1), (2, 1, 1, 1)],
        [(1, 4, 1, 1)],
        [(1, 4, -1, 1)]]
-  Gs = Hecke.LocalGenusHerm{typeof(L), typeof(p)}[ genus(HermLat, L, p, x) for x in l ]
-  myG = @inferred local_genera_hermitian(L, p, 4, 2, 0, 4)
+  Gs = Hecke.HermLocalGenus{typeof(L), typeof(p)}[ genus(HermLat, L, p, x) for x in l ]
+  myG = @inferred hermitian_local_genera(L, p, 4, 2, 0, 4)
   @test length(Gs) == length(myG)
   @test all(x -> x in Gs, myG)
   @test all(x -> x in myG, Gs)
@@ -490,7 +490,7 @@
   Kt, t = K["t"]
   L, b = number_field(t^2 - a * t + 1)
   rlp = real_places(K)
-  G = @inferred genera_hermitian(L, 3, Dict(rlp[1] => 1, rlp[2] => 1), 100 * maximal_order(L))
+  G = @inferred hermitian_genera(L, 3, Dict(rlp[1] => 1, rlp[2] => 1), 100 * maximal_order(L))
   for i in 1:10
     g1 = rand(G)
     g2 = rand(G)
@@ -532,7 +532,7 @@ end
   DE = EabstoE(DEabs)
   rp = real_places(base_field(E))
   sig = Dict(r => 1 for r in rp)
-  gh = @inferred genera_hermitian(E, 4, sig, inv(DE), min_scale =inv(DE)^2)
+  gh = @inferred hermitian_genera(E, 4, sig, inv(DE), min_scale =inv(DE)^2)
   @test length(gh) == 22
   @test allunique(gh)
   @test all(G -> signatures(G) == sig, gh)
@@ -543,7 +543,7 @@ end
   K = base_field(E)
   sig[rp[1]] = 7
   sig[rp[2]] = 3
-  gh = @inferred genera_hermitian(E, 8, sig, E(1//135)*maximal_order(E), min_scale = E(1//45)*maximal_order(E), max_scale = E(45)*maximal_order(E))
+  gh = @inferred hermitian_genera(E, 8, sig, E(1//135)*maximal_order(E), min_scale = E(1//45)*maximal_order(E), max_scale = E(45)*maximal_order(E))
   @test allunique(gh)
   @test all(G -> (signatures(G), rank(G)) == (sig, 8), gh)
   @test all(G -> !is_integral(G), gh)
@@ -553,10 +553,10 @@ end
     @test prod([fractional_ideal(prime(g))^(sum([rank(g,i)*scale(g,i) for i in 1:length(g)])) for g in G.LGS]) == inv(135*maximal_order(base_field(E)))
   end
 
-  @test_throws ArgumentError genera_hermitian(E, -1, sig, DE)
-  @test_throws ArgumentError genera_hermitian(E, 1, sig, DE, min_scale = 0*DE)
-  @test_throws ArgumentError genera_hermitian(E, 1, sig, DE, max_scale = 0*DE)
+  @test_throws ArgumentError hermitian_genera(E, -1, sig, DE)
+  @test_throws ArgumentError hermitian_genera(E, 1, sig, DE, min_scale = 0*DE)
+  @test_throws ArgumentError hermitian_genera(E, 1, sig, DE, max_scale = 0*DE)
   sig[rp[1]] = -12
-  @test_throws ArgumentError genera_hermitian(E, 4, sig, DE)
+  @test_throws ArgumentError hermitian_genera(E, 4, sig, DE)
 end
 

--- a/test/QuadForm/Quad/Genus.jl
+++ b/test/QuadForm/Quad/Genus.jl
@@ -9,43 +9,43 @@
   p3 = prime_decomposition(OK, 3)[1][1]
   p5 = prime_decomposition(OK, 5)[1][1]
 
-  @test length(Hecke.local_genera_quadratic(K, p2, rank = 2, det_val = 0)) == 8
-  @test length(Hecke.local_genera_quadratic(K, p2, rank = 2, det_val = 1)) == 8
-  @test length(Hecke.local_genera_quadratic(K, p2, rank = 2, det_val = 2)) == 16
-  @test length(Hecke.local_genera_quadratic(K, p2, rank = 2, det_val = 3)) == 24
-  @test length(Hecke.local_genera_quadratic(K, p2, rank = 2, det_val = 4)) == 32
+  @test length(Hecke.quadratic_local_genera(K, p2, rank = 2, det_val = 0)) == 8
+  @test length(Hecke.quadratic_local_genera(K, p2, rank = 2, det_val = 1)) == 8
+  @test length(Hecke.quadratic_local_genera(K, p2, rank = 2, det_val = 2)) == 16
+  @test length(Hecke.quadratic_local_genera(K, p2, rank = 2, det_val = 3)) == 24
+  @test length(Hecke.quadratic_local_genera(K, p2, rank = 2, det_val = 4)) == 32
 
-  @test length(Hecke.local_genera_quadratic(K, p3, rank = 5, det_val = 0)) == 2
-  @test length(Hecke.local_genera_quadratic(K, p3, rank = 5, det_val = 1)) == 4
-  @test length(Hecke.local_genera_quadratic(K, p3, rank = 5, det_val = 2)) == 8
-  @test length(Hecke.local_genera_quadratic(K, p3, rank = 5, det_val = 3)) == 16
-  @test length(Hecke.local_genera_quadratic(K, p3, rank = 5, det_val = 4)) == 28
-  @test length(Hecke.local_genera_quadratic(K, p3, rank = 5, det_val = 5)) == 46
-  @test length(Hecke.local_genera_quadratic(K, p3, rank = 5, det_val = 6)) == 72
+  @test length(Hecke.quadratic_local_genera(K, p3, rank = 5, det_val = 0)) == 2
+  @test length(Hecke.quadratic_local_genera(K, p3, rank = 5, det_val = 1)) == 4
+  @test length(Hecke.quadratic_local_genera(K, p3, rank = 5, det_val = 2)) == 8
+  @test length(Hecke.quadratic_local_genera(K, p3, rank = 5, det_val = 3)) == 16
+  @test length(Hecke.quadratic_local_genera(K, p3, rank = 5, det_val = 4)) == 28
+  @test length(Hecke.quadratic_local_genera(K, p3, rank = 5, det_val = 5)) == 46
+  @test length(Hecke.quadratic_local_genera(K, p3, rank = 5, det_val = 6)) == 72
 
-  @test length(Hecke.local_genera_quadratic(K, p5, rank = 4, det_val = 2)) == 8
-  @test length(Hecke.local_genera_quadratic(K, p5, rank = 4, det_val = 1)) == 4
-  @test length(Hecke.local_genera_quadratic(K, p5, rank = 2, det_val = 0)) == 2
-  @test length(Hecke.local_genera_quadratic(K, p5, rank = 2, det_val = 1)) == 4
+  @test length(Hecke.quadratic_local_genera(K, p5, rank = 4, det_val = 2)) == 8
+  @test length(Hecke.quadratic_local_genera(K, p5, rank = 4, det_val = 1)) == 4
+  @test length(Hecke.quadratic_local_genera(K, p5, rank = 2, det_val = 0)) == 2
+  @test length(Hecke.quadratic_local_genera(K, p5, rank = 2, det_val = 1)) == 4
 
-  @test length(Hecke.genera_quadratic(K, rank = 2, signatures = sig, det = 5^2 * 8 * 9 * OK)) == 27
-  @test length(Hecke.genera_quadratic(K, rank = 2, signatures = sig, det = 5 * 7 * 8 * 9 * OK)) == 36
-  @test length(Hecke.genera_quadratic(K, rank = 2, signatures = sig, det = 2^5 * OK)) == 5
-  @test length(Hecke.genera_quadratic(K, rank = 2, signatures = sig, det = 11 * 13^2 * OK)) == 6
+  @test length(Hecke.quadratic_genera(K, rank = 2, signatures = sig, det = 5^2 * 8 * 9 * OK)) == 27
+  @test length(Hecke.quadratic_genera(K, rank = 2, signatures = sig, det = 5 * 7 * 8 * 9 * OK)) == 36
+  @test length(Hecke.quadratic_genera(K, rank = 2, signatures = sig, det = 2^5 * OK)) == 5
+  @test length(Hecke.quadratic_genera(K, rank = 2, signatures = sig, det = 11 * 13^2 * OK)) == 6
 
-  G1 = Hecke.local_genera_quadratic(K, p3, rank = 3, det_val = 1)[4]
-  G1a = Hecke.local_genera_quadratic(K, p3, rank = 3, det_val = 1)[4]
+  G1 = Hecke.quadratic_local_genera(K, p3, rank = 3, det_val = 1)[4]
+  G1a = Hecke.quadratic_local_genera(K, p3, rank = 3, det_val = 1)[4]
   G1a.uniformizer = 4*G1.uniformizer
   @test G1 == G1a
   @test G1+G1a == G1+G1
-  G2 = Hecke.local_genera_quadratic(K, p3, rank = 3, det_val = 1)[4]
+  G2 = Hecke.quadratic_local_genera(K, p3, rank = 3, det_val = 1)[4]
   G2.uniformizer = -G2.uniformizer
   @test G2 != G1
   @test G2 != G1a
 
   # test representative and orthogonal_sum
 
-  G = Hecke.local_genera_quadratic(K, p2, rank = 3, det_val = 4)
+  G = Hecke.quadratic_local_genera(K, p2, rank = 3, det_val = 4)
   for i in 1:10
     G1 = rand(G)
     G2 = rand(G)
@@ -60,7 +60,7 @@
   @test sprint(show, G[1]) isa String
   @test sprint(show, "text/plain", G[1]) isa String
 
-  G = Hecke.local_genera_quadratic(K, p2, rank = 3, det_val = 1)
+  G = Hecke.quadratic_local_genera(K, p2, rank = 3, det_val = 1)
   for i in 1:10
     G1 = rand(G)
     G2 = rand(G)
@@ -71,7 +71,7 @@
     @test G3 == genus(L3, p2)
   end
 
-  G = Hecke.local_genera_quadratic(K, p2, rank = 5, det_val = 1)
+  G = Hecke.quadratic_local_genera(K, p2, rank = 5, det_val = 1)
   for i in 1:10
     G1 = rand(G)
     G2 = rand(G)
@@ -83,7 +83,7 @@
     @test G3 == genus(L3, p2)
   end
 
-  G = Hecke.local_genera_quadratic(K, p3, rank = 5, det_val = 5)
+  G = Hecke.quadratic_local_genera(K, p3, rank = 5, det_val = 5)
   for i in 1:10
     G1 = rand(G)
     G2 = rand(G)
@@ -102,7 +102,7 @@
   @test sprint(show, G[1]) isa String
   @test sprint(show, "text/plain", G[1]) isa String
 
-  G = Hecke.local_genera_quadratic(K, p5, rank = 2, det_val = 1)
+  G = Hecke.quadratic_local_genera(K, p5, rank = 2, det_val = 1)
   for i in 1:10
     G1 = rand(G)
     G2 = rand(G)
@@ -113,7 +113,7 @@
     @test G3 == genus(L3, p5)
   end
 
-  G = Hecke.genera_quadratic(K, rank = 3, signatures = sig, det = 2 * 9 * OK)
+  G = Hecke.quadratic_genera(K, rank = 3, signatures = sig, det = 2 * 9 * OK)
   for i in 1:10
     G1 = rand(G)
     G2 = rand(G)
@@ -154,12 +154,12 @@
   p3 = prime_ideals_over(OF, 3)[1]
 
   # Test the computation of jordan decomposition
-  G = Hecke.local_genera_quadratic(F, p, rank = 3, det_val = 2)
+  G = Hecke.quadratic_local_genera(F, p, rank = 3, det_val = 2)
   for g in G
     g1 = genus(QuadLat, p, g.ranks, g.scales, g.weights, g.dets, g.normgens, g.witt)
     representative(g1) in G  # computes jordan decompositions
   end
-  G = Hecke.local_genera_quadratic(F, p3, rank = 3, det_val = 2)
+  G = Hecke.quadratic_local_genera(F, p3, rank = 3, det_val = 2)
   for g in G
     g1 = genus(QuadLat, p3, g.uniformizer, g.ranks, g.scales, g.detclasses)
     representative(g1) in G  # computes jordan decompositions
@@ -167,13 +167,13 @@
 
   sig = Dict([(pl[1],0),(pl[2],0)])
   for d in 1:(long_test ? 10 : 3)
-    for G in Hecke.genera_quadratic(F,rank=2,det=d*OF,signatures=sig)
+    for G in Hecke.quadratic_genera(F,rank=2,det=d*OF,signatures=sig)
       @test representative(G) in G
     end
   end
   sig = Dict([(pl[1],3),(pl[2],2)])
   for d in 1:(long_test ? 10 : 3)
-    for G in Hecke.genera_quadratic(F,rank=4,det=d*OF,signatures=sig)
+    for G in Hecke.quadratic_genera(F,rank=4,det=d*OF,signatures=sig)
       @test representative(G) in G
     end
   end
@@ -184,13 +184,13 @@
   pl = real_places(F)
   sig = Dict([(pl[1],0)])
   for d in 1:(long_test ? 10 : 3)
-    for G in Hecke.genera_quadratic(F,rank=2,det=d*OF,signatures=sig)
+    for G in Hecke.quadratic_genera(F,rank=2,det=d*OF,signatures=sig)
       @test representative(G) in G
     end
   end
   sig = Dict([(pl[1],3)])
   for d in 1:(long_test ? 10 : 3)
-    for G in Hecke.genera_quadratic(F,rank=3,det=d*OF,signatures=sig)
+    for G in Hecke.quadratic_genera(F,rank=3,det=d*OF,signatures=sig)
       @test representative(G) in G
     end
   end

--- a/test/QuadForm/Quad/GenusRep.jl
+++ b/test/QuadForm/Quad/GenusRep.jl
@@ -124,7 +124,7 @@ end
   # The following is unrolled
   # sig = Dict([(pl[1],0),(pl[2],0)])
   # for d in 1:12
-  #   for g in Hecke.genera_quadratic(F,rank=3,det=d*OF,signatures=sig)
+  #   for g in Hecke.quadratic_genera(F,rank=3,det=d*OF,signatures=sig)
   #     representatives(g)
 
   res = [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 1,
@@ -718,7 +718,7 @@ end
   # The next is the unrolled version of
   # sig = Dict([(pl[1],1),(pl[2],2)])
   # for d in 1:12
-  #  for g in Hecke.genera_quadratic(F,rank=3,det=d*OF,signatures=sig)
+  #  for g in Hecke.quadratic_genera(F,rank=3,det=d*OF,signatures=sig)
   #    representatives(g)
 
   res = [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
@@ -1313,7 +1313,7 @@ end
   # The next is the unrolled version of
   # sig = Dict([(pl[1],1),(pl[2],1)])
   # for d in 1:12
-  #  for g in Hecke.genera_quadratic(F,rank=3,det=d*OF,signatures=sig)
+  #  for g in Hecke.quadratic_genera(F,rank=3,det=d*OF,signatures=sig)
   #    representatives(g)
 
   res = [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
@@ -1938,17 +1938,17 @@ end
 
   sig = Dict([(pl[1],0),(pl[2],0)])
   for d in 1:12
-    [representatives(g) for g in Hecke.genera_quadratic(F,rank=2,det=d*OF,signatures=sig)]
+    [representatives(g) for g in Hecke.quadratic_genera(F,rank=2,det=d*OF,signatures=sig)]
   end
 
   # Indefinite not implemented for K != QQ
   # sig = Dict([(pl[1],1),(pl[2],2)])
   # for d in 1:12
-  #   [representatives(g) for g in Hecke.genera_quadratic(F,rank=2,det=d*OF,signatures=sig)]
+  #   [representatives(g) for g in Hecke.quadratic_genera(F,rank=2,det=d*OF,signatures=sig)]
   # end
 
   # sig = Dict([(pl[1],1),(pl[2],1)])
   # for d in 1:12
-  #   [representatives(g) for g in Hecke.genera_quadratic(F,rank=2,det=d*OF,signatures=sig)]
+  #   [representatives(g) for g in Hecke.quadratic_genera(F,rank=2,det=d*OF,signatures=sig)]
   # end
 end

--- a/test/QuadForm/Quad/ZGenus.jl
+++ b/test/QuadForm/Quad/ZGenus.jl
@@ -114,8 +114,8 @@
   @test size(Hecke._local_genera(2, 3, 1, 0, 2, true))[1]==4
   @test size(Hecke._local_genera(5, 2, 2, 0, 2, true))[1]==6
 
-  @test length(genera((2,2), 10, even=true))==0  # check that a bug in catesian_product_iterator is fixed
-  @test 4 == length(genera((4,0), 125, even=true))
+  @test length(Zgenera((2,2), 10, even=true))==0  # check that a bug in catesian_product_iterator is fixed
+  @test 4 == length(Zgenera((4,0), 125, even=true))
   G = genus(diagonal_matrix(map(ZZ,[2, 4, 18])))
   @test 36 == level(G)
   G = genus(diagonal_matrix(map(ZZ,[2, 4, 18])))
@@ -259,7 +259,7 @@
   @test length(representatives(G2)) == 1
   @test representative(G2)===representative(G2) # caching
 
-  G = genera((8,0), 1, even=true)[1]
+  G = Zgenera((8,0), 1, even=true)[1]
   @test mass(G) == 1//696729600
 
   G = genus(diagonal_matrix(fmpz[1, 3, 9]),3)
@@ -281,7 +281,7 @@
   genus_orders_sage = [[1, 1], [1], [1, 1], [1, 1, 1, 1], [1, 1], [1, 1], [1, 1], [1, 1, 1], [1, 1, 1, 1, 1, 1], [1, 1], [1, 1], [1, 1, 1, 1], [1, 1], [1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1, 1], [1, 1], [1, 1, 1], [1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1], [1, 1], [1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 2, 2], [1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1], [1, 1, 1, 1], [1, 1], [1, 1, 1, 1, 1], [1, 1, 1, 1], [1, 2], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], [1, 2], [1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1], [1, 1], [1, 1, 1, 1], [1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1], [1, 1], [1, 1], [1, 1, 1, 1, 1, 1, 1, 1], [1, 1, 2, 2, 2, 2], [1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1], [1, 1, 1, 1], [1, 1], [1, 1], [1, 1, 1, 1, 1, 1, 1, 1], [1, 1], [1, 1], [1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1], [1, 1, 1, 1, 1, 1, 1, 1, 1], [1, 1], [1, 1], [1, 1, 1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [2, 2], [1, 1, 1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 2, 2, 2, 2], [1, 2], [1, 1], [1, 1, 1, 1, 1, 1, 1, 1], [1, 1, 1, 1], [1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1], [1, 1], [1, 1, 1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1], [1, 1], [1, 1, 1], [1, 1, 1, 1, 2, 2], [1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2], [1, 2], [1, 1, 1, 1], [1, 1], [1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1, 1], [1, 1], [1, 1], [1, 1, 1, 1, 1, 1, 1, 1], [1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1, 1], [1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1], [1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], [1, 1, 3, 3, 3, 3], [1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1], [1, 1], [1, 1, 1, 1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1], [1, 1, 1, 1, 1, 1, 1, 1], [1, 1, 1, 1], [1, 1], [1, 1, 1, 1, 1, 1, 1, 1], [1, 1, 1, 2, 2, 2], [1, 1], [1, 1, 1, 1], [1, 1], [1, 1, 1, 1, 1, 1, 1, 1], [1, 1, 2, 2], [2, 2], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], [1, 1, 2, 2], [1, 2], [1, 1, 1, 1, 1, 1], [1, 2, 2, 2], [1, 1], [1, 1, 1, 1, 1, 1], [1, 1], [1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 2, 2], [1, 1], [1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1], [1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1, 1], [1, 1], [1, 1], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], [1, 1, 3, 3, 4, 4], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1], [1, 1, 1, 1], [1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1, 1], [1, 1, 1, 1], [1, 2], [1, 1], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], [1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 2, 2], [1, 1, 1, 1], [1, 1], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], [1, 1], [1, 2], [1, 1, 1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2], [1, 2], [1, 1, 1, 1, 1, 1], [1, 1]]
 
   for d in 1:(long_test ? 199 : 50)
-    L = [length(representatives(G)) for G in genera((1,1), d)]
+    L = [length(representatives(G)) for G in Zgenera((1,1), d)]
     @test genus_orders_sage[d] == sort!(L)
   end
 
@@ -305,7 +305,7 @@
   end
 
   for (sig,d) in sigdet
-    for G in genera(sig, d)
+    for G in Zgenera(sig, d)
       L = representative(G)
       spL = ambient_space(L)
       b = B[rank(L)-1]
@@ -356,7 +356,7 @@
 
   for d in 1:(long_test ? 50 : 10)
     for sig in [(2,0),(3,0),(4,0)]
-      for G in genera(sig,d)
+      for G in Zgenera(sig,d)
         m = mass(G)
         L = representative(G)
         @test genus(L)==G
@@ -510,7 +510,7 @@ end
   G22 = orthogonal_sum(G2, G)
   L2 = representative(G22)
   @test genus(L2) == G22
-  G = genera((0,8), 1)[1]
+  G = Zgenera((0,8), 1)[1]
   G2 = rescale(G, -5)
   G3 = rescale(G, 7//92)
   G4 = rescale(G, -1//10000009)
@@ -530,30 +530,30 @@ end
   @test !is_isometric(repL2[1], repL2[2])
 
   # Enumeration
-  gen = @inferred genera((1, 1), 4//3, min_scale = 1//18, max_scale = 12)
+  gen = @inferred Zgenera((1, 1), 4//3, min_scale = 1//18, max_scale = 12)
   @test length(gen) == 8
   @test all(g -> det(g) == -4//3, gen)
   @test all(g -> !is_integral(g), gen)
   @test all(g -> scale(g) in [1//9, 1//3, 2//9, 2//3], gen)
-  gen = @inferred genera((1, 1), 4//3, min_scale = 1//18, max_scale = 12, even = true)
+  gen = @inferred Zgenera((1, 1), 4//3, min_scale = 1//18, max_scale = 12, even = true)
   @test isempty(gen)
-  @test_throws ArgumentError genera((1,1), 4//3, min_scale = -1//18)
-  @test_throws ArgumentError genera((1,1), 4//3, max_scale = -12)
-  gen1 = @inferred genera((0,8), 5, even = true)
+  @test_throws ArgumentError Zgenera((1,1), 4//3, min_scale = -1//18)
+  @test_throws ArgumentError Zgenera((1,1), 4//3, max_scale = -12)
+  gen1 = @inferred Zgenera((0,8), 5, even = true)
   @test length(gen1) == 1
-  gen2 = @inferred genera((0, 8), 5, min_scale = 1//5, even = true)
+  gen2 = @inferred Zgenera((0, 8), 5, min_scale = 1//5, even = true)
   @test length(gen2) == 1
   @test gen1 == gen2
-  gen3 = genera((0,8), 5)
-  gen4 = genera((0, 8), 5, min_scale = 1//5)
+  gen3 = Zgenera((0,8), 5)
+  gen4 = Zgenera((0, 8), 5, min_scale = 1//5)
   @test all(g -> g in gen4, gen3)
   @test all(g -> g in gen4, gen2)
-  @test isempty(genera((0, 8), 1, min_scale = 2))
-  gen = @inferred genera((0,8), 1, min_scale = 1//2, max_scale = 4)
+  @test isempty(Zgenera((0, 8), 1, min_scale = 2))
+  gen = @inferred Zgenera((0,8), 1, min_scale = 1//2, max_scale = 4)
   @test length(gen) == 53
 
   # Mass
-  gen = genera((0,8), 16, even=true)
+  gen = Zgenera((0,8), 16, even=true)
   for g in gen
     k = rand(-50:50)
     while k == 0

--- a/test/QuadForm/Quad/ZLattices.jl
+++ b/test/QuadForm/Quad/ZLattices.jl
@@ -278,7 +278,7 @@ end
   @test all(m -> multiplicative_order(m) == 2, G)
   @test_throws ArgumentError automorphism_group_order(U)
 
-  g = genera((1,1), 12)
+  g = Zgenera((1,1), 12)
   Lg = representative.(g)
   for L in Lg
     V = ambient_space(L)
@@ -537,23 +537,23 @@ end
 
   # LLL-reduction
 
-  L = representative(genera((0,16), 768, max_scale = 6, even=true)[2])
+  L = representative(Zgenera((0,16), 768, max_scale = 6, even=true)[2])
   LL = lll(L) # L and LL are equal since they are in the same space
   @test L == LL
 
   LL = lll(L, same_ambient = false) # L and LL are not equal, but isometric
   @test_broken false && is_isometric_with_isometry(L, LL)[1] # tests takes too long
 
-  L = representative(genera((2,1), -1)[1])
+  L = representative(Zgenera((2,1), -1)[1])
   LL = lll(L)
   @test L == LL
   @test rescale(L, -1) == lll(rescale(L, -1))
 
-  L = representative(genera((3,11), 1)[2])
+  L = representative(Zgenera((3,11), 1)[2])
   LL = lll(L)
   @test L == LL
 
-  L = representative(genera((3,12), 3)[1])
+  L = representative(Zgenera((3,12), 3)[1])
   LL = lll(L)
   @test L == LL
 

--- a/test/QuadForm/Torsion.jl
+++ b/test/QuadForm/Torsion.jl
@@ -1,7 +1,7 @@
 @testset "Torsion" begin
   # Trivial torsion module
   A = diagonal_matrix(fmpq[1, 1])
-  T = Hecke.TorQuadMod(A)
+  T = Hecke.TorQuadModule(A)
   @test order(T) == 1
   # discriminant_group group of a non full lattice
   L = Zlattice(2*identity_matrix(ZZ,2))
@@ -75,7 +75,7 @@
   @test_throws ArgumentError torsion_quadratic_module(L, M, gens = [[1, 1, 2]])
   @test_throws ArgumentError torsion_quadratic_module(L, lattice(ambient_space(L), QQ[1//2 0; 0 0]))
 
-  #primary part of a TorQuadMod
+  #primary part of a TorQuadModule
   L = Zlattice(matrix(ZZ, [[2,0,0],[0,2,0],[0,0,2]]))
   T = Hecke.discriminant_group(L)
   @test basis_matrix(Hecke.cover(Hecke.primary_part(T,fmpz(2))[1])) == matrix(QQ, 3, 3, [1//2, 0, 0, 0, 1//2, 0, 0, 0, 1//2])
@@ -86,7 +86,7 @@
   @test Hecke.cover(Hecke.primary_part(T1, exponent(T1))[1]) == Hecke.cover(T1)
   @test gram_matrix(Hecke.cover(Hecke.primary_part(T1, exponent(T1))[1])) == gram_matrix(Hecke.cover(T1))
 
-  #orthogonal submodule to a TorQuadMod
+  #orthogonal submodule to a TorQuadModule
   L = Zlattice(matrix(ZZ, [[2,0,0],[0,2,0],[0,0,2]]))
   T = Hecke.discriminant_group(L)
   S, i = sub(T, gens(T))
@@ -97,15 +97,15 @@
   S1, _ = sub(T1, gens(T1)[1:5])
   @test ambient_space(Hecke.cover(Hecke.orthogonal_submodule(T1, S1)[1])) == ambient_space(L1)
 
-  #checks if a TorQuadMod is degenerate
+  #checks if a TorQuadModule is degenerate
   @test Hecke.is_degenerate(T) == false
-  t = Hecke.TorQuadMod(matrix(QQ,1,1,[1//27]))
+  t = Hecke.TorQuadModule(matrix(QQ,1,1,[1//27]))
   d = sub(t, gens(t)*3)[1]
   @test Hecke.is_degenerate(d) == true
 
   #test for rescaled torsion quadratic module
   @test Hecke.gram_matrix_quadratic(Hecke.rescale(T, -1)) == matrix(QQ, 3, 3, [7//4,0,0,0,7//4,0,0,0,7//4])
-  t = Hecke.TorQuadMod(QQ[1//3 0; 0 1//9])
+  t = Hecke.TorQuadModule(QQ[1//3 0; 0 1//9])
   @test Hecke.gram_matrix_quadratic(Hecke.rescale(t, -1)) == matrix(QQ, 2, 2, [2//3,0,0,8//9])
   #This form is defined modulo `2`
   @test Hecke.gram_matrix_quadratic(Hecke.rescale(t, 2)) == matrix(QQ, 2, 2, [2//3,0,0,2//9])
@@ -274,7 +274,7 @@
   qLf = discriminant_group(Lf)
   @test modulus_quadratic_form(qLf) == 2
 
-  T = TorQuadMod(matrix(QQ, 1, 1, [1//27]))
+  T = TorQuadModule(matrix(QQ, 1, 1, [1//27]))
   @test Hecke._isometry_non_split_degenerate(T, T)[1]
   T1sub, _ = sub(T, 3*gens(T))
   T2sub, _ = sub(T, 15*gens(T))

--- a/test/QuadForm/Torsion.jl
+++ b/test/QuadForm/Torsion.jl
@@ -200,7 +200,7 @@
   @test all(g == i(j(g)) for g in gens(N))
 
   # iterator
-  gen = genera((0,6), 2^3*3^3*5^2)
+  gen = Zgenera((0,6), 2^3*3^3*5^2)
   disc = discriminant_group.(gen)
   @test all(T -> length(collect(T)) == order(T), disc)
 

--- a/test/QuadForm/indefiniteLLL.jl
+++ b/test/QuadForm/indefiniteLLL.jl
@@ -119,61 +119,61 @@
   L3 = lattice(ambient_space(L2), UU8*basis_matrix(L2))
   @test L == L3
 
-  gen1 = genera((1,1),1)
+  gen1 = Zgenera((1,1),1)
   L1 = representative(gen1[1])
   H1,U1 = Hecke.lll_gram_indef_with_transform(change_base_ring(ZZ,gram_matrix(L1)))
   Lat1 = lattice(ambient_space(L1),U1*basis_matrix(L1))
   @test L1 == Lat1
 
-  gen2 = genera((2,1),1)
+  gen2 = Zgenera((2,1),1)
   L2 = representative(gen2[1])
   H2,U2 = Hecke.lll_gram_indef_with_transform(change_base_ring(ZZ,gram_matrix(L2)))
   Lat2 = lattice(ambient_space(L2),U2*basis_matrix(L2))
   @test L2 == Lat2
 
-  gen3 = genera((2,2),1)
+  gen3 = Zgenera((2,2),1)
   L3 = representative(gen3[1])
   H3,U3 = Hecke.lll_gram_indef_with_transform(change_base_ring(ZZ,gram_matrix(L3)))
   Lat3 = lattice(ambient_space(L3),U3*basis_matrix(L3))
   @test L3 == Lat3
 
-  gen4 = genera((2,3),1)
+  gen4 = Zgenera((2,3),1)
   L4 = representative(gen4[1])
   H4,U4 = Hecke.lll_gram_indef_with_transform(change_base_ring(ZZ,gram_matrix(L4)))
   Lat4 = lattice(ambient_space(L4),U4*basis_matrix(L4))
   @test L4 == Lat4
 
-  gen5 = genera((1,5),1)
+  gen5 = Zgenera((1,5),1)
   L5 = representative(gen5[1])
   H5,U5 = Hecke.lll_gram_indef_with_transform(change_base_ring(ZZ,gram_matrix(L5)))
   Lat5 = lattice(ambient_space(L5),U5*basis_matrix(L5))
   @test L5 == Lat5
 
-  gen6 = genera((4,2),1)
+  gen6 = Zgenera((4,2),1)
   L6 = representative(gen6[1])
   H6,U6 = Hecke.lll_gram_indef_with_transform(change_base_ring(ZZ,gram_matrix(L6)))
   Lat6 = lattice(ambient_space(L6),U6*basis_matrix(L6))
   @test L6 == Lat6
 
-  gen7 = genera((1,3),1)
+  gen7 = Zgenera((1,3),1)
   L7 = representative(gen7[1])
   H7,U7 = Hecke.lll_gram_indef_with_transform(change_base_ring(ZZ,gram_matrix(L7)))
   Lat7 = lattice(ambient_space(L7),U7*basis_matrix(L7))
   @test L7 == Lat7
 
-  gen8 = genera((1,2),1)
+  gen8 = Zgenera((1,2),1)
   L8 = representative(gen8[1])
   H8,U8 = Hecke.lll_gram_indef_with_transform(change_base_ring(ZZ,gram_matrix(L8)))
   Lat8 = lattice(ambient_space(L8),U8*basis_matrix(L8))
   @test L8 == Lat8
 
-  gen9 = genera((3,3),1)
+  gen9 = Zgenera((3,3),1)
   L9 = representative(gen9[1])
   H9,U9 = Hecke.lll_gram_indef_with_transform(change_base_ring(ZZ,gram_matrix(L9)))
   Lat9 = lattice(ambient_space(L9),U9*basis_matrix(L9))
   @test L9 == Lat9
 
-  gen10 = genera((1,3),1)
+  gen10 = Zgenera((1,3),1)
   L10 = representative(gen10[1])
   H10,U10 = Hecke.lll_gram_indef_with_transform(change_base_ring(ZZ,gram_matrix(L10)))
   Lat10 = lattice(ambient_space(L10),U10*basis_matrix(L10))


### PR DESCRIPTION
Renamings done:
- `AbsSpace` -> `AbstractSpace` (`Abs` is reserved for `Absolute`)
- `AbsSpaceMor` -> `AbstractSpaceMor` (same as above)
- `AbsLat` -> `AbstractLat` (same as above)
- `TorQuadMod` -> `TorQuadModule` (modules are called `Module`)
- `TorQuadModElem` -> `TorQuadModuleElem` (same as above)
- `TorQuadModMor` -> `TorQuadModuleMor` (same as above)
- `LatticeDB` -> `LatDB` (lattices defined as `Lat` except group lattices (which are not the same kind of lattices))
- `NfLattice` -> `NfLat` (same as above)

Some other renamings for genera, in order to have something consistent. I chose `ZGenus` as a standard, and so:
- `genera` -> `Zgenera` ( the enumeration function)
- `GenusHerm` -> `HermGenus` (since it is a genus, we put `Genus` at the end)
- `LocalGenusHerm` -> `HermLocalGenus` (same as before)
- `GenusQuad` -> `QuadGenus` (same as before)
- `LocalGenusQuad` -> `QuadLocalGenus` (same as before)
- `genera_hermitian` -> `hermitian_genera`
- `local_genera_hermitian` -> `hermitian_local_genera`
- `genera_quadratic` -> `quadratic_genera`
- `local_genera_quadratic` -> `quadratic_local_genera`