### PR TITLE
Fix input checks for creation of `ZLat`

### DIFF
--- a/src/QuadForm/Quad/ZLattices.jl
+++ b/src/QuadForm/Quad/ZLattices.jl
@@ -67,7 +67,7 @@ function Zlattice(;gram, check=true)
 end
 
 @doc raw"""
-    lattice(V::QuadSpace{QQField, QQMatrix}, B::QQMatrix) -> ZLat
+    lattice(V::QuadSpace{QQField, QQMatrix}, B::QQMatrix; isbasis=true, check=true) -> ZLat
 
 Return the $\mathbb Z$-lattice with basis matrix $B$ inside the quadratic space $V$.
 """

--- a/test/QuadForm/Quad/ZLattices.jl
+++ b/test/QuadForm/Quad/ZLattices.jl
@@ -687,3 +687,14 @@ end
   end
 end
 
+@testset "Constructor checks" begin
+  m = matrix(QQ, 2, 1, [1; -4])
+  @test_throws ArgumentError Zlattice(m)
+
+  L = root_lattice(:E, 7)
+  v = zero_matrix(QQ, 1, degree(L))
+  @test v in L
+  @test is_primitive(L, v)
+  @test_throws ArgumentError lattice_in_same_ambient_space(L, v)
+  @test rank(0*L) == 0
+end


### PR DESCRIPTION
Calling the function `ZLattice` was made by assuming that the entry matrix was actually a basis matrix, without checking it. Now it is always checked by default, but we leave the optional arguments `isbasis` and `check` for internal use.

There were few other places where the entry matrix was not always a basis so I have modified the functions accordingly (namely `lattice_in_same_ambient_space`, `is_primitive` and multiplication of a lattice by a scalar).

Then to avoid checking arguments in functions for which we know what is happening, I have disabled the input checks.