### PR TITLE
Turn MatSpace from mutable struct to struct

### DIFF
--- a/src/HeckeTypes.jl
+++ b/src/HeckeTypes.jl
@@ -400,23 +400,19 @@ end
 #
 ################################################################################
 
-const SMatSpaceDict = IdDict()
-
 """
     SMatSpace
 
 Parent for sparse matrices. Usually only created from a sparse matrix
 via a call to parent.
 """
-mutable struct SMatSpace{T} <: Ring
+struct SMatSpace{T}
   rows::Int
   cols::Int
   base_ring::Ring
 
-  function SMatSpace{T}(R::Ring, r::Int, c::Int, cached = false) where {T}
-    return get_cached!(SMatSpaceDict, (R, r, c), cached) do
-      return new{T}(r, c, R)
-    end::SMatSpace{T}
+  function SMatSpace{T}(R::Ring, r::Int, c::Int) where {T}
+    return new{T}(r, c, R)
   end
 end
 
@@ -505,18 +501,14 @@ end
 
 export FakeFmpqMat, FakeFmpqMatSpace
 
-mutable struct FakeFmpqMatSpace
+struct FakeFmpqMatSpace
   rows::Int
   cols::Int
 
-  function FakeFmpqMatSpace(r::Int, c::Int, cached::Bool=false)
-    return get_cached!(FakeFmpqMatSpaceID, (r,c), cached) do
-      return new(r,c)
-    end
+  function FakeFmpqMatSpace(r::Int, c::Int)
+    return new(r,c)
   end
 end
-
-const FakeFmpqMatSpaceID = IdDict{Tuple{Int,Int}, FakeFmpqMatSpace}()
 
 """
     FakeFmpqMat
@@ -1407,14 +1399,14 @@ mutable struct FactorBaseSingleP{T}
   lf::Vector{T}
   doit::Function
 
-  function FactorBaseSingleP(p::Integer, lp::Vector{Tuple{Int, NfOrdIdl}}) 
+  function FactorBaseSingleP(p::Integer, lp::Vector{Tuple{Int, NfOrdIdl}})
     Fpx = polynomial_ring(residue_ring(FlintZZ, UInt(p), cached=false), "x", cached=false)[1]
     O = order(lp[1][2])
     K = O.nf
     return FactorBaseSingleP(Fpx(Globals.Zx(K.pol)), lp)
   end
 
-  function FactorBaseSingleP(p::ZZRingElem, lp::Vector{Tuple{Int, NfOrdIdl}}) 
+  function FactorBaseSingleP(p::ZZRingElem, lp::Vector{Tuple{Int, NfOrdIdl}})
     Fpx = polynomial_ring(residue_ring(FlintZZ, p, cached=false), "x", cached=false)[1]
     O = order(lp[1][2])
     K = O.nf

--- a/src/LinearAlgebra/Solve.jl
+++ b/src/LinearAlgebra/Solve.jl
@@ -149,7 +149,7 @@ end
 function algebraic_reconstruction(a::nf_elem, M::ZZRingElem)
   K = parent(a)
   n = degree(K)
-  Znn = matrix_space(FlintZZ, n, n; cached=false)
+  Znn = matrix_space(FlintZZ, n, n)
 #  L = [ Znn(1) representation_matrix_q(a)[1] ; Znn(0) Znn(M)]
   L = vcat(hcat(Znn(1), representation_matrix_q(a)[1]), hcat(Znn(0),Znn(M)))
   lll!(L)
@@ -162,7 +162,7 @@ end
 function algebraic_reconstruction(a::nf_elem, M::NfAbsOrdIdl)
   K = parent(a)
   n = degree(K)
-  Znn = matrix_space(FlintZZ, n, n; cached=false)
+  Znn = matrix_space(FlintZZ, n, n)
   L = [ Znn(1) representation_matrix_q(a)[1] ; Znn(0) basis_matrix(M, copy = false)]
   lll!(L)
   d = Nemo.elem_from_mat_row(K, sub(L, 1:1, 1:n), 1, ZZRingElem(1))

--- a/src/NumFieldOrd/NfOrd/Ideal/Prime.jl
+++ b/src/NumFieldOrd/NfOrd/Ideal/Prime.jl
@@ -438,7 +438,7 @@ function anti_uniformizer(P::NfAbsOrdIdl)
   end
   p = minimum(P)
   M = representation_matrix(uniformizer(P))
-  #Mp = matrix_space(residue_field(FlintZZ, p, cached=false), nrows(M), ncols(M), false)(M)
+  #Mp = matrix_space(residue_field(FlintZZ, p), nrows(M), ncols(M), false)(M)
   Mp = change_base_ring(GF(p, cached = false), M)
   K = left_kernel_basis(Mp)
   @assert length(K) > 0

--- a/src/Sparse/Matrix.jl
+++ b/src/Sparse/Matrix.jl
@@ -6,9 +6,9 @@ export SMatSpace, sparse_matrix, nnz, sparsity, density
 #
 ################################################################################
 
-function SMatSpace(R::Ring, r::Int, c::Int; cached = true)
+function SMatSpace(R::Ring, r::Int, c::Int)
   T = elem_type(R)
-  return SMatSpace{T}(R, r, c, cached)
+  return SMatSpace{T}(R, r, c)
 end
 
 ################################################################################
@@ -59,7 +59,7 @@ end
 
 function release_tmp(A::SMat{T}, s::SRow{T}) where T
   return
-  if isdefined(A, :tmp) 
+  if isdefined(A, :tmp)
     if length(A.tmp) < 10
       push!(A.tmp, s)
     end


### PR DESCRIPTION
This minimizes overhead from them and also allows us to remove
the caches as instances can be stack allocated.
