### PR TITLE
Fix generic `_hermitian_form_with_invariants`

### DIFF
--- a/src/QuadForm.jl
+++ b/src/QuadForm.jl
@@ -18,9 +18,6 @@ include("QuadForm/Lattices.jl")
 # Functionality for pseudo matrices
 include("QuadForm/PseudoMatrices.jl")
 
-# Functionality for IO with Hecke/Magma
-include("QuadForm/IO.jl")
-
 # Torsion
 include("QuadForm/Torsion.jl")
 
@@ -56,3 +53,6 @@ include("QuadForm/CloseVectors.jl")
 
 # indefinite LLL 
 include("QuadForm/indefiniteLLL.jl")
+
+# Functionality for IO with Hecke/Magma
+include("QuadForm/IO.jl")

--- a/src/QuadForm/Herm/Genus.jl
+++ b/src/QuadForm/Herm/Genus.jl
@@ -1,7 +1,7 @@
 export genus, representative, rank, det, uniformizer, det_representative,
        gram_matrix, hermitian_genera, hermitian_local_genera, rank,
        is_inert, scales, ranks, dets, is_split, is_ramified, is_dyadic,
-       norms, primes, signatures
+       norms, primes, signatures, HermLocalGenus, HermGenus
 
 ################################################################################
 #
@@ -1556,7 +1556,8 @@ function representative(G::HermGenus)
   if !is_integral(G)
     s = denominator(_scale(G))
     L = representative(rescale(G, s))
-    return rescale(L, 1//s)
+    L = rescale(L, 1//s)
+    return L
   end
   P = _non_norm_primes(G.LGS)
   E = base_field(G)
@@ -1564,6 +1565,8 @@ function representative(G::HermGenus)
   @vprint :Lattice 1 "Finding maximal integral lattice\n"
   M = maximal_integral_lattice(V)
   lp = primes(G)
+  bd = union(support(2*fixed_ring(M)), support(discriminant(maximal_order(E))))
+  lp = union(lp, bd)
   for p in lp
     @vprint :Lattice 1 "Finding representative for $g at $(prime(g))...\n"
     g = G[p]

--- a/src/QuadForm/Misc.jl
+++ b/src/QuadForm/Misc.jl
@@ -1022,7 +1022,7 @@ function _weak_approximation_generic(I::Vector{<: InfPlc}, val::Vector{Int})
   end
 
   for P in I
-    v = log(uni[P])::GrpAbFinGenElem
+    v = log(uni[embedding(P)])::GrpAbFinGenElem
     for i in 1:ngens(A)
       if v.coeff[i] == 1
         target_signs[i] = val[i] == -1 ? 1 : 0


### PR DESCRIPTION
This was a piece of code which I guess was not triggered by the tests we currently had.
At first it was suppose to be a fix for `representative`, but the example I had is taking forever, so I just restricted to computing the middle step which was bugged (to avoid to have a test running for 20min because of the computation of a maximal integral lattice)

For help I have added another `to_hecke` function for `HermGenus`.