### PR TITLE
Fix variable name in `morphism` of `ModAlgAss`

### DIFF
--- a/src/ModAlgAss/Morphisms.jl
+++ b/src/ModAlgAss/Morphisms.jl
@@ -30,7 +30,7 @@ function morphism(V::T, W::T, M::MatrixElem; check = true) where {T <: ModAlgAss
   if check
     x, y = consistent_action(V, W)
     for i in 1:length(x)
-      @req x[i] * matrix == matrix * y[i] "Matrix is not a morphism"
+      @req x[i] * M == M * y[i] "Matrix is not a morphism"
     end
   end
   return ModAlgHom(V, W, M)


### PR DESCRIPTION
The `morphism` function for `ModAlgAss` just did not work due to `M` erroneously being called `matrix`:

```julia
m1 = matrix(QQ, [1;;])
M1 = Amodule([m1])
Hecke.morphism(M1, M1, m1)
```

results in

    ERROR: MethodError: no method matching *(::QQMatrix, ::typeof(matrix))