### PR TITLE
Add functionalities for `TorQuadModuleMor`

### DIFF
--- a/src/GrpAb/Map.jl
+++ b/src/GrpAb/Map.jl
@@ -497,8 +497,22 @@ Base.:(*)(f::GrpAbFinGenMap, a::IntegerUnion) = a*f
 function Base.:^(f::GrpAbFinGenMap, n::Integer)
   @assert domain(f) === codomain(f)
   @assert n >= 0
-  M = f.map^n
   C = codomain(f)
+  if isdefined(C, :exponent)
+    if fits(Int, C.exponent)
+      RR = residue_ring(FlintZZ, Int(C.exponent), cached = false)
+      fRR = map_entries(RR, f.map)
+      MRR = fRR^n
+      M = lift(MRR)
+    else
+      R = residue_ring(FlintZZ, C.exponent, cached = false)
+      fR = map_entries(R, f.map)
+      MR = fR^n
+      M = map_entries(lift, MR)
+    end
+  else
+    M = f.map^n
+  end
   if is_snf(C)
     reduce_mod_snf!(M, C.snf)
   else

--- a/src/QuadForm/Torsion.jl
+++ b/src/QuadForm/Torsion.jl
@@ -476,7 +476,7 @@ end
 @doc raw"""
     id(T::TorQuadModule) -> TorQuadModuleElem
 
-Return the identity element of `T` as an abelian group.
+Return the identity element for the abelian group structure on `T`.
 """
 id(T::TorQuadModule) = T(id(abelian_group(T)))
 
@@ -625,9 +625,6 @@ end
 Given two torsion quadratic modules `T` and `S`, and a matrix `M` representing
 an abelian group homomorphism between the underlying groups of `T` and `S`,
 return the corresponding abelian group homomorphism between `T` and `S`.
-
-Note that such a map needs not to preserve the torsion quadratic module
-structures.
 """
 function hom(T::TorQuadModule, S::TorQuadModule, M::ZZMatrix)
   map_ab = hom(abelian_group(T), abelian_group(S), M)
@@ -641,9 +638,6 @@ end
 Given two torsion quadratic modules `T` and `S`, and a set of elements of `S`
 containing as many elements as `ngens(T)`, return the abelian group homomorphism
 between `T` and `S` mapping the generators of `T` to the elements of `img`.
-
-Note that such a map needs not to preserve the torsion quadratic module
-structures.
 """
 function hom(T::TorQuadModule, S::TorQuadModule, img::Vector{TorQuadModuleElem})
   _img = GrpAbFinGenElem[]
@@ -691,7 +685,7 @@ trivial_map(T::TorQuadModule, U::TorQuadModule) = hom(T, U, TorQuadModuleElem[id
 @doc raw"""
     trivial_map(T::TorQuadModule) -> TorQuadModuleMor
 
-Return the abelian group endomorphism of `T sending every elements of `T`
+Return the abelian group endomorphism of `T` sending every elements of `T`
 to the zero element of `T`.
 """
 trivial_map(T::TorQuadModule) = trivial_map(T, T)
@@ -828,8 +822,6 @@ end
 
 Given an abelian group homomorphism `f` between two torsion quadratic modules `T`
 and `U`, return the kernel `S` of `f` as well as the injection $S \to T$.
-
-Note: `f` need not be a morphism of torsion quadratic modules.
 """
 function kernel(f::TorQuadModuleMor)
   g = abelian_group_homomorphism(f)
@@ -904,17 +896,17 @@ return the $n$-fold self-composition of `f`.
 Note that `n` must be non-negative and $f^0$ is by default the identity map
 of the domain of `f` (see [`identity_map`](@ref)).
 """
-function Base.:^(f::TorQuadModuleMor, a::Integer)
-  @req a >= 0 "a must be a positive integer"
+function Base.:^(f::TorQuadModuleMor, n::Integer)
+  @req n >= 0 "n must be a positive integer"
   @assert domain(f) === codomain(f) "f must be a self-map"
-  if a == 0
+  if n == 0
     return id_hom(domain(f))
-  elseif a == 1
+  elseif n == 1
     return f
   else
     k = 1
     f2 = f
-    while k != a
+    while k != n
       f2 = compose(f2, f)
       k += 1
     end

--- a/src/QuadForm/Types.jl
+++ b/src/QuadForm/Types.jl
@@ -406,7 +406,7 @@ true
 Hecke provides several constructors for objects of type `TorQuadModuleMor`, see
 for instance [`hom(::TorQuadModule, ::TorQuadModule, ::ZZMatrix)`](@ref),
 [`hom(::TorQuadModule, ::TorQuadModule, ::Vector{TorQuadModuleElem})`](@ref),
-[`identity_map(::TorQuadModule)`](@ref) or [`trivial_map(::TorQuadModule)`](@ref).
+[`identity_map(::TorQuadModule)`](@ref) or [`trivial_morphism(::TorQuadModule)`](@ref).
 """
 mutable struct TorQuadModuleMor <: Map{TorQuadModule, TorQuadModule, HeckeMap, TorQuadModuleMor}
   header::MapHeader{TorQuadModule, TorQuadModule}

--- a/src/QuadForm/Types.jl
+++ b/src/QuadForm/Types.jl
@@ -324,7 +324,7 @@ julia> N, f = normal_form(T)
 (TorQuadModule: [1//4 0 0 0; 0 4//3 0 0; 0 0 4//3 0; 0 0 0 4//3], Map with following data
 Domain:
 =======
-T
+TorQuadModule [2//3 0 1//3; 0 0 2//3; 1//3 2//3 1//4]
 Codomain:
 =========
 TorQuadModule [1//4 0 0 0; 0 4//3 0 0; 0 0 4//3 0; 0 0 0 4//3])
@@ -391,10 +391,10 @@ julia> f = hom(T, T6, gens(T6))
 Map with following data
 Domain:
 =======
-T
+TorQuadModule [2//3 0 1//3; 0 0 2//3; 1//3 2//3 1//4]
 Codomain:
 =========
-T6
+TorQuadModule [4 0 2; 0 0 4; 2 4 3//2]
 
 julia> T[1]*T[1] == f(T[1])*f(T[1])
 false

--- a/src/QuadForm/Types.jl
+++ b/src/QuadForm/Types.jl
@@ -216,7 +216,7 @@ end
 @doc raw"""
     TorQuadModule
 
-# Example:
+# Examples
 ```jldoctest
 julia> A = matrix(ZZ, [[2,0,0,-1],[0,2,0,-1],[0,0,2,-1],[-1,-1,-1,2]]);
 
@@ -300,6 +300,114 @@ end
 
 ### Maps
 
+@doc raw"""
+    TorQuadModuleMor
+
+Type for abelian group homomorphisms between torsion quadratic modules. It
+consists of a header which keeps track of the domain and the codomain of type
+`TorQuadModule` as well as the underlying abelian group homomorphism.
+
+# Examples
+```jldoctest
+julia> L = rescale(root_lattice(:A,3), 3)
+Quadratic lattice of rank 3 and degree 3 over the rationals
+
+julia> T = discriminant_group(L)
+Finite quadratic module over Integer Ring with underlying abelian group
+GrpAb: (Z/3)^2 x Z/12
+Gram matrix of the quadratic form with values in Q/2Z
+[2//3      0   1//3]
+[   0      0   2//3]
+[1//3   2//3   1//4]
+
+julia> N, f = normal_form(T)
+(TorQuadModule: [1//4 0 0 0; 0 4//3 0 0; 0 0 4//3 0; 0 0 0 4//3], Map with following data
+Domain:
+=======
+T
+Codomain:
+=========
+TorQuadModule [1//4 0 0 0; 0 4//3 0 0; 0 0 4//3 0; 0 0 0 4//3])
+
+
+julia> domain(f)
+Finite quadratic module over Integer Ring with underlying abelian group
+GrpAb: (Z/3)^2 x Z/12
+Gram matrix of the quadratic form with values in Q/2Z
+[2//3      0   1//3]
+[   0      0   2//3]
+[1//3   2//3   1//4]
+
+julia> codomain(f)
+Finite quadratic module over Integer Ring with underlying abelian group
+(General) abelian group with relation matrix
+[4 0 0 0; 0 3 0 0; 0 0 3 0; 0 0 0 3]
+with structure of GrpAb: (Z/3)^2 x Z/12
+
+Gram matrix of the quadratic form with values in Q/2Z
+[1//4      0      0      0]
+[   0   4//3      0      0]
+[   0      0   4//3      0]
+[   0      0      0   4//3]
+
+julia> abelian_group_homomorphism(f)
+Map with following data
+Domain:
+=======
+Abelian group with structure: (Z/3)^2 x Z/12
+Codomain:
+=========
+(General) abelian group with relation matrix
+[4 0 0 0; 0 3 0 0; 0 0 3 0; 0 0 0 3]
+with structure of Abelian group with structure: (Z/3)^2 x Z/12
+```
+
+Note that an object of type `TorQuadModuleMor` needs not to be a morphism
+of torsion quadratic modules, i.e. it does not have to preserve the
+respective bilinear or quadratic forms of its domain and codomain. Though,
+it must be a homomorphism between the underlying finite abelian groups.
+
+# Examples
+```jldoctest
+julia> L = rescale(root_lattice(:A,3), 3);
+
+julia> T = discriminant_group(L)
+Finite quadratic module over Integer Ring with underlying abelian group
+GrpAb: (Z/3)^2 x Z/12
+Gram matrix of the quadratic form with values in Q/2Z
+[2//3      0   1//3]
+[   0      0   2//3]
+[1//3   2//3   1//4]
+
+julia> T6 = rescale(T, 6)
+Finite quadratic module over Integer Ring with underlying abelian group
+GrpAb: (Z/3)^2 x Z/12
+Gram matrix of the quadratic form with values in Q/12Z
+[4   0      2]
+[0   0      4]
+[2   4   3//2]
+
+julia> f = hom(T, T6, gens(T6))
+Map with following data
+Domain:
+=======
+T
+Codomain:
+=========
+T6
+
+julia> T[1]*T[1] == f(T[1])*f(T[1])
+false
+
+julia> is_bijective(f)
+true
+```
+
+Hecke provides several constructors for objects of type `TorQuadModuleMor`, see
+for instance [`hom(::TorQuadModule, ::TorQuadModule, ::ZZMatrix)`](@ref),
+[`hom(::TorQuadModule, ::TorQuadModule, ::Vector{TorQuadModuleElem})`](@ref),
+[`identity_map(::TorQuadModule)`](@ref) or [`trivial_map(::TorQuadModule)`](@ref).
+"""
 mutable struct TorQuadModuleMor <: Map{TorQuadModule, TorQuadModule, HeckeMap, TorQuadModuleMor}
   header::MapHeader{TorQuadModule, TorQuadModule}
   map_ab::GrpAbFinGenMap

--- a/test/QuadForm/Torsion.jl
+++ b/test/QuadForm/Torsion.jl
@@ -385,7 +385,7 @@ end
   M = @inferred matrix(f)
   @test isone(M)
 
-  f = @inferred trivial_map(qL)
+  f = @inferred trivial_morphism(qL)
   @test iszero(matrix(f))
 
   N, qLtoN = normal_form(qL)
@@ -407,13 +407,16 @@ end
   p = minpoly(m) # p = (X^2+1)(X+1)
 
   @test iszero(matrix(p(f)))
+  @test iszero(p(abelian_group_homomorphism(f))) #trivia for test coverage
   @test !iszero(matrix(p(-f)))
   @test iszero(matrix(f-f))
   @test iszero(matrix(f*order(qL)))
   @test isone(matrix(f^4))
   @test !isone(matrix(f^2))
   @test abelian_group_homomorphism(f) == abelian_group_homomorphism(f^5)
+  @test abelian_group_homomorphism(f*4) == abelian_group_homomorphism(f)*4 #trivia for test coverage
 
   Zx, x = ZZ["x"]
   @test matrix((x-1)(f)) == matrix(f) - 1
+  @test x(abelian_group_homomorphism(f)).map == matrix(f) #trivia for test coverage
 end

--- a/test/QuadForm/Torsion.jl
+++ b/test/QuadForm/Torsion.jl
@@ -367,5 +367,53 @@
   S, f = @inferred snf(Tsub)
   @test is_snf(S)
 
+  # trivial element
+  L = root_lattice(:E, 7)
+  qL = discriminant_group(L)
+  a = @inferred id(qL)
+  @test iszero(a)
 end
 
+
+@testset "Maps functionalities" begin
+
+  L = rescale(root_lattice(:A, 3), 15)
+  qL = discriminant_group(L)
+  f = id_hom(qL)
+  fab = @inferred abelian_group_homomorphism(f)
+  @test all(a -> fab(data(a)) == data(f(a)), gens(qL))
+  M = @inferred matrix(f)
+  @test isone(M)
+
+  f = @inferred trivial_map(qL)
+  @test iszero(matrix(f))
+
+  N, qLtoN = normal_form(qL)
+  f = @inferred zero(qLtoN)
+  @test domain(f) === qL
+  @test codomain(f) === N
+  @test iszero(matrix(f))
+
+  K, KtoqL = @inferred kernel(qLtoN)
+  @assert order(K) == 1
+  K, KtoqL = kernel(f)
+  @assert order(K) == order(qL)
+  @assert isone(matrix(KtoqL))
+
+  m = matrix(QQ, 3, 3, [ 0  1  1;
+                        -1 -1 -1;
+                         1  1  0])  # this has order 4
+  f = hom(qL, qL, TorQuadModuleElem[qL(lift(a)*m) for a in gens(qL)]) # This has also order 4!
+  p = minpoly(m) # p = (X^2+1)(X+1)
+
+  @test iszero(matrix(p(f)))
+  @test !iszero(matrix(p(-f)))
+  @test iszero(matrix(f-f))
+  @test iszero(matrix(f*order(qL)))
+  @test isone(matrix(f^4))
+  @test !isone(matrix(f^2))
+  @test abelian_group_homomorphism(f) == abelian_group_homomorphism(f^5)
+
+  Zx, x = ZZ["x"]
+  @test matrix((x-1)(f)) == matrix(f) - 1
+end


### PR DESCRIPTION
- Add accessors to underlying abelian group homomorphism and the associated matrix
- Add `id` for `TorQuadModule`, parallel to the existing method for `GrpAbFinGen`
- Add `kernel` for `TorQuadModuleMor`
- Add `trivial_map` and `zero` for zero maps between torsion quadratic modules
- Add arithmetic for `TorQuadModuleMor`
- Add multiple self composition for torsion quadratic modules endormorphism using `^`
- Add evaluation of polynomial with integral coefficients at torsion quadratic module endomorphisms