### PR TITLE
More renamings

### DIFF
--- a/benchmark/Lattices.jl
+++ b/benchmark/Lattices.jl
@@ -64,7 +64,7 @@ function to_sage(x::QQMatrix, varname = "x")
   return s
 end
 
-function benchmark_code_sage(L::Vector{Hecke.ZLat}, repetitions::Int = 10; out_file::String = "sage_timings")
+function benchmark_code_sage(L::Vector{Hecke.ZZLat}, repetitions::Int = 10; out_file::String = "sage_timings")
   s = """
   from sage.all import *
   import timeit
@@ -96,7 +96,7 @@ quit()
   return s
 end
 
-function benchmark_code_magma(L::Vector{Hecke.ZLat}, repetitions::Int = 10; out_file::String = "magma_timings")
+function benchmark_code_magma(L::Vector{Hecke.ZZLat}, repetitions::Int = 10; out_file::String = "magma_timings")
   default_repetitions = repetitions
   s = """
   res := [];
@@ -129,7 +129,7 @@ function benchmark_code_magma(L::Vector{Hecke.ZLat}, repetitions::Int = 10; out_
   return s
 end
 
-function benchmark_magma(L::Vector{Hecke.ZLat})
+function benchmark_magma(L::Vector{Hecke.ZZLat})
   t, fp = mktemp()
   @show t
   out_file, fp_out = mktemp()
@@ -149,7 +149,7 @@ function benchmark_magma(L::Vector{Hecke.ZLat})
   return Float64[x[1] for x in t]
 end
 
-function benchmark_sage(L::Vector{Hecke.ZLat})
+function benchmark_sage(L::Vector{Hecke.ZZLat})
   t, fp = mktemp()
   @show t
   out_file, fp_out = mktemp()
@@ -168,7 +168,7 @@ function benchmark_sage(L::Vector{Hecke.ZLat})
   return Meta.eval(Meta.parse(s))
 end
 
-function benchmark_hecke(L::Vector{Hecke.ZLat})
+function benchmark_hecke(L::Vector{Hecke.ZZLat})
   res = Float64[]
   for i in 1:length(L)
     LL = L[i]
@@ -179,7 +179,7 @@ function benchmark_hecke(L::Vector{Hecke.ZLat})
   return res
 end
 
-function benchmark_all(L::Vector{Hecke.ZLat})
+function benchmark_all(L::Vector{Hecke.ZZLat})
   bM = benchmark_magma(L)
   bH = benchmark_hecke(L)
   bS = benchmark_sage(L)

--- a/docs/Build.jl
+++ b/docs/Build.jl
@@ -29,7 +29,7 @@ pages = [
 					      "quad_forms/lattices.md",
 					      "quad_forms/genusherm.md",
 					      "quad_forms/integer_lattices.md",
-					      "quad_forms/Zgenera.md",
+					      "quad_forms/integer_genera.md",
 					      "quad_forms/discriminant_group.md"
 					    ],
          "Abelian groups" => "abelian/introduction.md",

--- a/docs/Build.jl
+++ b/docs/Build.jl
@@ -29,7 +29,7 @@ pages = [
 					      "quad_forms/lattices.md",
 					      "quad_forms/genusherm.md",
 					      "quad_forms/integer_lattices.md",
-					      "quad_forms/integer_genera.md",
+					      "quad_forms/Zgenera.md",
 					      "quad_forms/discriminant_group.md"
 					    ],
          "Abelian groups" => "abelian/introduction.md",

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -91,7 +91,7 @@ nav:
       - Lattices: 'quad_forms/lattices.md'
       - Integer lattices: 'quad_forms/integer_lattices.md'
       - Genera for hermitian lattices: 'quad_forms/genusherm.md'
-      - Genera for integer lattices: 'quad_forms/Zgenera.md'
+      - Genera for integer lattices: 'quad_forms/integer_genera.md'
       - Discriminant groups: 'quad_forms/discriminant_group.md'
     - Abelian groups:
       - Introduction:     abelian/introduction.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -91,7 +91,7 @@ nav:
       - Lattices: 'quad_forms/lattices.md'
       - Integer lattices: 'quad_forms/integer_lattices.md'
       - Genera for hermitian lattices: 'quad_forms/genusherm.md'
-      - Genera for integer lattices: 'quad_forms/integer_genera.md'
+      - Genera for integer lattices: 'quad_forms/Zgenera.md'
       - Discriminant groups: 'quad_forms/discriminant_group.md'
     - Abelian groups:
       - Introduction:     abelian/introduction.md

--- a/docs/src/dev/test.md
+++ b/docs/src/dev/test.md
@@ -17,7 +17,7 @@ The Hecke tests can be found in `Hecke/test/` and are organized in such a way th
 │   │   │   ├── NormalForm.jl
 │   │   │   ├── Spaces.jl
 │   │   │   ├── Types.jl
-│   │   │   ├── ZGenus.jl
+│   │   │   ├── ZZGenus.jl
 │   │   │   └── ZLattices.jl
 │   │   ├── QuadBin.jl
 │   │   ├── Torsion.jl
@@ -35,7 +35,7 @@ The Hecke tests can be found in `Hecke/test/` and are organized in such a way th
 │   │   │   ├── GenusRep.jl
 │   │   │   ├── NormalForm.jl
 │   │   │   ├── Spaces.jl
-│   │   │   ├── ZGenus.jl
+│   │   │   ├── ZZGenus.jl
 │   │   │   └── ZLattices.jl
 │   │   ├── QuadBin.jl
 │   │   └── Torsion.jl

--- a/docs/src/dev/test.md
+++ b/docs/src/dev/test.md
@@ -17,7 +17,7 @@ The Hecke tests can be found in `Hecke/test/` and are organized in such a way th
 │   │   │   ├── NormalForm.jl
 │   │   │   ├── Spaces.jl
 │   │   │   ├── Types.jl
-│   │   │   ├── ZZGenus.jl
+│   │   │   ├── ZGenus.jl
 │   │   │   └── ZLattices.jl
 │   │   ├── QuadBin.jl
 │   │   ├── Torsion.jl
@@ -35,7 +35,7 @@ The Hecke tests can be found in `Hecke/test/` and are organized in such a way th
 │   │   │   ├── GenusRep.jl
 │   │   │   ├── NormalForm.jl
 │   │   │   ├── Spaces.jl
-│   │   │   ├── ZZGenus.jl
+│   │   │   ├── ZGenus.jl
 │   │   │   └── ZLattices.jl
 │   │   ├── QuadBin.jl
 │   │   └── Torsion.jl

--- a/docs/src/quad_forms/Zgenera.md
+++ b/docs/src/quad_forms/Zgenera.md
@@ -14,10 +14,10 @@ The genus symbol itself is a collection of its local genus symbols.
 See [CS99](@cite) Chapter 15 for the definitions.
 Note that genera for non-integral lattices are supported.
 
-The class `ZGenus` supports genera of $\mathbb{Z}$-lattices.
+The class `ZZGenus` supports genera of $\mathbb{Z}$-lattices.
 
 ```@docs
-ZGenus
+ZZGenus
 ```
 
 ## Creation of Genera
@@ -25,7 +25,7 @@ ZGenus
 ### From an integral Lattice
 
 ```@docs
-genus(::ZLat)
+genus(::ZZLat)
 ```
 
 ### From a gram matrix
@@ -37,103 +37,103 @@ genus(A::MatElem)
 ### Enumeration of genus symbols
 
 ```@docs
-Zgenera(sig_pair::Tuple{Int,Int}, determinant::Union{Int,ZZRingElem})
+integer_genera(sig_pair::Tuple{Int,Int}, determinant::Union{Int,ZZRingElem})
 ```
 ### From other genus symbols
 ```@docs
-direct_sum(G1::ZGenus, G2::ZGenus)
+direct_sum(G1::ZZGenus, G2::ZZGenus)
 ```
 
 ## Attributes of the genus
 
 ```@docs
-dim(G::ZGenus)
-rank(G::ZGenus)
-signature(G::ZGenus)
-det(G::ZGenus)
-iseven(G::ZGenus)
-is_definite(G::ZGenus)
-level(G::ZGenus)
-scale(G::ZGenus)
-norm(G::ZGenus)
-primes(G::ZGenus)
-is_integral(G::ZGenus)
+dim(G::ZZGenus)
+rank(G::ZZGenus)
+signature(G::ZZGenus)
+det(G::ZZGenus)
+iseven(G::ZZGenus)
+is_definite(G::ZZGenus)
+level(G::ZZGenus)
+scale(G::ZZGenus)
+norm(G::ZZGenus)
+primes(G::ZZGenus)
+is_integral(G::ZZGenus)
 ```
 ### Discriminant group
-[`discriminant_group(::ZGenus)`](@ref)
+[`discriminant_group(::ZZGenus)`](@ref)
 
 ### Primary genera
 ```docs
-is_primary_with_prime(G::ZGenus)
-is_primary(G::ZGenus, p::Union{Integer, ZZRingElem})
-is_elementary_with_prime(G::ZGenus)
-is_elementary(G::ZGenus, p::Union{Integer, ZZRingElem})
+is_primary_with_prime(G::ZZGenus)
+is_primary(G::ZZGenus, p::Union{Integer, ZZRingElem})
+is_elementary_with_prime(G::ZZGenus)
+is_elementary(G::ZZGenus, p::Union{Integer, ZZRingElem})
 ```
 
 ### local Symbol
 ```@docs
-local_symbol(G::ZGenus, p)
+local_symbol(G::ZZGenus, p)
 ```
 
 ## Representative(s)
 
 ```@docs
-quadratic_space(G::ZGenus)
-rational_representative(G::ZGenus)
-representative(G::ZGenus)
-representatives(G::ZGenus)
-mass(G::ZGenus)
-rescale(::ZGenus, ::RationalUnion)
+quadratic_space(G::ZZGenus)
+rational_representative(G::ZZGenus)
+representative(G::ZZGenus)
+representatives(G::ZZGenus)
+mass(G::ZZGenus)
+rescale(::ZZGenus, ::RationalUnion)
 ```
 
 ## Embeddings and Representations
 ```@docs
-represents(G1::ZGenus, G2::ZGenus)
+represents(G1::ZZGenus, G2::ZZGenus)
 ```
 
 ## Local genus Symbols
 
 ```@docs
-ZpGenus
+LocalZZGenus
 ```
 
 ### Creation
 
 ```@docs
-genus(L::ZLat, p)
+genus(L::ZZLat, p)
 genus(A::ZZMatrix, p)
 ```
 
 ### Attributes
 ```@docs
-prime(S::ZpGenus)
-iseven(S::ZpGenus)
-symbol(S::ZpGenus, scale::Int)
-hasse_invariant(S::ZpGenus)
-det(S::ZpGenus)
-dim(S::ZpGenus)
-rank(S::ZpGenus)
-excess(S::ZpGenus)
-signature(S::ZpGenus)
-oddity(S::ZpGenus)
-scale(S::ZpGenus)
-norm(S::ZpGenus)
-level(S::ZpGenus)
+prime(S::LocalZZGenus)
+iseven(S::LocalZZGenus)
+symbol(S::LocalZZGenus, scale::Int)
+hasse_invariant(S::LocalZZGenus)
+det(S::LocalZZGenus)
+dim(S::LocalZZGenus)
+rank(S::LocalZZGenus)
+excess(S::LocalZZGenus)
+signature(S::LocalZZGenus)
+oddity(S::LocalZZGenus)
+scale(S::LocalZZGenus)
+norm(S::LocalZZGenus)
+level(S::LocalZZGenus)
 ```
 ### Representative
 ```@docs
-representative(S::ZpGenus)
-gram_matrix(S::ZpGenus)
-rescale(S::ZpGenus, a::RationalUnion)
+representative(S::LocalZZGenus)
+gram_matrix(S::LocalZZGenus)
+rescale(S::LocalZZGenus, a::RationalUnion)
 ```
 
 ### Direct sums
 ```@docs
-direct_sum(S1::ZpGenus, S2::ZpGenus)
+direct_sum(S1::LocalZZGenus, S2::LocalZZGenus)
 ```
 
 ### Embeddings/Representations
 ```@docs
-represents(G1::ZpGenus, G2::ZpGenus)
+represents(G1::LocalZZGenus, G2::LocalZZGenus)
 ```
 

--- a/docs/src/quad_forms/discriminant_group.md
+++ b/docs/src/quad_forms/discriminant_group.md
@@ -22,7 +22,7 @@ where $n \mathbb{Z} = \Phi(M,N)$ and
 $m \mathbb{Z} = 2n\mathbb{Z} + \sum_{x \in N} \mathbb{Z} \Phi (x,x)$.
 
 ```@docs
-torsion_quadratic_module(M::ZLat, N::ZLat)
+torsion_quadratic_module(M::ZZLat, N::ZZLat)
 ```
 
 ### The underlying Type
@@ -92,7 +92,7 @@ integral integer quadratic lattices.
 ### From a lattice
 
 ```@docs
-discriminant_group(::ZLat)
+discriminant_group(::ZZLat)
 ```
 
 ### From a Matrix

--- a/docs/src/quad_forms/integer_lattices.md
+++ b/docs/src/quad_forms/integer_lattices.md
@@ -10,11 +10,11 @@ vector space $V = \mathbb{Q}^n$ over the rational numbers.
 Integer lattices are also known as quadratic forms over the integers.
 We will refer to them as $\mathbb{Z}$-lattices.
 
-A $\mathbb{Z}$-lattice $L$ has the type `ZLat`. It is given in terms of
+A $\mathbb{Z}$-lattice $L$ has the type `ZZLat`. It is given in terms of
 its ambient quadratic space $V$ together with a basis matrix $B$ whose rows span $L$,
 i.e. $L = \mathbb{Z}^r B$ where $r$ is the ($\mathbb{Z}$-module) rank of $L$.
 
-To access $V$ and $B$ see [`ambient_space(L::ZLat)`](@ref) and [`basis_matrix(L::ZLat)`](@ref).
+To access $V$ and $B$ see [`ambient_space(L::ZZLat)`](@ref) and [`basis_matrix(L::ZZLat)`](@ref).
 
 
 ## Creation of integer lattices
@@ -22,7 +22,7 @@ To access $V$ and $B$ see [`ambient_space(L::ZLat)`](@ref) and [`basis_matrix(L:
 ### From a gram matrix
 
 ```@docs
-Zlattice(B::QQMatrix)
+integer_lattice(B::QQMatrix)
 ```
 
 ### In a quadratic space
@@ -36,76 +36,76 @@ lattice(V::QuadSpace{QQField, QQMatrix}, B::MatElem;)
 ```@docs
 root_lattice(::Symbol, ::Int)
 hyperbolic_plane_lattice(n::Union{Int64, ZZRingElem})
-Zlattice(S::Symbol, n::Union{Int64, ZZRingElem})
+integer_lattice(S::Symbol, n::Union{Int64, ZZRingElem})
 leech_lattice
 ```
 
 ### From a genus
 Integer lattices can be created as representatives of a genus.
-See ([`representative(L::ZGenus)`](@ref))
+See ([`representative(L::ZZGenus)`](@ref))
 
 ### Rescaling the Quadratic Form
 
 ```@docs
-rescale(::ZLat, ::RationalUnion)
+rescale(::ZZLat, ::RationalUnion)
 ```
 
 ## Attributes
 
 ```@docs
-ambient_space(L::ZLat)
-basis_matrix(L::ZLat)
-gram_matrix(L::ZLat)
-rational_span(L::ZLat)
-base_ring(::ZLat)
-base_field(::ZLat)
+ambient_space(L::ZZLat)
+basis_matrix(L::ZZLat)
+gram_matrix(L::ZZLat)
+rational_span(L::ZZLat)
+base_ring(::ZZLat)
+base_field(::ZZLat)
 ```
 
 ## Invariants
 ```@docs
-rank(L::ZLat)
-det(L::ZLat)
+rank(L::ZZLat)
+det(L::ZZLat)
 
-scale(L::ZLat)
-norm(L::ZLat)
-iseven(L::ZLat)
-is_integral(L::ZLat)
+scale(L::ZZLat)
+norm(L::ZZLat)
+iseven(L::ZZLat)
+is_integral(L::ZZLat)
 
-is_primary_with_prime(L::ZLat)
-is_primary(L::ZLat, p::Union{Integer, ZZRingElem})
-is_elementary_with_prime(L::ZLat)
-is_elementary(L::ZLat, p::Union{Integer, ZZRingElem})
+is_primary_with_prime(L::ZZLat)
+is_primary(L::ZZLat, p::Union{Integer, ZZRingElem})
+is_elementary_with_prime(L::ZZLat)
+is_elementary(L::ZZLat, p::Union{Integer, ZZRingElem})
 ```
 
 ### The Genus
 
 For an integral lattice
 The genus of an integer lattice collects its local invariants.
-[`genus(::ZLat)`](@ref)
+[`genus(::ZZLat)`](@ref)
 ```@docs
-mass(L::ZLat)
-genus_representatives(L::ZLat)
+mass(L::ZZLat)
+genus_representatives(L::ZZLat)
 ```
 
 ### Real invariants
 ```@docs
-signature_tuple(L::ZLat)
-is_positive_definite(L::ZLat)
-is_negative_definite(L::ZLat)
-is_definite(L::ZLat)
+signature_tuple(L::ZZLat)
+is_positive_definite(L::ZZLat)
+is_negative_definite(L::ZZLat)
+is_definite(L::ZZLat)
 ```
 
 ## Isometries
 ```@docs
-automorphism_group_generators(L::ZLat)
-automorphism_group_order(L::ZLat)
-is_isometric(L::ZLat, M::ZLat)
-is_locally_isometric(L::ZLat, M::ZLat, p::Int)
+automorphism_group_generators(L::ZZLat)
+automorphism_group_order(L::ZZLat)
+is_isometric(L::ZZLat, M::ZZLat)
+is_locally_isometric(L::ZZLat, M::ZZLat, p::Int)
 ```
 # Root lattices
 ```@docs
-root_lattice_recognition(L::ZLat)
-root_lattice_recognition_fundamental(L::ZLat)
+root_lattice_recognition(L::ZZLat)
+root_lattice_recognition_fundamental(L::ZZLat)
 ADE_type(G::MatrixElem)
 coxeter_number(ADE::Symbol, n)
 highest_root(ADE::Symbol, n)
@@ -116,81 +116,81 @@ Most module operations assume that the lattices live in the same ambient space.
 For instance only lattices in the same ambient space compare.
 
 ```@docs
-Base.:(==)(L1::ZLat, L2::ZLat)
-is_sublattice(M::ZLat, N::ZLat)
-is_sublattice_with_relations(M::ZLat, N::ZLat)
-+(M::ZLat, N::ZLat)
-Base.:(*)(a::RationalUnion, L::ZLat)
-intersect(M::ZLat, N::ZLat)
-Base.in(v::Vector, L::ZLat)
-Base.in(v::QQMatrix, L::ZLat)
-primitive_closure(M::ZLat, N::ZLat)
-is_primitive(M::ZLat, N::ZLat)
-is_primitive(::ZLat, ::Union{Vector, QQMatrix})
-divisibility(::ZLat, ::Union{Vector, QQMatrix})
+Base.:(==)(L1::ZZLat, L2::ZZLat)
+is_sublattice(M::ZZLat, N::ZZLat)
+is_sublattice_with_relations(M::ZZLat, N::ZZLat)
++(M::ZZLat, N::ZZLat)
+Base.:(*)(a::RationalUnion, L::ZZLat)
+intersect(M::ZZLat, N::ZZLat)
+Base.in(v::Vector, L::ZZLat)
+Base.in(v::QQMatrix, L::ZZLat)
+primitive_closure(M::ZZLat, N::ZZLat)
+is_primitive(M::ZZLat, N::ZZLat)
+is_primitive(::ZZLat, ::Union{Vector, QQMatrix})
+divisibility(::ZZLat, ::Union{Vector, QQMatrix})
 ```
 
 ## Embeddings
 
 ### Categorical constructions
 ```@docs
-direct_sum(x::Vector{ZLat})
-direct_product(x::Vector{ZLat})
-biproduct(x::Vector{ZLat})
+direct_sum(x::Vector{ZZLat})
+direct_product(x::Vector{ZZLat})
+biproduct(x::Vector{ZZLat})
 ```
 
 ### Orthogonal sublattices
 ```@docs
-orthogonal_submodule(::ZLat, ::ZLat)
-irreducible_components(::ZLat)
+orthogonal_submodule(::ZZLat, ::ZZLat)
+irreducible_components(::ZZLat)
 ```
 
 ### Dual lattice
 ```@docs
-dual(L::ZLat)
+dual(L::ZZLat)
 ```
 
 ### Discriminant group
-See [`discriminant_group(L::ZLat)`](@ref).
+See [`discriminant_group(L::ZZLat)`](@ref).
 
 ### Overlattices
 ```@docs
-glue_map(L::ZLat, S::ZLat, R::ZLat; check=true)
+glue_map(L::ZZLat, S::ZZLat, R::ZZLat; check=true)
 overlattice(glue_map::TorQuadModuleMor)
-local_modification(M::ZLat, L::ZLat, p)
-maximal_integral_lattice(L::ZLat)
+local_modification(M::ZZLat, L::ZZLat, p)
+maximal_integral_lattice(L::ZZLat)
 ```
 
 ### Sublattices defined by endomorphisms
 ```@docs
-kernel_lattice(L::ZLat, f::MatElem; ambient_representation::Bool = true)
-invariant_lattice(L::ZLat, G::Vector{<:MatElem};
+kernel_lattice(L::ZZLat, f::MatElem; ambient_representation::Bool = true)
+invariant_lattice(L::ZZLat, G::Vector{<:MatElem};
                            ambient_representation::Bool = true)
 ```
 
 ### Computing embeddings
 ```@docs
-embed(S::ZLat, G::ZGenus, primitive::Bool=true)
-embed_in_unimodular(S::ZLat, pos, neg; primitive=true, even=true)
+embed(S::ZZLat, G::ZZGenus, primitive::Bool=true)
+embed_in_unimodular(S::ZZLat, pos, neg; primitive=true, even=true)
 ```
 
 ## LLL, Short and Close Vectors
 
 ### LLL and indefinite LLL
 ```@docs
-lll(L::ZLat; same_ambient::Bool = true)
+lll(L::ZZLat; same_ambient::Bool = true)
 ```
 ### Short Vectors
 ```@docs
 short_vectors
 shortest_vectors
 short_vectors_iterator
-minimum(L::ZLat)
-kissing_number(L::ZLat)
+minimum(L::ZZLat)
+kissing_number(L::ZZLat)
 ```
 
 ### Close Vectors
 ```@docs
-close_vectors(L::ZLat, v::Vector, arg...; kw...)
+close_vectors(L::ZZLat, v::Vector, arg...; kw...)
 ```
 ---

--- a/src/Aliases.jl
+++ b/src/Aliases.jl
@@ -11,6 +11,7 @@
 
 @alias get_assert_level get_assertion_level
 @alias get_verbose_level get_verbosity_level
+@alias genera Zgenera
 @alias genera_hermitian hermitian_genera
 @alias genera_quadratic quadratic_genera
 @alias GenusHerm HermGenus

--- a/src/Aliases.jl
+++ b/src/Aliases.jl
@@ -11,7 +11,6 @@
 
 @alias get_assert_level get_assertion_level
 @alias get_verbose_level get_verbosity_level
-@alias genera Zgenera
 @alias genera_hermitian hermitian_genera
 @alias genera_quadratic quadratic_genera
 @alias GenusHerm HermGenus
@@ -205,6 +204,12 @@
 @alias TorQuadMod TorQuadModule
 @alias TorQuadModElem TorQuadModuleElem
 @alias TorQuadModMor TorQuadModuleMor
+
+@alias ZGenus ZZGenus
+@alias ZLat ZZLat
+@alias Zgenera integer_genera
+@alias Zlattice integer_lattice
+@alias ZpGenus LocalZZGenus
 
 # Deprecated during 0.17.*
 @alias real_field real_number_field

--- a/src/Aliases.jl
+++ b/src/Aliases.jl
@@ -11,7 +11,7 @@
 
 @alias get_assert_level get_assertion_level
 @alias get_verbose_level get_verbosity_level
-@alias genera Zgenera
+@alias genera integer_genera
 @alias genera_hermitian hermitian_genera
 @alias genera_quadratic quadratic_genera
 @alias GenusHerm HermGenus

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -34,7 +34,7 @@
 
 # Deprecated during 0.18.*
 
-@deprecate orthogonal_sum(x::T, y::T) where T <: Union{AbstractSpace, ZGenus, ZpGenus, HermGenus, HermLocalGenus, QuadGenus, QuadLocalGenus, JorDec, LocalQuadSpaceCls, QuadSpaceCls} direct_sum(x, y)
+@deprecate orthogonal_sum(x::T, y::T) where T <: Union{AbstractSpace, ZZGenus, LocalZZGenus, HermGenus, HermLocalGenus, QuadGenus, QuadLocalGenus, JorDec, LocalQuadSpaceCls, QuadSpaceCls} direct_sum(x, y)
 
 # Things that moved to Nemo
 

--- a/src/QuadForm/CloseVectors.jl
+++ b/src/QuadForm/CloseVectors.jl
@@ -1,7 +1,7 @@
 export close_vectors, close_vectors_iterator
 
 @doc raw"""
-    close_vectors(L:ZLat, v:Vector, [lb,], ub; check::Bool = false)
+    close_vectors(L:ZZLat, v:Vector, [lb,], ub; check::Bool = false)
                                             -> Vector{Tuple{Vector{Int}}, QQFieldElem}
 
 Return all tuples `(x, d)` where `x` is an element of `L` such that `d = b(v -
@@ -18,7 +18,7 @@ Both input and output are with respect to the basis matrix of `L`.
 # Examples
 
 ```jldoctest
-julia> L = Zlattice(matrix(QQ, 2, 2, [1, 0, 0, 2]));
+julia> L = integer_lattice(matrix(QQ, 2, 2, [1, 0, 0, 2]));
 
 julia> close_vectors(L, [1, 1], 1)
 3-element Vector{Tuple{Vector{ZZRingElem}, QQFieldElem}}:
@@ -32,31 +32,31 @@ julia> close_vectors(L, [1, 1], 1, 1)
  ([0, 1], 1)
 ```
 """
-close_vectors(L::ZLat, v::Vector, arg...; kw...)
+close_vectors(L::ZZLat, v::Vector, arg...; kw...)
 
-function close_vectors(L::ZLat, v::Vector, upperbound, elem_type::Type{S} = ZZRingElem; kw...) where {S}
+function close_vectors(L::ZZLat, v::Vector, upperbound, elem_type::Type{S} = ZZRingElem; kw...) where {S}
   @req upperbound >= 0 "The upper bound must be non-negative"
   return _close_vectors(L, QQ.(v), nothing, QQ(upperbound), elem_type; kw...)
 end
 
-function close_vectors_iterator(L::ZLat, v::Vector, upperbound, elem_type::Type{S} = ZZRingElem; kw...) where {S}
+function close_vectors_iterator(L::ZZLat, v::Vector, upperbound, elem_type::Type{S} = ZZRingElem; kw...) where {S}
   @req upperbound >= 0 "The upper bound must be non-negative"
   return _close_vectors_iterator(L, QQ.(v), nothing, QQ(upperbound), elem_type; kw...)
 end
 
-function close_vectors(L::ZLat, v::Vector, lowerbound, upperbound, elem_type::Type{S} = ZZRingElem; kw...) where {S}
+function close_vectors(L::ZZLat, v::Vector, lowerbound, upperbound, elem_type::Type{S} = ZZRingElem; kw...) where {S}
   @req upperbound >= 0 "The upper bound must be non-negative"
   @req lowerbound >= 0 "The lower bound must be non-negative"
   return _close_vectors(L, QQ.(v), QQ(lowerbound), QQ(upperbound), elem_type; kw...)
 end
 
-function close_vectors_iterator(L::ZLat, v::Vector, lowerbound, upperbound, elem_type::Type{S} = ZZRingElem; kw...) where {S}
+function close_vectors_iterator(L::ZZLat, v::Vector, lowerbound, upperbound, elem_type::Type{S} = ZZRingElem; kw...) where {S}
   @req upperbound >= 0 "The upper bound must be non-negative"
   @req lowerbound >= 0 "The lower bound must be non-negative"
   return _close_vectors_iterator(L, QQ.(v), QQ(lowerbound), QQ(upperbound), elem_type; kw...)
 end
 
-function _close_vectors(L::ZLat, v::Vector{QQFieldElem}, lowerbound, upperbound::QQFieldElem, elem_type::Type{S} = ZZRingElem;
+function _close_vectors(L::ZZLat, v::Vector{QQFieldElem}, lowerbound, upperbound::QQFieldElem, elem_type::Type{S} = ZZRingElem;
                                 sorting::Bool=false,
                                 check=true)  where {S}
   epsilon = QQ(1//10)   # some number > 0, not sure how it influences performance
@@ -64,8 +64,8 @@ function _close_vectors(L::ZLat, v::Vector{QQFieldElem}, lowerbound, upperbound:
   V = rational_span(L)
   G1 = gram_matrix(V)
   if check
-    @req is_definite(L) == true && G1[1, 1] > 0 "Zlattice must be positive definite"
-    @req rank(L) == d "Zlattice must have the same rank as the length of the vector in the second argument."
+    @req is_definite(L) == true && G1[1, 1] > 0 "integer_lattice must be positive definite"
+    @req rank(L) == d "integer_lattice must have the same rank as the length of the vector in the second argument."
   end
 
   epsilon = QQ(1//10)   # some number > 0, not sure how it influences performance
@@ -126,15 +126,15 @@ function _close_vectors(L::ZLat, v::Vector{QQFieldElem}, lowerbound, upperbound:
   return cv
 end
 
-function _close_vectors_iterator(L::ZLat, v::Vector{QQFieldElem}, lowerbound, upperbound::QQFieldElem, elem_type::Type{S} = ZZRingElem;
+function _close_vectors_iterator(L::ZZLat, v::Vector{QQFieldElem}, lowerbound, upperbound::QQFieldElem, elem_type::Type{S} = ZZRingElem;
                                 sorting::Bool=false,
                                 check=true, filter = nothing) where S
   d = length(v)
   V = rational_span(L)
   G1 = gram_matrix(V)
   if check
-    @req is_definite(L) == true && G1[1, 1] > 0 "Zlattice must be positive definite"
-    @req rank(L) == d "Zlattice must have the same rank as the length of the vector in the second argument."
+    @req is_definite(L) == true && G1[1, 1] > 0 "integer_lattice must be positive definite"
+    @req rank(L) == d "integer_lattice must have the same rank as the length of the vector in the second argument."
   end
 
   epsilon = QQ(1//10)   # some number > 0, not sure how it influences performance
@@ -223,12 +223,12 @@ end
 #
 ################################################################################
 
-function closest_vectors(L::ZLat, v::MatrixElem{T} , upperbound::T; kw...) where T <: RingElem
+function closest_vectors(L::ZZLat, v::MatrixElem{T} , upperbound::T; kw...) where T <: RingElem
   _v = T[v[i] for i in 1:nrows(v)]
   return first.(close_vectors(L, _v, upperbound; kw...))
 end
 @doc raw"""
-    _convert_type(G::MatrixElem{T}, K::MatrixElem{T}, d::T) -> Tuple{ZLat, MatrixElem{T}, T}
+    _convert_type(G::MatrixElem{T}, K::MatrixElem{T}, d::T) -> Tuple{ZZLat, MatrixElem{T}, T}
 Where T is a concrete type, e.g. ZZRingElem, QQFieldElem, etc.
 Converts a quadratic triple QT = [Q, K, d] to the input values required for closest vector problem (CVP).
 """
@@ -237,17 +237,17 @@ function _convert_type(G::MatrixElem{T}, K::MatrixElem{T}, d::T) where T <: Ring
   Q = G
   vector = -solve(Q, K) #-inv(Q) * K
   upperbound = (transpose(vector) * Q * vector)[1,1] - d
-  Lattice = Zlattice(gram = Q, check=false)
+  Lattice = integer_lattice(gram = Q, check=false)
   return Lattice, vector, upperbound
 end
 
 @doc raw"""
-    _convert_type(L::ZLat, v::MatrixElem{T}, c::T) -> Tuple{QQMatrix, QQMatrix, QQFieldElem}
+    _convert_type(L::ZZLat, v::MatrixElem{T}, c::T) -> Tuple{QQMatrix, QQMatrix, QQFieldElem}
 
 Where T is a concrete type, e.g. ZZRingElem, QQFieldElem, etc.
 Converts the input values from closest vector enumeration (CVE) to the corresponding quadratic triple QT = [Q, K, d].
 """
-function _convert_type(L::ZLat, v::MatrixElem{T}, c::T) where T <: RingElem
+function _convert_type(L::ZZLat, v::MatrixElem{T}, c::T) where T <: RingElem
   V = ambient_space(L)
   Q = gram_matrix(V)
   @req all(Q[i,i]>0 for i in 1:nrows(Q)) "L must be definite"

--- a/src/QuadForm/Database.jl
+++ b/src/QuadForm/Database.jl
@@ -120,7 +120,7 @@ function lattice(L::LatDB, r::Int, i::Int)
   d = L.db[r][i].deg
   A = matrix(FlintQQ, d, d, L.db[r][i].amb)
   B = matrix(FlintQQ, r, d, L.db[r][i].basis_mat)
-  return Zlattice(B, gram = A)
+  return integer_lattice(B, gram = A)
 end
 
 function lattice(L::LatDB, i::Int)

--- a/src/QuadForm/IO.jl
+++ b/src/QuadForm/IO.jl
@@ -228,17 +228,17 @@ end
 #
 ################################################################################
 
-function to_hecke(io::IO, L::ZLat; target = "L", skip_field = false)
+function to_hecke(io::IO, L::ZZLat; target = "L", skip_field = false)
   B = basis_matrix(L)
   G = gram_matrix(ambient_space(L))
   Bst = "[" * split(string([B[i, j] for i in 1:nrows(B) for j in 1:ncols(B)]), '[')[2]
   Gst = "[" * split(string([G[i, j] for i in 1:nrows(G) for j in 1:ncols(G)]), '[')[2]
   println(io, "B = matrix(FlintQQ, ", nrows(B), ", ", ncols(B), " ,", Bst, ");")
   println(io, "G = matrix(FlintQQ, ", nrows(G), ", ", ncols(G), " ,", Gst, ");")
-  println(io, target, " = ", "Zlattice(B, gram = G);")
+  println(io, target, " = ", "integer_lattice(B, gram = G);")
 end
 
-function to_magma(io::IO, L::ZLat; target = "L")
+function to_magma(io::IO, L::ZZLat; target = "L")
   B = basis_matrix(L)
   G = gram_matrix(ambient_space(L))
   Bst = "[" * split(string([B[i, j] for i in 1:nrows(B) for j in 1:ncols(B)]), '[')[2]
@@ -260,7 +260,7 @@ function to_sage_string(L::AbstractLat; target = "L")
   return String(take!(b))
 end
 
-function to_sage(io::IO, L::ZLat; target = "L")
+function to_sage(io::IO, L::ZZLat; target = "L")
   B = basis_matrix(L)
   G = gram_matrix(ambient_space(L))
   Bst = "[" * split(string([B[i, j] for i in 1:nrows(B) for j in 1:ncols(B)]), '[')[2]

--- a/src/QuadForm/Lattices.jl
+++ b/src/QuadForm/Lattices.jl
@@ -9,7 +9,7 @@ export *, +, absolute_basis, absolute_basis_matrix, ambient_space,
        is_sublattice, is_sublattice_with_relations, jordan_decomposition, lattice,
        local_basis_matrix, norm, normic_defect, pseudo_matrix, quadratic_lattice,
        rank, rational_span, rescale, restrict_scalars, restrict_scalars_with_map, scale,
-       volume, witt_invariant, Zlattice, trace_lattice_with_isometry,
+       volume, witt_invariant, integer_lattice, trace_lattice_with_isometry,
        trace_lattice_with_isometry_and_transfer_data, hermitian_structure,
        hermitian_structure_with_transfer_data
 
@@ -617,7 +617,7 @@ end
 function _intersect_via_restriction_of_scalars(L::AbstractLat, M::AbstractLat)
   @assert has_ambient_space(L) && has_ambient_space(M)
   @assert ambient_space(L) === ambient_space(M)
-  @assert !(L isa ZLat)
+  @assert !(L isa ZZLat)
   Lres, f = restrict_scalars_with_map(L, FlintQQ)
   Mres = restrict_scalars(M, f)
   Nres = intersect(Lres, Mres)
@@ -969,7 +969,7 @@ is_isotropic(L::AbstractLat, p) = is_isotropic(rational_span(L), p)
 
 @doc raw"""
     restrict_scalars(L::AbstractLat, K::QQField,
-                                     alpha::FieldElem = one(base_field(L))) -> ZLat
+                                     alpha::FieldElem = one(base_field(L))) -> ZZLat
 
 Given a lattice `L` in a space $(V, \Phi)$, return the $\mathcal O_K$-lattice
 obtained by restricting the scalars of $(V, \alpha\Phi)$ to the number field `K`.
@@ -989,13 +989,13 @@ function restrict_scalars(L::AbstractLat, K::QQField,
       Mabs[i, j] = v[j]
     end
   end
-  return ZLat(Vabs, Mabs)
+  return ZZLat(Vabs, Mabs)
 end
 
 @doc raw"""
     restrict_scalars_with_map(L::AbstractLat, K::QQField,
                                               alpha::FieldElem = one(base_field(L)))
-                                                        -> Tuple{ZLat, AbstractSpaceRes}
+                                                        -> Tuple{ZZLat, AbstractSpaceRes}
 
 Given a lattice `L` in a space $(V, \Phi)$, return the $\mathcal O_K$-lattice
 obtained by restricting the scalars of $(V, \alpha\Phi)$ to the number field `K`,
@@ -1016,11 +1016,11 @@ function restrict_scalars_with_map(L::AbstractLat, K::QQField,
       Mabs[i, j] = v[j]
     end
   end
-  return ZLat(Vabs, Mabs), f
+  return ZZLat(Vabs, Mabs), f
 end
 
 @doc raw"""
-    restrict_scalars(L::AbstractLat, f::AbstractSpaceRes) -> ZLat
+    restrict_scalars(L::AbstractLat, f::AbstractSpaceRes) -> ZZLat
 
 Given a lattice `L` in a space $(V, \Phi)$ and a map `f` for restricting the
 scalars of $(V, \alpha\Phi)$ to a number field `K`, where $\alpha$ is in the
@@ -1040,7 +1040,7 @@ function restrict_scalars(L::AbstractLat, f::AbstractSpaceRes)
       Mabs[i, j] = v[j]
     end
   end
-  return ZLat(Vabs, Mabs)
+  return ZZLat(Vabs, Mabs)
 end
 
 ################################################################################
@@ -1054,11 +1054,11 @@ end
     trace_lattice_with_isometry(H::AbstractLat{T}; alpha::FieldElem = one(base_field(H)),
                                                    beta::FieldElem = gen(base_field(H)),
                                                    order::Integer = 2) where T
-                                                                       -> ZLat, QQMatrix
+                                                                       -> ZZLat, QQMatrix
 
 Given a lattice `H` which is either:
 
-   - a $\mathbb Z$-lattice (i.e. of type `ZLat`);
+   - a $\mathbb Z$-lattice (i.e. of type `ZZLat`);
    - a hermitian lattice over a CM-extension $E/K$, where $E/\mathbb{Q}$ is defined
      by an irreducible monic polynomial $p$ with $p(0) = 1$
 
@@ -1066,8 +1066,8 @@ return the pair $(L, f)$ where $L$ is a $\mathbb{Z}$-lattice obtained as the tra
 lattice of $H$ [`restrict_scalars(::AbstractLat)`](@ref)) and $f$ is an isometry
 of $L$ given by:
 
-   - the identity if $H$ is a `ZLat` and `order == 1`;
-   - the opposite of the identity if $H$ is a `ZLat` and `order == 2`;
+   - the identity if $H$ is a `ZZLat` and `order == 1`;
+   - the opposite of the identity if $H$ is a `ZZLat` and `order == 2`;
    - given by the multiplication by an element `beta` of norm 1 in $E$
      otherwise.
 
@@ -1095,7 +1095,7 @@ end
     trace_lattice_with_isometry_and_transfer_data(H::AbstractLat{T}; alpha::FieldElem = one(base_field(H)),
                                                                      beta::FieldElem = gen(base_field(H)),
                                                                      order::Integer = 2) where T
-                                                                        -> ZLat, QQMatrix, AbstractSpaceRes
+                                                                        -> ZZLat, QQMatrix, AbstractSpaceRes
 
 Return the trace lattice of `H` together with the associated isometry corresponding
 to multiplication by `beta` (see [`trace_lattice(::AbstractLat)`](@ref)) and with
@@ -1116,7 +1116,7 @@ function trace_lattice_with_isometry_and_transfer_data(H::AbstractLat{T}; alpha:
 
   # will be useful to shorten code of lattices with isometry on Oscar
   if E == QQ
-    @req order in [1,2] "For ZLat the order must be 1 or 2"
+    @req order in [1,2] "For ZZLat the order must be 1 or 2"
     V = ambient_space(H)
     if order == 1
       f = identity_matrix(E, n)
@@ -1155,7 +1155,7 @@ end
 # TODO: add jldoctest
 @doc raw"""
     trace_lattice_with_isometry(H::HermLat, res::AbstractSpaceRes) where T
-                                                       -> ZLat, QQMatrix, AbstractSpaceRes
+                                                       -> ZZLat, QQMatrix, AbstractSpaceRes
 
 Return the trace lattice of `H` together with the associated isometry (see
 [`trace_lattice(::AbstractLat)`](@ref)) with respect to the given map of change of scalars
@@ -1233,7 +1233,7 @@ end
 
 #TODO: add jldoctest
 @doc raw"""
-    hermitian_structure(L::ZLat, f::QQMatrix; check::Bool = true
+    hermitian_structure(L::ZZLat, f::QQMatrix; check::Bool = true
                                               ambient_representation::Bool = true)
                                                                      -> HermLat
 
@@ -1244,15 +1244,15 @@ Note that `f` must be of infinite order or of order at least 3. In which case, t
 should be divisible by the degree of the minimal polynomial of `f`.
 
 If `L` is not of full rank, then the associated map of change of scalars is defined on the rational
-span of `L` (see [`rational_span(::ZLat)`](@ref)), since only the action on the rational span of the lattice
+span of `L` (see [`rational_span(::ZZLat)`](@ref)), since only the action on the rational span of the lattice
 matters for the trace equivalence. If `L` is of full rank, we use its ambient space as rational span since both
-are isometric (see [`ambient_space(::ZLat)`](@ref))
+are isometric (see [`ambient_space(::ZZLat)`](@ref))
 
 If `ambient_representation` is set to true, then the isometry `f` is seen as an isometry of the ambient space of `L`.
 If `check == true`, then the function checks whether the minimal polynomial of the action of `f` on the rational
 span of `L` is irreducible.
 """
-function hermitian_structure(L::ZLat, f::QQMatrix; check::Bool = true,
+function hermitian_structure(L::ZZLat, f::QQMatrix; check::Bool = true,
                                                    ambient_representation::Bool = true,
                                                    res = nothing,
                                                    E = nothing)
@@ -1265,7 +1265,7 @@ end
 
 # TODO: add jldoctest
 @doc raw"""
-    hermitian_structure_with_transfer_data(L::ZLat, f::QQMatrix; check::Bool = true,
+    hermitian_structure_with_transfer_data(L::ZZLat, f::QQMatrix; check::Bool = true,
                                                                  ambient_representation::Bool = true)
                                                                               -> HermLat, AbstractSpaceRes
 
@@ -1276,15 +1276,15 @@ Note that `f` must be of infinite order or of order at least 3. In which case, t
 should be divisible by the degree of the minimal polynomial of `f`.
 
 If `L` is not of full rank, then the associated map of change of scalars is defined on the rational
-span of `L` (see [`rational_span(::ZLat)`](@ref)), since only the action on the rational span of the lattice
+span of `L` (see [`rational_span(::ZZLat)`](@ref)), since only the action on the rational span of the lattice
 matters for the trace equivalence. If `L` is of full rank, we use its ambient space as rational span since both
-are isometric (see [`ambient_space(::ZLat)`](@ref))
+are isometric (see [`ambient_space(::ZZLat)`](@ref))
 
 If `ambient_representation` is set to true, then the isometry `f` is seen as an isometry of the ambient space of `L`.
 If `check == true`, then the function checks whether the minimal polynomial of the action of `f` on the rational
 span of `L` is irreducible.
 """
-function hermitian_structure_with_transfer_data(_L::ZLat, f::QQMatrix; check::Bool = true,
+function hermitian_structure_with_transfer_data(_L::ZZLat, f::QQMatrix; check::Bool = true,
                                                                        ambient_representation::Bool = true,
                                                                        res = nothing,
                                                                        E = nothing)
@@ -1295,7 +1295,7 @@ function hermitian_structure_with_transfer_data(_L::ZLat, f::QQMatrix; check::Bo
   # "full rank version". Otherwise, we keep it as is and consider f as
   # acting on the ambient space (which is isometric to the rational span of _L)
   if rank(_L) != degree(_L)
-    L = Zlattice(gram = gram_matrix(_L))
+    L = integer_lattice(gram = gram_matrix(_L))
     if ambient_representation
       ok, f = can_solve_with_solution(basis_matrix(_L), basis_matrix(_L)*f, side=:left)
       @req ok "Isometry does not restrict to L"

--- a/src/QuadForm/Morphism.jl
+++ b/src/QuadForm/Morphism.jl
@@ -589,7 +589,7 @@ function _get_vectors_of_length(G::Union{ZZMatrix, FakeFmpqMat}, max::ZZRingElem
   return res
 end
 
-function _get_vectors_of_length(G::ZLat, max::ZZRingElem)
+function _get_vectors_of_length(G::ZZLat, max::ZZRingElem)
   return _get_vectors_of_length(FakeFmpqMat(gram_matrix(G)), max)
 end
 

--- a/src/QuadForm/Quad/Lattices.jl
+++ b/src/QuadForm/Quad/Lattices.jl
@@ -291,7 +291,7 @@ end
 #
 ################################################################################
 
-function jordan_decomposition(L::Union{ZLat, QuadLat}, p)
+function jordan_decomposition(L::Union{ZZLat, QuadLat}, p)
   F = gram_matrix(ambient_space(L))
   even = is_dyadic(p)
   if even

--- a/src/QuadForm/Quad/Types.jl
+++ b/src/QuadForm/Quad/Types.jl
@@ -1,8 +1,8 @@
 export QuadGenus
 export QuadLat
 export QuadLocalGenus
-export ZGenus
-export ZpGenus
+export ZZGenus
+export LocalZZGenus
 
 ###############################################################################
 #
@@ -13,7 +13,7 @@ export ZpGenus
 ### Local
 
 @doc raw"""
-    ZpGenus
+    LocalZZGenus
 
 Local genus symbol over a p-adic ring.
 
@@ -45,11 +45,11 @@ Reference: [CS99](@cite) Chapter 15, Section 7.
 - `symbol`: the list of invariants for Jordan blocks `A_t,...,A_t` given
   as a list of lists of integers
 """
-mutable struct ZpGenus
+mutable struct LocalZZGenus
   _prime::ZZRingElem
   _symbol::Vector{Vector{Int}}
 
-  function ZpGenus(prime, symbol, check=true)
+  function LocalZZGenus(prime, symbol, check=true)
     if check
       if prime == 2
         @assert all(length(g)==5 for g in symbol)
@@ -68,25 +68,25 @@ end
 ### Global
 
 @doc raw"""
-    ZGenus
+    ZZGenus
 
 A collection of local genus symbols (at primes)
 and a signature pair. Together they represent the genus of a
-non-degenerate Zlattice.
+non-degenerate integer_lattice.
 """
-@attributes mutable struct ZGenus
+@attributes mutable struct ZZGenus
   _signature_pair::Tuple{Int, Int}
-  _symbols::Vector{ZpGenus} # assumed to be sorted by their primes
-  _representative::ZLat
+  _symbols::Vector{LocalZZGenus} # assumed to be sorted by their primes
+  _representative::ZZLat
 
-  function ZGenus(signature_pair, symbols)
+  function ZZGenus(signature_pair, symbols)
     G = new()
     G._signature_pair = signature_pair
     G._symbols = sort!(symbols, by = x->prime(x))
     return G
   end
 
-  function ZGenus(signature_pair, symbols, representative::ZLat)
+  function ZZGenus(signature_pair, symbols, representative::ZZLat)
     G = new()
     G._signature_pair = signature_pair
     G._symbols = sort!(symbols, by = x->prime(x))

--- a/src/QuadForm/Quad/ZGenus.jl
+++ b/src/QuadForm/Quad/ZGenus.jl
@@ -1,5 +1,5 @@
 export genus, rank, det, dim, prime, symbol, representative, signature,
-       oddity, excess, level, Zgenera, scale, norm, mass,
+       oddity, excess, level, integer_genera, scale, norm, mass,
        quadratic_space, hasse_invariant, local_symbol, local_symbols,
        representatives, is_elementary, is_primary, is_unimodular,
        is_primary_with_prime, is_elementary_with_prime, automorphous_numbers,
@@ -294,26 +294,26 @@ end
 ###############################################################################
 
 @doc raw"""
-    genus(A::MatElem) -> ZGenus
+    genus(A::MatElem) -> ZZGenus
 
 Return the genus of a $\mathbb Z$-lattice with gram matrix `A`.
 """
 function genus(A::MatElem)
   @req ncols(A) == nrows(A) "Input must be a square matrix"
   @req rank(A) == ncols(A) "Input must have full rank"
-  return genus(Zlattice(gram=A))
+  return genus(integer_lattice(gram=A))
 end
 
 @doc raw"""
-    genus(L::ZLat) -> ZGenus
+    genus(L::ZZLat) -> ZZGenus
 
 Return the genus of the lattice `L`.
 """
-function genus(L::ZLat)
+function genus(L::ZZLat)
   A = gram_matrix(L)
   denom = denominator(A)
   A = change_base_ring(ZZ, denom^2 * A)
-  symbols = ZpGenus[]
+  symbols = LocalZZGenus[]
   if ncols(A)>0
     el = lcm(diagonal(hnf(A)))
     primes = prime_divisors(el)
@@ -335,15 +335,15 @@ function genus(L::ZLat)
   neg = Int(count(x<0 for x in DA))
   pos = Int(count(x>0 for x in DA))
   @req neg+pos == ncols(A) "Underlying quadratic form is degenerate"
-  return ZGenus((pos, neg), symbols, L)
+  return ZZGenus((pos, neg), symbols, L)
 end
 
 @doc raw"""
-    genus(L::ZLat, p) -> ZpGenus
+    genus(L::ZZLat, p) -> LocalZZGenus
 
 Return the local genus symbol of `L` at the prime `p`.
 """
-function genus(L::ZLat, p)
+function genus(L::ZZLat, p)
   return genus(gram_matrix(L), p)
 end
 
@@ -354,11 +354,11 @@ function genus(A::ZZMatrix, p, val; offset=0)
   for i in 1:size(symbol)[1]
     symbol[i][1] = symbol[i][1] - offset
   end
-  return ZpGenus(p, symbol)
+  return LocalZZGenus(p, symbol)
 end
 
 @doc raw"""
-    genus(A::MatElem, p) -> ZpGenus
+    genus(A::MatElem, p) -> LocalZZGenus
 
 Return the local genus symbol of a Z-lattice with gram matrix `A` at the prime `p`.
 """
@@ -382,14 +382,14 @@ function genus(A::MatElem, p)
 end
 
 @doc raw"""
-    direct_sum(S1::ZpGenus, S2::ZpGenus) -> ZpGenus
+    direct_sum(S1::LocalZZGenus, S2::LocalZZGenus) -> LocalZZGenus
 
 Return the local genus of the direct sum of two representatives.
 """
-function direct_sum(S1::ZpGenus, S2::ZpGenus)
+function direct_sum(S1::LocalZZGenus, S2::LocalZZGenus)
   @req prime(S1) == prime(S2) "The local genus symbols must be over the same prime"
   if rank(S1) == rank(S2) == 0
-    return ZpGenus(prime(S1), Hecke.symbol(S1))
+    return LocalZZGenus(prime(S1), Hecke.symbol(S1))
   end
   _sym1 = Hecke.symbol(S1)
   _sym2 = Hecke.symbol(S2)
@@ -422,17 +422,17 @@ function direct_sum(S1::ZpGenus, S2::ZpGenus)
       push!(symbol, b)
     end
   end
-  return ZpGenus(prime(S1), symbol)
+  return LocalZZGenus(prime(S1), symbol)
 end
 
 @doc raw"""
-    direct_sum(G1::ZGenus, G2::ZGenus) -> ZGenus
+    direct_sum(G1::ZZGenus, G2::ZZGenus) -> ZZGenus
 
 Return the genus of the direct sum of `G1` and `G2`.
 
 The direct sum is defined via representatives.
 """
-function direct_sum(G1::ZGenus, G2::ZGenus)
+function direct_sum(G1::ZZGenus, G2::ZZGenus)
   p1, n1 = signature_pair(G1)
   p2, n2 = signature_pair(G2)
   sign_pair = (p1 + p2, n1 + n2)
@@ -444,7 +444,7 @@ function direct_sum(G1::ZGenus, G2::ZGenus)
     sym_p = direct_sum(local_symbol(G1, p), local_symbol(G2, p))
     push!(local_symbols, sym_p)
   end
-  return ZGenus(sign_pair, local_symbols)
+  return ZZGenus(sign_pair, local_symbols)
 end
 
 ###############################################################################
@@ -454,10 +454,10 @@ end
 ###############################################################################
 
 @doc raw"""
-    Zgenera(sig_pair::Vector{Int}, determinant::RationalUnion;
+    integer_genera(sig_pair::Vector{Int}, determinant::RationalUnion;
            min_scale::RationalUnion = min(one(QQ), QQ(abs(determinant))),
            max_scale::RationalUnion = max(one(QQ), QQ(abs(determinant))),
-           even=false)                                         -> Vector{ZGenus}
+           even=false)                                         -> Vector{ZZGenus}
 
 Return a list of all genera with the given conditions. Genera of non-integral
 $\mathbb Z$-lattices are also supported.
@@ -471,20 +471,20 @@ $\mathbb Z$-lattices are also supported.
   integer multiple of the scale (default: `max(one(QQ), QQ(abs(determinant)))`)
 - `even`: boolean; if set to true, return only the even genera (default: `false`)
 """
-function Zgenera(sig_pair::Tuple{Int,Int}, determinant::RationalUnion;
+function integer_genera(sig_pair::Tuple{Int,Int}, determinant::RationalUnion;
                 min_scale::RationalUnion = min(one(QQ), QQ(abs(determinant))),
                 max_scale::RationalUnion = max(one(QQ), QQ(abs(determinant))),
                 even=false)
   @req all(s >= 0 for s in sig_pair) "The signature vector must be a pair of non negative integers."
   determinant = QQ(determinant)
-  denominator(determinant) != 1 && even && return ZGenus[]
+  denominator(determinant) != 1 && even && return ZZGenus[]
   @req min_scale > 0 "Minimal scale must be a positive integer"
   min_scale = QQ(min_scale)
   @req max_scale > 0 "Maximal scale must be a positive integer"
   max_scale = QQ(max_scale)
   rank = sig_pair[1] + sig_pair[2]
-  out = ZGenus[]
-  local_symbols = Vector{ZpGenus}[]
+  out = ZZGenus[]
+  local_symbols = Vector{LocalZZGenus}[]
   pd = prime_divisors(numerator(determinant)*denominator(determinant))
   append!(pd, prime_divisors(numerator(min_scale)*denominator(min_scale)))
   append!(pd, prime_divisors(numerator(max_scale)*denominator(max_scale)))
@@ -510,7 +510,7 @@ function Zgenera(sig_pair::Tuple{Int,Int}, determinant::RationalUnion;
   # clever way to directly match the symbols for different primes.
   for g in cartesian_product_iterator(local_symbols,inplace=false)
     # create a Genus from a list of local symbols
-    G = ZGenus(sig_pair, g)
+    G = ZZGenus(sig_pair, g)
     abs(det(G)) != abs(determinant) && continue
     even && !iseven(G) && continue
     # discard the empty genera
@@ -524,7 +524,7 @@ function Zgenera(sig_pair::Tuple{Int,Int}, determinant::RationalUnion;
 end
 
 @doc raw"""
-    _local_genera(p, rank, det_val, min_scale, max_scale, even) -> Vector{ZpGenus}
+    _local_genera(p, rank, det_val, min_scale, max_scale, even) -> Vector{LocalZZGenus}
 
 Return all `p`-adic genera with the given conditions.
 
@@ -561,7 +561,7 @@ function _local_genera(p::ZZRingElem, rank::Int, det_val::Int, min_scale::Int,
     end
   end
   # add possible determinant square classes
-  symbols = Vector{ZpGenus}()
+  symbols = Vector{LocalZZGenus}()
   if p != 2
     for g in scales_rks
       n = length(g)
@@ -570,7 +570,7 @@ function _local_genera(p::ZZRingElem, rank::Int, det_val::Int, min_scale::Int,
         for k in 1:n
           g1[k][3] = v[k]
         end
-        g1 = ZpGenus(p, g1)
+        g1 = LocalZZGenus(p, g1)
         push!(symbols, g1)
       end
     end
@@ -590,7 +590,7 @@ function _local_genera(p::ZZRingElem, rank::Int, det_val::Int, min_scale::Int,
       end
       for g1 in cartesian_product_iterator(poss_blocks,inplace=false)
         if _is2adic_genus(g1)
-          g1 = ZpGenus(p, g1)
+          g1 = LocalZZGenus(p, g1)
           # some of our symbols have the same canonical symbol
           # thus they are equivalent - we want only one in
           # each equivalence class
@@ -715,11 +715,11 @@ end
 ###############################################################################
 
 @doc raw"""
-    _isglobal_genus(G::ZGenus) -> Bool
+    _isglobal_genus(G::ZZGenus) -> Bool
 
 Return if `S` is the symbol of of a global quadratic form || lattice.
 """
-function _isglobal_genus(G::ZGenus)
+function _isglobal_genus(G::ZZGenus)
   if denominator(scale(G)) != 1
     return _isglobal_genus(rescale(G, denominator(scale(G))))
   end
@@ -761,7 +761,7 @@ end
 
 Given a `2`-adic local symbol check whether it is symbol of a `2`-adic form.
 """
-function _is2adic_genus(S::ZpGenus)
+function _is2adic_genus(S::LocalZZGenus)
   @req prime(S)==2 "the symbol must be 2-adic"
   return _is2adic_genus(symbol(S))
 end
@@ -817,12 +817,12 @@ end
 ###############################################################################
 
 @doc raw"""
-   (==)(G1::ZpGenus, G2::ZpGenus) -> Bool
+   (==)(G1::LocalZZGenus, G2::LocalZZGenus) -> Bool
 
 Return whether the local genus symbols `G1` and `G2` define the same local
 genus.
 """
-function Base.:(==)(G1::ZpGenus, G2::ZpGenus)
+function Base.:(==)(G1::LocalZZGenus, G2::LocalZZGenus)
   # This follows p.381 Chapter 15.7 Theorem 10 in Conway Sloane's book
   @req prime(G1) == prime(G2) ("Symbols must be over the same prime "
                                 *"to be comparable")
@@ -876,11 +876,11 @@ function Base.:(==)(G1::ZpGenus, G2::ZpGenus)
 end
 
 @doc raw"""
-    (==)(G1::ZGenus, G2::ZGenus) -> Bool
+    (==)(G1::ZZGenus, G2::ZZGenus) -> Bool
 
 Return if the genus symbols `G1` and `G2` define the same genus.
 """
-function Base.:(==)(G1::ZGenus, G2::ZGenus)
+function Base.:(==)(G1::ZZGenus, G2::ZZGenus)
   if signature_tuple(G1) != signature_tuple(G2)
     return false
   end
@@ -902,15 +902,15 @@ end
 #
 ###############################################################################
 
-function Base.show(io::IO, G::ZGenus)
-  rep = "ZGenus\nSignature: $(signature_pair(G))"
+function Base.show(io::IO, G::ZZGenus)
+  rep = "ZZGenus\nSignature: $(signature_pair(G))"
   for s in local_symbols(G)
     rep *= "\n$s"
   end
   print(io, rep)
 end
 
-function Base.show(io::IO, G::ZpGenus)
+function Base.show(io::IO, G::LocalZZGenus)
   p = prime(G)
   CS_string = ""
   if p == 2
@@ -947,31 +947,31 @@ end
 ###############################################################################
 
 @doc raw"""
-    prime(S::ZpGenus) -> ZZRingElem
+    prime(S::LocalZZGenus) -> ZZRingElem
 
 Return the prime `p` of this `p`-adic genus.
 """
-function prime(S::ZpGenus)
+function prime(S::LocalZZGenus)
   return S._prime
 end
 
 @doc raw"""
-    symbol(S::ZpGenus) -> Vector{Vector{Int}}
+    symbol(S::LocalZZGenus) -> Vector{Vector{Int}}
 
 Return a copy of the underlying lists of integers for the Jordan blocks of `S`.
 """
-function symbol(S::ZpGenus)
+function symbol(S::LocalZZGenus)
   return copy(S._symbol)
 end
 
 @doc raw"""
-    iseven(S::ZpGenus) -> Bool
+    iseven(S::LocalZZGenus) -> Bool
 
 Return if the underlying `p`-adic lattice is even.
 
 If `p` is odd, every lattice is even.
 """
-function iseven(S::ZpGenus)
+function iseven(S::LocalZZGenus)
   if prime(S) != 2 || rank(S) == 0
     return true
   end
@@ -981,12 +981,12 @@ function iseven(S::ZpGenus)
 end
 
 @doc raw"""
-    symbol(S::ZpGenus, scale::Int) -> Vector{Int}
+    symbol(S::LocalZZGenus, scale::Int) -> Vector{Int}
 
 Return a copy of the underlying lists of integers
 for the Jordan block of the given scale
 """
-function symbol(S::ZpGenus, scale::Int)
+function symbol(S::LocalZZGenus, scale::Int)
   sym = symbol(S)
   for s in sym
     if s[1] == scale
@@ -1001,7 +1001,7 @@ function symbol(S::ZpGenus, scale::Int)
 end
 
 @doc raw"""
-    hasse_invariant(S::ZpGenus) -> Int
+    hasse_invariant(S::LocalZZGenus) -> Int
 
 Return the Hasse invariant of a representative.
 If the representative is diagonal (a_1, ... , a_n)
@@ -1009,7 +1009,7 @@ Then the Hasse invariant is
 
 $\prod_{i < j}(a_i, a_j)_p$.
 """
-function hasse_invariant(S::ZpGenus)
+function hasse_invariant(S::LocalZZGenus)
   # Conway Sloane Chapter 15 5.3
   n = dim(S)
   d = det(S)
@@ -1025,11 +1025,11 @@ function hasse_invariant(S::ZpGenus)
 end
 
 @doc raw"""
-    det(S::ZpGenus) -> QQFieldElem
+    det(S::LocalZZGenus) -> QQFieldElem
 
 Return an rational representing the determinant of this genus.
 """
-function det(S::ZpGenus)
+function det(S::LocalZZGenus)
   p = prime(S)
   e = prod(Int[s[3] for s in symbol(S)])
   if p == 2
@@ -1042,25 +1042,25 @@ end
 
 
 @doc raw"""
-    dim(S::ZpGenus) -> Int
+    dim(S::LocalZZGenus) -> Int
 
 Return the dimension of this genus.
 """
-function dim(S::ZpGenus)
+function dim(S::LocalZZGenus)
   return sum(Int[s[2] for s in symbol(S)])
 end
 
 @doc raw"""
-    rank(S::ZpGenus) -> Int
+    rank(S::LocalZZGenus) -> Int
 
 Return the rank of (a representative of) `S`.
 """
-function rank(S::ZpGenus)
+function rank(S::LocalZZGenus)
   return dim(S)
 end
 
 @doc raw"""
-    excess(S::ZpGenus) -> zzModRingElem
+    excess(S::LocalZZGenus) -> zzModRingElem
 
 Return the p-excess of the quadratic form whose Hessian
 matrix is the symmetric matrix A.
@@ -1073,7 +1073,7 @@ p is congruent 1 mod 4.
 # Reference
 [CS99](@cite) pp 370-371.
 """
-function excess(S::ZpGenus)
+function excess(S::LocalZZGenus)
   R = residue_ring(ZZ, 8)
   p = prime(S)
   if p == 2
@@ -1097,11 +1097,11 @@ function excess(S::ZpGenus)
 end
 
 @doc raw"""
-    signature(S::ZpGenus) -> zzModRingElem
+    signature(S::LocalZZGenus) -> zzModRingElem
 
 Return the $p$-signature of this $p$-adic form.
 """
-function signature(S::ZpGenus)
+function signature(S::LocalZZGenus)
   R = residue_ring(ZZ, 8)
   if prime(S) == 2
     return oddity(S)
@@ -1111,12 +1111,12 @@ function signature(S::ZpGenus)
 end
 
 @doc raw"""
-    oddity(S::ZpGenus) -> zzModRingElem
+    oddity(S::LocalZZGenus) -> zzModRingElem
 
 Return the oddity of this even form.
 The oddity is also called the $2$-signature
 """
-function oddity(S::ZpGenus)
+function oddity(S::LocalZZGenus)
   R = residue_ring(FlintZZ, 8)
   p = prime(S)
   @req p == 2 "The oddity is only defined for p=2"
@@ -1130,7 +1130,7 @@ function oddity(S::ZpGenus)
 end
 
 @doc raw"""
-    scale(S::ZpGenus) -> QQFieldElem
+    scale(S::LocalZZGenus) -> QQFieldElem
 
 Return the scale of this local genus.
 
@@ -1138,7 +1138,7 @@ Let `L` be a lattice with bilinear form `b`.
 The scale of `(L,b)` is defined as the ideal
 `b(L,L)`.
 """
-function scale(S::ZpGenus)
+function scale(S::LocalZZGenus)
   if rank(S) == 0
     return ZZ(0)
   end
@@ -1147,7 +1147,7 @@ function scale(S::ZpGenus)
 end
 
 @doc raw"""
-    norm(S::ZpGenus) -> QQFieldElem
+    norm(S::LocalZZGenus) -> QQFieldElem
 
 Return the norm of this local genus.
 
@@ -1155,7 +1155,7 @@ Let `L` be a lattice with bilinear form `b`.
 The norm of `(L,b)` is defined as the ideal
 generated by $\{b(x,x) | x \in L\}$.
 """
-function norm(S::ZpGenus)
+function norm(S::LocalZZGenus)
   if rank(S) == 0
     return ZZ(0)
   end
@@ -1168,11 +1168,11 @@ function norm(S::ZpGenus)
   end
 end
 @doc raw"""
-    level(S::ZpGenus) -> QQFieldElem
+    level(S::LocalZZGenus) -> QQFieldElem
 
 Return the maximal scale of a jordan component.
 """
-function level(S::ZpGenus)
+function level(S::LocalZZGenus)
   if rank(S) == 0
     return ZZ(1)
   end
@@ -1181,11 +1181,11 @@ function level(S::ZpGenus)
 end
 
 @doc raw"""
-    iseven(G::ZGenus) -> Bool
+    iseven(G::ZZGenus) -> Bool
 
 Return if this genus is even.
 """
-function iseven(G::ZGenus)
+function iseven(G::ZZGenus)
   if rank(G) == 0
     return true
   end
@@ -1197,49 +1197,49 @@ end
 
 
 @doc raw"""
-    signature(G::ZGenus) -> Int
+    signature(G::ZZGenus) -> Int
 
 Return the signature of this genus.
 
 The signature is `p - n` where `p` is the number of positive eigenvalues
 and `n` the number of negative eigenvalues.
 """
-function signature(G::ZGenus)
+function signature(G::ZZGenus)
   p, n = signature_pair(G)
   return p - n
 end
 
 @doc raw"""
-    signature_pair(G::ZGenus) -> Tuple{Int,Int}
+    signature_pair(G::ZZGenus) -> Tuple{Int,Int}
 
 Return the signature pair of this genus.
 
 The signature is `[p, n]` where `p` is the number of positive eigenvalues
 and `n` the number of negative eigenvalues.
 """
-function signature_pair(G::ZGenus)
+function signature_pair(G::ZZGenus)
   return G._signature_pair
 end
 
 @doc raw"""
-    signature_tuple(G::ZGenus) -> Tuple{Int, Int, Int}
+    signature_tuple(G::ZZGenus) -> Tuple{Int, Int, Int}
 
 Return the signature tuple of this genus.
 
 The signature is `[p, d, n]` where `p` is the number of positive eigenvalues,
 `d` is the number of zero eigenvalues and `n` is the number of negative eigenvalues.
 """
-function signature_tuple(G::ZGenus)
+function signature_tuple(G::ZZGenus)
   s = signature_pair(G)
   return (s[1],0,s[2])
 end
 
 @doc raw"""
-    det(G::ZGenus) -> QQFieldElem
+    det(G::ZZGenus) -> QQFieldElem
 
 Return the determinant of this genus.
 """
-function det(G::ZGenus)
+function det(G::ZZGenus)
   p, n = signature_pair(G)
   d = QQ(-1)^n
   return QQ(-1)^n*prod(QQ(prime(g))^sum(Int[s[1]*s[2] for s in g._symbol])
@@ -1247,36 +1247,36 @@ function det(G::ZGenus)
 end
 
 @doc raw"""
-    dim(G::ZGenus) -> Int
+    dim(G::ZZGenus) -> Int
 
 Return the dimension of this genus.
 """
-function dim(G::ZGenus)
+function dim(G::ZZGenus)
   return sum(signature_pair(G))
 end
 
 @doc raw"""
-    rank(G::ZGenus) -> Int
+    rank(G::ZZGenus) -> Int
 
 Return the rank of a (representative of) the genus `G`.
 """
-rank(G::ZGenus) = dim(G)
+rank(G::ZZGenus) = dim(G)
 
 @doc raw"""
-    local_symbols(G::ZGenus) -> Vector{ZpGenus}
+    local_symbols(G::ZZGenus) -> Vector{LocalZZGenus}
 
 Return a copy of the local symbols.
 """
-function local_symbols(G::ZGenus)
+function local_symbols(G::ZZGenus)
   return deepcopy(G._symbols)
 end
 
 @doc raw"""
-    local_symbol(G::ZGenus, p) -> ZpGenus
+    local_symbol(G::ZZGenus, p) -> LocalZZGenus
 
 Return the local symbol at `p`.
 """
-function local_symbol(G::ZGenus, p)
+function local_symbol(G::ZZGenus, p)
   p = ZZ(p)
   for sym in local_symbols(G)
     if p == prime(sym)
@@ -1285,23 +1285,23 @@ function local_symbol(G::ZGenus, p)
   end
   @assert p != 2
   sym_p = [[0, rank(G), _kronecker_symbol(numerator(det(G)),p)*_kronecker_symbol(denominator(det(G)), p)]]
-  return ZpGenus(p, sym_p)
+  return LocalZZGenus(p, sym_p)
 end
 
 @doc raw"""
-    level(G::ZGenus) -> QQFieldElem
+    level(G::ZZGenus) -> QQFieldElem
 
 Return the level of this genus.
 
 This is the denominator of the inverse gram matrix
 of a representative.
 """
-function level(G::ZGenus)
+function level(G::ZZGenus)
   return prod(level(sym) for sym in local_symbols(G))
 end
 
 @doc raw"""
-    scale(G::ZGenus) -> QQFieldElem
+    scale(G::ZZGenus) -> QQFieldElem
 
 Return the scale of this genus.
 
@@ -1309,12 +1309,12 @@ Let `L` be a lattice with bilinear form `b`.
 The scale of `(L,b)` is defined as the ideal
 `b(L,L)`.
 """
-function scale(G::ZGenus)
+function scale(G::ZZGenus)
   return prod([scale(s) for s in local_symbols(G)])
 end
 
 @doc raw"""
-    norm(G::ZGenus) -> QQFieldElem
+    norm(G::ZZGenus) -> QQFieldElem
 
 Return the norm of this genus.
 
@@ -1322,26 +1322,26 @@ Let `L` be a lattice with bilinear form `b`.
 The norm of `(L,b)` is defined as the ideal
 generated by $\{b(x,x) | x \in L\}$.
 """
-function norm(G::ZGenus)
+function norm(G::ZZGenus)
   return prod([norm(s) for s in local_symbols(G)])
 end
 
 @doc raw"""
-    primes(G::ZGenus) -> Vector{ZZRingElem}
+    primes(G::ZZGenus) -> Vector{ZZRingElem}
 
 Return the list of primes of the local symbols of `G`.
 
 Note that 2 is always in the output since the 2-adic symbol
-of a `ZGenus` is, by convention, always defined.
+of a `ZZGenus` is, by convention, always defined.
 """
-primes(G::ZGenus) = prime.(local_symbols(G))
+primes(G::ZZGenus) = prime.(local_symbols(G))
 
 @doc raw"""
-    is_integral(G::ZGenus) -> Bool
+    is_integral(G::ZZGenus) -> Bool
 
 Return whether `G` is a genus of integral $\mathbb Z$-lattices.
 """
-is_integral(G::ZGenus) = is_integral(scale(G))
+is_integral(G::ZZGenus) = is_integral(scale(G))
 
 ###############################################################################
 #
@@ -1350,11 +1350,11 @@ is_integral(G::ZGenus) = is_integral(scale(G))
 ###############################################################################
 
 @doc raw"""
-    quadratic_space(G::ZGenus) -> QuadSpace{QQField, QQMatrix}
+    quadratic_space(G::ZZGenus) -> QuadSpace{QQField, QQMatrix}
 
 Return the quadratic space defined by this genus.
 """
-function quadratic_space(G::ZGenus)
+function quadratic_space(G::ZZGenus)
   dimension = dim(G)
   if dimension == 0
     qf = zero_matrix(QQ, 0, 0)
@@ -1369,18 +1369,18 @@ function quadratic_space(G::ZGenus)
 end
 
 @doc raw"""
-    rational_representative(G::ZGenus) -> QuadSpace{QQField, QQMatrix}
+    rational_representative(G::ZZGenus) -> QuadSpace{QQField, QQMatrix}
 
 Return the quadratic space defined by this genus.
 """
-rational_representative(G::ZGenus) = quadratic_space(G)
+rational_representative(G::ZZGenus) = quadratic_space(G)
 
 @doc raw"""
-    discriminant_group(G::ZGenus) -> TorQuadModule
+    discriminant_group(G::ZZGenus) -> TorQuadModule
 
 Return the discriminant form associated to this genus.
 """
-function discriminant_group(G::ZGenus)
+function discriminant_group(G::ZZGenus)
   @req is_integral(G) "G must be a genus of integral lattices"
   qL = QQMatrix[]
   for gs in G._symbols
@@ -1395,11 +1395,11 @@ function discriminant_group(G::ZGenus)
 end
 
 @doc raw"""
-    representative(G::ZGenus) -> ZLat
+    representative(G::ZZGenus) -> ZZLat
 
 Compute a representative of this genus && cache it.
 """
-function representative(G::ZGenus)
+function representative(G::ZZGenus)
   if isdefined(G, :_representative)
     return G._representative
   end
@@ -1426,18 +1426,18 @@ function representative(G::ZGenus)
 end
 
 @doc raw"""
-    is_definite(G::ZGenus) -> Bool
+    is_definite(G::ZZGenus) -> Bool
 
 Return if this genus is definite.
 """
-is_definite(G::ZGenus) = any(x == 0 for x in signature_pair(G))
+is_definite(G::ZZGenus) = any(x == 0 for x in signature_pair(G))
 
 @doc raw"""
-    representatives(G::ZGenus) -> Vector{ZLat}
+    representatives(G::ZZGenus) -> Vector{ZZLat}
 
 Return a list of representatives of the isometry classes in this genus.
 """
-function representatives(G::ZGenus)
+function representatives(G::ZZGenus)
   L = representative(G)
   rep = genus_representatives(L)
   @hassert :Lattice 2 !is_definite(G) || mass(G) == sum(QQFieldElem[1//automorphism_group_order(S) for S in rep])
@@ -1445,11 +1445,11 @@ function representatives(G::ZGenus)
 end
 
 @doc raw"""
-    gram_matrix(S::ZpGenus) -> MatElem
+    gram_matrix(S::LocalZZGenus) -> MatElem
 
 Return a gram matrix of some representative of this local genus.
 """
-function gram_matrix(S::ZpGenus)
+function gram_matrix(S::LocalZZGenus)
   G = QQMatrix[]
   p = prime(S)
   for block in S._symbol
@@ -1461,12 +1461,12 @@ function gram_matrix(S::ZpGenus)
 end
 
 @doc raw"""
-    representative(S::ZpGenus) -> ZLat
+    representative(S::LocalZZGenus) -> ZZLat
 
 Return an integer lattice which represents this local genus.
 """
-function representative(S::ZpGenus)
-  return Zlattice(gram = gram_matrix(S))
+function representative(S::LocalZZGenus)
+  return integer_lattice(gram = gram_matrix(S))
 end
 
 
@@ -1582,7 +1582,7 @@ end
 ###############################################################################
 
 @doc raw"""
-    automorphous_numbers(g::ZpGenus) -> Vector{ZZRingElem}
+    automorphous_numbers(g::LocalZZGenus) -> Vector{ZZRingElem}
 
 Return generators of the group of automorphous square classes at this prime.
 
@@ -1590,7 +1590,7 @@ A `p`-adic square class `r` is called automorphous if it is
 the spinor norm of a proper `p`-adic integral automorphism of this form.
 See [CS99](@cite) Chapter 15, 9.6 for details.
 """
-function automorphous_numbers(g::ZpGenus)
+function automorphous_numbers(g::LocalZZGenus)
   @req is_integral(scale(g)) "g must have integral scale"
   automorphs = ZZRingElem[]
   sym = symbol(g)
@@ -1765,14 +1765,14 @@ function local_multiplicative_group_modulo_squares(primes::Vector{ZZRingElem})
 end
 
 @doc raw"""
-    _automorphous_numbers(G::ZGenus)
+    _automorphous_numbers(G::ZZGenus)
 
 Return `(Delta, f)` where f: QQ^x -> Delta`
 
 has the property that q is automorphous if and only if $f(q)=0$.
 Further Delta is in bijection with the proper spinor genera of `G`.
 """
-@attr function _automorphous_numbers(G::ZGenus)
+@attr function _automorphous_numbers(G::ZZGenus)
   @assert is_integral(G)
   P = [prime(g) for g in local_symbols(G)]
   A, proj, inj, diagonal_map = local_multiplicative_group_modulo_squares(P)
@@ -1826,28 +1826,28 @@ Further Delta is in bijection with the proper spinor genera of `G`.
   return Delta, f2, delta
 end
 
-function is_unimodular(g::ZpGenus)
+function is_unimodular(g::LocalZZGenus)
   return scale(g) == level(g) == 1
 end
 
 @doc raw"""
-    bad_primes(g::ZGenus) -> Vector{ZZRingElem}
+    bad_primes(g::ZZGenus) -> Vector{ZZRingElem}
 
 Return `2` and the primes at which `g` is not unimodular.
 """
-function bad_primes(g::ZGenus)
+function bad_primes(g::ZZGenus)
   return [prime(g) for g in local_symbols(g) if !is_unimodular(g) || prime(g)==2]
 end
 
 @doc raw"""
-    is_automorphous(G::ZGenus, q::RationalUnion) -> Bool
+    is_automorphous(G::ZZGenus, q::RationalUnion) -> Bool
 
 Return if `q` is the spinor norm of an element of `SO(V)` where `V` is the
 rational quadratic space of `G`.
 
 See [CS99](@cite) Chapter 15, Theorem 18.
 """
-function is_automorphous(G::ZGenus, q::RationalUnion)
+function is_automorphous(G::ZZGenus, q::RationalUnion)
   @req is_integral(G) "G must be a genus of integral lattices"
   q = QQ(q)
   P = bad_primes(G)
@@ -1859,7 +1859,7 @@ function is_automorphous(G::ZGenus, q::RationalUnion)
 end
 
 @doc raw"""
-    improper_spinor_generators(G::ZGenus) -> Vector{ZZRingElem}
+    improper_spinor_generators(G::ZZGenus) -> Vector{ZZRingElem}
 
 Return a list of primes describing the improper spinor genera of `G`.
 
@@ -1874,7 +1874,7 @@ The following genus consists of two proper spinor genera but only
 one improper spinor genus.
 
 ```jldoctest
-julia> L1 = Zlattice(gram=ZZ[3 0 -1 1; 0 3 -1 -1; -1 -1 6 0; 1 -1 0 6]);
+julia> L1 = integer_lattice(gram=ZZ[3 0 -1 1; 0 3 -1 -1; -1 -1 6 0; 1 -1 0 6]);
 
 julia> length(Hecke.proper_spinor_generators(genus(L1)))
 1
@@ -1883,7 +1883,7 @@ julia> length(Hecke.improper_spinor_generators(genus(L1)))
 0
 ```
 """
-function improper_spinor_generators(G::ZGenus)
+function improper_spinor_generators(G::ZZGenus)
   if denominator(scale(G)) != 1
     return improper_spinor_generators(rescale(G, denominator(scale(G))))
   end
@@ -1891,14 +1891,14 @@ function improper_spinor_generators(G::ZGenus)
 end
 
 """
-    _improper_spinor_generators(G::ZGenus) -> Vector{ZZRingElem}, map
+    _improper_spinor_generators(G::ZZGenus) -> Vector{ZZRingElem}, map
 
 The first return value are the improper spinor generators.
 The second return value is a map f:QQ -> AbelianGroup
 (not defined over the bad primes)
 which satisfies f(r) == 0 if and only if r is improperly automorphous.
 """
-function _improper_spinor_generators(G::ZGenus)
+function _improper_spinor_generators(G::ZZGenus)
   @assert is_integral(G)
   P = bad_primes(G)
   Delta, i_prop,Deltap = _automorphous_numbers(G)
@@ -1931,9 +1931,9 @@ function _improper_spinor_generators(G::ZGenus)
   return S,i_improp
 end
 
-function _norm_generator(G::ZpGenus)
+function _norm_generator(G::LocalZZGenus)
   @assert is_integral(scale(G))
-  h1 = ZpGenus(prime(G), symbol(G)[1:1])
+  h1 = LocalZZGenus(prime(G), symbol(G)[1:1])
   g = gram_matrix(h1)
   if g[end, end] == 0
     # hyperbolic plane
@@ -1943,7 +1943,7 @@ function _norm_generator(G::ZpGenus)
 end
 
 @doc raw"""
-    proper_spinor_generators(G::ZGenus) -> Vector{ZZRingElem}
+    proper_spinor_generators(G::ZZGenus) -> Vector{ZZRingElem}
 
 Return a list of primes describing the proper spinor genera of `G`.
 
@@ -1956,13 +1956,13 @@ See [CS99](@cite) Chapter 15, Theorem 15.
 # Example
 The following genus consists of two proper spinor genera.
 ```jldoctest
-julia> L1 = Zlattice(gram=ZZ[6 3 0; 3 6 0; 0 0 2]);
+julia> L1 = integer_lattice(gram=ZZ[6 3 0; 3 6 0; 0 0 2]);
 
 julia> length(Hecke.proper_spinor_generators(genus(L1)))
 1
 ```
 """
-function proper_spinor_generators(G::ZGenus)
+function proper_spinor_generators(G::ZZGenus)
   if denominator(scale(G)) != 1
     return proper_spinor_generators(rescale(G, denominator(scale(G))))
   end
@@ -2014,12 +2014,12 @@ function _M_p(species, p)
 end
 
 @doc raw"""
-    _standard_mass_squared(G::ZGenus) -> QQFieldElem
+    _standard_mass_squared(G::ZZGenus) -> QQFieldElem
 
 Return the standard mass of this genus.
 It depends only on the dimension and determinant.
 """
-function _standard_mass_squared(G::ZGenus)
+function _standard_mass_squared(G::ZZGenus)
   n = dim(G)
   if n % 2 == 0
     s = div(n, 2)
@@ -2048,7 +2048,7 @@ function _standard_mass_squared(G::ZGenus)
 end
 
 @doc raw"""
-    mass(G::ZGenus) -> QQFieldElem
+    mass(G::ZZGenus) -> QQFieldElem
 
 Return the mass of this genus.
 
@@ -2057,7 +2057,7 @@ Let `L_1, ... L_n` be a complete list of representatives
 of the isometry classes in this genus.
 Its mass is defined as $\sum_{i=1}^n \frac{1}{|O(L_i)|}$.
 """
-function mass(G::ZGenus)
+function mass(G::ZZGenus)
   if denominator(scale(G)) != 1
     return mass(rescale(G, denominator(scale(G))))
   end
@@ -2074,13 +2074,13 @@ end
 
 
 @doc raw"""
-    _mass_squared(G::ZpGenus) -> QQFieldElem
+    _mass_squared(G::LocalZZGenus) -> QQFieldElem
 
 Return the local mass `m_p` of this genus as defined by Conway.
 
 See Equation (3) in [CS1988]_
 """
-function _mass_squared(G::ZpGenus)
+function _mass_squared(G::LocalZZGenus)
   @req dim(G) > 1 "the dimension must be at least 2"
   p = prime(G)
   sym = symbol(G)
@@ -2113,13 +2113,13 @@ function _mass_squared(G::ZpGenus)
 end
 
 @doc raw"""
-    _standard_mass(G::ZpGenus) -> QQFieldElem
+    _standard_mass(G::LocalZZGenus) -> QQFieldElem
 
 Return the standard p-mass of this local genus.
 
 See Equation (6) of [CS1988]_.
 """
-function _standard_mass(G::ZpGenus)
+function _standard_mass(G::LocalZZGenus)
   n = dim(G)
   p = prime(G)
   s = div(n + 1, 2)
@@ -2135,12 +2135,12 @@ function _standard_mass(G::ZpGenus)
 end
 
 @doc raw"""
-    _species_list(G::ZpGenus) -> Vector{Int}
+    _species_list(G::LocalZZGenus) -> Vector{Int}
 
 Return the species list.
 See Table 1 in [CS1988]_.
 """
-function _species_list(G::ZpGenus)
+function _species_list(G::LocalZZGenus)
   p = prime(G)
   species_list = Int[]
   sym = symbol(G)
@@ -2300,12 +2300,12 @@ function _quadratic_L_function_squared(n, d)
 end
 
 @doc raw"""
-    rational_isometry_class(g::ZpGenus) -> LocalQuadSpaceCls
+    rational_isometry_class(g::LocalZZGenus) -> LocalQuadSpaceCls
 
 Return the abstract isometry class of the quadratic space
 $g \otimes \mathbb{Q}$.
 """
-function rational_isometry_class(g::ZpGenus)
+function rational_isometry_class(g::LocalZZGenus)
   K = QQ
   n = dim(g)
   h = hasse_invariant(g)
@@ -2315,12 +2315,12 @@ function rational_isometry_class(g::ZpGenus)
 end
 
 @doc raw"""
-    rational_isometry_class(g::ZGenus) -> QuadSpaceCls
+    rational_isometry_class(g::ZZGenus) -> QuadSpaceCls
 
 Return the abstract isometry class of the quadratic space
 $g \otimes \mathbb{Q}$.
 """
-function rational_isometry_class(g::ZGenus)
+function rational_isometry_class(g::ZZGenus)
   K = QQ
   G = class_quad_type(K)(K)
   n = dim(g)
@@ -2348,7 +2348,7 @@ end
 ################################################################################
 
 @doc raw"""
-    represents(g1::ZpGenus, g2::ZpGenus) -> Bool
+    represents(g1::LocalZZGenus, g2::LocalZZGenus) -> Bool
 
 Return whether `g1` represents `g2`.
 
@@ -2357,7 +2357,7 @@ Note that for `p == 2` there is a typo in O'Meara Theorem 3 (V).
 The correct statement is
 (V) $2^i(1+4\omega) \to \mathfrak{L}_{i+1}/\mathfrak{l}_{[i]}$.
 """
-function represents(G1::ZpGenus, G2::ZpGenus)
+function represents(G1::LocalZZGenus, G2::LocalZZGenus)
   G1, G2 = G2, G1
   s = lcm(denominator(scale(G1)), denominator(scale(G2)))
   G1 = rescale(G1, s)
@@ -2368,7 +2368,7 @@ function represents(G1::ZpGenus, G2::ZpGenus)
   s2 = symbol(G2)
   level = max(s1[end][1], s2[end][1])
   # notation
-  function delta(pgenus::ZpGenus, i)
+  function delta(pgenus::LocalZZGenus, i)
     # O'Meara p.857
     if symbol(pgenus, i+1)[4] == 1
       return ZZ(2)^(i+1)
@@ -2381,15 +2381,15 @@ function represents(G1::ZpGenus, G2::ZpGenus)
 
   genus1 = G1
   genus2 = G2
-  gen1 = ZpGenus[]  # gen1[i+1] = \mathfrak{l}_i
-  gen2 = ZpGenus[]  # gen1[i+1] = \mathfrak{L}_i
+  gen1 = LocalZZGenus[]  # gen1[i+1] = \mathfrak{l}_i
+  gen2 = LocalZZGenus[]  # gen1[i+1] = \mathfrak{L}_i
 
   for scale in 0:(level+2)
     i = scale + 1
     g1 = [s for s in s1 if s[1]<=scale]
     g2 = [s for s in s2 if s[1]<=scale]
-    push!(gen1, ZpGenus(p, g1))
-    push!(gen2, ZpGenus(p, g2))
+    push!(gen1, LocalZZGenus(p, g1))
+    push!(gen2, LocalZZGenus(p, g2))
     if p!=2 && !represents(rational_isometry_class(gen2[i]),
                            rational_isometry_class(gen1[i]))
       return false
@@ -2450,16 +2450,16 @@ function represents(G1::ZpGenus, G2::ZpGenus)
     end
   end
 
-  gen2_round = ZpGenus[]  # gen2_round[i-1] = \mathfrak{L}_{(i)}
+  gen2_round = LocalZZGenus[]  # gen2_round[i-1] = \mathfrak{L}_{(i)}
   for scale in 0:(level + 2)
       g2 = [s for s in s2 if s[1]<scale || (s[1]==scale && s[4]==1)]
-      push!(gen2_round, ZpGenus(p, g2))
+      push!(gen2_round, LocalZZGenus(p, g2))
   end
 
-  gen1_square = ZpGenus[] # gen2_square[i-1] = \mathfrak{l}_{[i]}
+  gen1_square = LocalZZGenus[] # gen2_square[i-1] = \mathfrak{l}_{[i]}
   for scale in 0:level
       g1 = [s for s in s1 if s[1]<=scale || (s[1]==scale+1 && s[4]==0)]
-      push!(gen1_square, ZpGenus(p, g1))
+      push!(gen1_square, LocalZZGenus(p, g1))
   end
 
   FH = isometry_class(quadratic_space(QQ, QQ[0 1; 1 0]), p)
@@ -2515,12 +2515,12 @@ function represents(G1::ZpGenus, G2::ZpGenus)
 end
 
 @doc raw"""
-    represents(G1::ZGenus, G2::ZGenus) -> Bool
+    represents(G1::ZZGenus, G2::ZZGenus) -> Bool
 
 Return if `G1` represents `G2`. That is if some element in the genus of `G1`
 represents some element in the genus of `G2`.
 """
-function represents(G1::ZGenus, G2::ZGenus)
+function represents(G1::ZZGenus, G2::ZZGenus)
   p1, m1 = signature_pair(G1)
   p2, m2 = signature_pair(G2)
   if  p1<p2 || m1 < m2
@@ -2552,18 +2552,18 @@ end
 ################################################################################
 
 @doc raw"""
-    embed(S::ZLat, G::Genus, primitive=true) -> Bool, embedding
+    embed(S::ZZLat, G::Genus, primitive=true) -> Bool, embedding
 
 Return a (primitive) embedding of the integral lattice `S` into some lattice in the genus of `G`.
 
 ```jldoctest
-julia> G = Zgenera((8,0), 1, even=true)[1];
+julia> G = integer_genera((8,0), 1, even=true)[1];
 
 julia> L, S, i = embed(root_lattice(:A,5), G);
 
 ```
 """
-function embed(S::ZLat, G::ZGenus, primitive::Bool=true)
+function embed(S::ZZLat, G::ZZGenus, primitive::Bool=true)
   @req scale(S) >= 1 && scale(G) >= 1 "L and G must be integral"
   @req signature_tuple(S)[2]==0 "S must be nondegenerate"
   if abs(det(G)) == 1
@@ -2574,7 +2574,7 @@ function embed(S::ZLat, G::ZGenus, primitive::Bool=true)
 end
 
 @doc raw"""
-    embed_in_unimodular(S::ZLat, pos, neg, primitive=true, even=true) -> Bool, L, S', iS, iR
+    embed_in_unimodular(S::ZZLat, pos, neg, primitive=true, even=true) -> Bool, L, S', iS, iR
 
 Return a (primitive) embedding of the integral lattice `S` into some
 (even) unimodular lattice of signature `(pos, neg)`.
@@ -2582,12 +2582,12 @@ Return a (primitive) embedding of the integral lattice `S` into some
 For now this works only for even lattices.
 
 ```jldoctest
-julia> NS = direct_sum(Zlattice(:U), rescale(root_lattice(:A, 16), -1))[1];
+julia> NS = direct_sum(integer_lattice(:U), rescale(root_lattice(:A, 16), -1))[1];
 
 julia> LK3, iNS, i = embed_in_unimodular(NS, 3, 19);
 
 julia> genus(LK3)
-ZGenus
+ZZGenus
 Signature: (3, 19)
 Genus symbol at 2:   1^22
 
@@ -2598,7 +2598,7 @@ julia> is_primitive(LK3, iNS)
 true
 ```
 """
-function embed_in_unimodular(S::ZLat, pos, neg; primitive=true, even=true)
+function embed_in_unimodular(S::ZZLat, pos, neg; primitive=true, even=true)
   @vprint :Lattice 1 "computing embedding in L_$(n) \n"
   pS,kS, nS = signature_tuple(S)
   @req kS == 0 "S must be non-degenerate"
@@ -2610,7 +2610,7 @@ function embed_in_unimodular(S::ZLat, pos, neg; primitive=true, even=true)
   GR = genus(DR, (pR, nR)) # genus of R
   R = representative(GR)
   R = lll(R)  # make R a bit nicer
-  R = Zlattice(gram=gram_matrix(R)) # clear the history of R
+  R = integer_lattice(gram=gram_matrix(R)) # clear the history of R
 
   SR, inj = direct_sum(S, R)
   iS, iR = inj
@@ -2634,7 +2634,7 @@ end
 ###############################################################################
 
 @doc raw"""
-    is_primary_with_prime(G::ZGenus) -> Bool, ZZRingElem
+    is_primary_with_prime(G::ZZGenus) -> Bool, ZZRingElem
 
 Given a genus of $\mathbb Z$-lattices `G`, return whether it is primary,
 that is whether the bilinear form is integral and the associated
@@ -2644,7 +2644,7 @@ prime number `p`. In case it is, `p` is also returned as second output.
 Note that for unimodular genera, this function returns `(true, 1)`. If the
 genus is not primary, the second return value is `-1` by default.
 """
-function is_primary_with_prime(G::ZGenus)
+function is_primary_with_prime(G::ZZGenus)
   @req is_integral(G) "G must be a genus of integral lattices"
   length(primes(G)) >= 3 && return false, ZZ(-1)
 
@@ -2665,28 +2665,28 @@ function is_primary_with_prime(G::ZGenus)
 end
 
 @doc raw"""
-    is_primary(G::ZGenus, p::Union{Integer, ZZRingElem}) -> Bool
+    is_primary(G::ZZGenus, p::Union{Integer, ZZRingElem}) -> Bool
 
 Given a genus of integral $\mathbb Z$-lattices `G` and a prime number `p`,
 return whether `G` is `p`-primary, that is whether the associated discriminant
 form (see [`discriminant_group`](@ref)) is a `p`-group.
 """
-function is_primary(G::ZGenus, p::Union{Integer, ZZRingElem})
+function is_primary(G::ZZGenus, p::Union{Integer, ZZRingElem})
   bool, q = is_primary_with_prime(G)
   return bool && q == p
 end
 
 @doc raw"""
-    is_unimodular(G::ZGenus) -> Bool
+    is_unimodular(G::ZZGenus) -> Bool
 
 Given a genus of integral $\mathbb Z$-lattices `G`, return whether `G` is
 unimodular, that is whether the associated discriminant form
 (see [`discriminant_group`](@ref)) is trivial.
 """
-is_unimodular(G::ZGenus) = is_primary(G, 1)
+is_unimodular(G::ZZGenus) = is_primary(G, 1)
 
 @doc raw"""
-    is_elementary_with_prime(G::ZGenus) -> Bool, ZZRingElem
+    is_elementary_with_prime(G::ZZGenus) -> Bool, ZZRingElem
 
 Given a genus of $\mathbb Z$-lattices `G`, return whether it is elementary,
 that is whether the bilinear form is inegtral and the associated discriminant
@@ -2696,7 +2696,7 @@ prime number `p`. In case it is, `p` is also returned as second output.
 Note that for unimodular genera, this function returns `(true, 1)`. If the
 genus is not elementary, the second return value is `-1` by default.
 """
-function is_elementary_with_prime(G::ZGenus)
+function is_elementary_with_prime(G::ZZGenus)
   bool, p = is_primary_with_prime(G)
   bool || return bool, ZZ(-1)
   if p == 1
@@ -2710,13 +2710,13 @@ function is_elementary_with_prime(G::ZGenus)
 end
 
 @doc raw"""
-    is_elementary(G::ZGenus, p::Union{Integer, ZZRingElem}) -> Bool
+    is_elementary(G::ZZGenus, p::Union{Integer, ZZRingElem}) -> Bool
 
 Given a genus of integral $\mathbb Z$-lattices `G` and a prime number `p`,
 return whether `G` is `p`-elementary, that is whether its associated discriminant
 form (see [`discriminant_group`](@ref)) is an elementary `p`-group.
 """
-function is_elementary(G::ZGenus, p::Union{Integer, ZZRingElem})
+function is_elementary(G::ZZGenus, p::Union{Integer, ZZRingElem})
   bool, q = is_elementary_with_prime(G)
   return bool && q == p
 end
@@ -2730,12 +2730,12 @@ end
 # TODO: this could be done faster by working on symbols directly! It is
 # straightforward when p != 2; for p == 2 one has to be careful...
 @doc raw"""
-    rescale(G::ZpGenus, a::RationalUnion) -> ZpGenus
+    rescale(G::LocalZZGenus, a::RationalUnion) -> LocalZZGenus
 
 Given a local genus symbol `G` of $\mathbb Z$-lattices, return the local genus
 symbol of any representative of `G` rescaled by `a`.
 """
-function rescale(G::ZpGenus, a::RationalUnion)
+function rescale(G::LocalZZGenus, a::RationalUnion)
   @req !iszero(a) "a must be non-zero"
   a = QQ(a)
   p = prime(G)
@@ -2744,14 +2744,14 @@ function rescale(G::ZpGenus, a::RationalUnion)
 end
 
 @doc raw"""
-    rescale(G::ZGenus, a::RationalUnion) -> ZGenus
+    rescale(G::ZZGenus, a::RationalUnion) -> ZZGenus
 
 Given a genus symbol `G` of $\mathbb Z$-lattices, return the genus
 symbol of any representative of `G` rescaled by `a`.
 """
-rescale(::ZGenus, ::RationalUnion)
+rescale(::ZZGenus, ::RationalUnion)
 
-function rescale(G::ZGenus, a::IntegerUnion)
+function rescale(G::ZZGenus, a::IntegerUnion)
   @req !iszero(a) "a must be non-zero"
   a = ZZ(a)
   if isdefined(G, :_representative)
@@ -2769,10 +2769,10 @@ function rescale(G::ZGenus, a::IntegerUnion)
     p != 2 && length(ss) == 1 && ss[1][1] == 0 && continue
     push!(sym, s)
   end
-  return ZGenus(sig_pair, sym)
+  return ZZGenus(sig_pair, sym)
 end
 
-function rescale(G::ZGenus, a::RationalUnion)
+function rescale(G::ZZGenus, a::RationalUnion)
   @req !iszero(a) "a must be non zero"
   a = QQ(a)
   if isdefined(G, :_representative)
@@ -2791,6 +2791,6 @@ function rescale(G::ZGenus, a::RationalUnion)
     p != 2 && length(ss) == 1 && ss[1][1] == 0 && continue
     push!(sym, s)
   end
-  return ZGenus(sig_pair, sym)
+  return ZZGenus(sig_pair, sym)
 end
 

--- a/src/QuadForm/Quad/ZLattices.jl
+++ b/src/QuadForm/Quad/ZLattices.jl
@@ -8,20 +8,20 @@ export *,+, basis_matrix, ambient_space, base_ring, base_field, root_lattice,
 
 # scope & verbose scope: :Lattice
 @doc raw"""
-    basis_matrix(L::ZLat)
+    basis_matrix(L::ZZLat)
 
 Return the basis matrix $B$ of the integer lattice $L$.
 
 The lattice is given by the row span of $B$ seen inside of the
 ambient quadratic space of $L$.
 """
-basis_matrix(L::ZLat) = L.basis_matrix
+basis_matrix(L::ZZLat) = L.basis_matrix
 
-ambient_space(L::ZLat) = L.space
+ambient_space(L::ZZLat) = L.space
 
-base_ring(L::ZLat) = FlintZZ
+base_ring(L::ZZLat) = FlintZZ
 
-base_field(L::ZLat) = base_ring(gram_matrix(ambient_space(L)))
+base_field(L::ZZLat) = base_ring(gram_matrix(ambient_space(L)))
 
 ################################################################################
 #
@@ -30,7 +30,7 @@ base_field(L::ZLat) = base_ring(gram_matrix(ambient_space(L)))
 ################################################################################
 
 @doc raw"""
-    Zlattice([B::MatElem]; gram) -> ZLat
+    integer_lattice([B::MatElem]; gram) -> ZZLat
 
 Return the Z-lattice with basis matrix $B$ inside the quadratic space with
 Gram matrix `gram`.
@@ -40,34 +40,34 @@ If $B$ is not specified, the basis matrix is the identity matrix.
 
 # Examples
 ```jldoctest
-julia> L = Zlattice(matrix(QQ, 2, 2, [1//2, 0, 0, 2]));
+julia> L = integer_lattice(matrix(QQ, 2, 2, [1//2, 0, 0, 2]));
 
 julia> gram_matrix(L) == matrix(QQ, 2, 2, [1//4, 0, 0, 4])
 true
 
-julia> L = Zlattice(gram = matrix(ZZ, [2 -1; -1 2]));
+julia> L = integer_lattice(gram = matrix(ZZ, [2 -1; -1 2]));
 
 julia> gram_matrix(L) == matrix(ZZ, [2 -1; -1 2])
 true
 ```
 """
-function Zlattice(B::QQMatrix; gram = identity_matrix(FlintQQ, ncols(B)), check::Bool=true)
+function integer_lattice(B::QQMatrix; gram = identity_matrix(FlintQQ, ncols(B)), check::Bool=true)
   V = quadratic_space(FlintQQ, gram, check=check)
   return lattice(V, B, check=check)
 end
 
-function Zlattice(B::ZZMatrix; gram = identity_matrix(FlintQQ, ncols(B)), check::Bool=true)
+function integer_lattice(B::ZZMatrix; gram = identity_matrix(FlintQQ, ncols(B)), check::Bool=true)
   V = quadratic_space(FlintQQ, gram, check=check)
   return lattice(V, B, check=check)
 end
 
-function Zlattice(;gram, check=true)
+function integer_lattice(;gram, check=true)
   n = nrows(gram)
   return lattice(quadratic_space(FlintQQ, gram, check=check), identity_matrix(FlintQQ, n), check=check)
 end
 
 @doc raw"""
-    lattice(V::QuadSpace{QQField, QQMatrix}, B::QQMatrix; isbasis=true, check=true) -> ZLat
+    lattice(V::QuadSpace{QQField, QQMatrix}, B::QQMatrix; isbasis=true, check=true) -> ZZLat
 
 Return the $\mathbb Z$-lattice with basis matrix $B$ inside the quadratic space $V$.
 """
@@ -85,21 +85,21 @@ function lattice(V::QuadSpace{QQField, QQMatrix}, B::MatElem{<:RationalUnion}; i
     while i > 0 && is_zero_row(BB, i)
       i = i - 1
     end
-    return ZLat(V, BB[1:i, :])
+    return ZZLat(V, BB[1:i, :])
   else
     @req !check || rank(B) == nrows(B) "The rows of B must define a free system of vectors in V"
-    return ZLat(V, B)
+    return ZZLat(V, B)
   end
 end
 
-function lattice_in_same_ambient_space(L::ZLat, B::MatElem; check::Bool = true)
+function lattice_in_same_ambient_space(L::ZZLat, B::MatElem; check::Bool = true)
   @req !check || (rank(B) == nrows(B)) "The rows of B must define a free system of vectors"
   V = ambient_space(L)
   return lattice(V, B, check = false)
 end
 
 @doc raw"""
-    rescale(L::ZLat, r::RationalUnion) -> ZLat
+    rescale(L::ZZLat, r::RationalUnion) -> ZZLat
 
 Return the lattice `L` in the quadratic space with form `r \Phi`.
 
@@ -107,7 +107,7 @@ Return the lattice `L` in the quadratic space with form `r \Phi`.
 This can be useful to apply methods intended for positive definite lattices.
 
 ```jldoctest
-julia> L = Zlattice(gram=ZZ[-1 0; 0 -1])
+julia> L = integer_lattice(gram=ZZ[-1 0; 0 -1])
 Quadratic lattice of rank 2 and degree 2 over the rationals
 
 julia> shortest_vectors(rescale(L, -1))
@@ -116,7 +116,7 @@ julia> shortest_vectors(rescale(L, -1))
  [1, 0]
 ```
 """
-function rescale(L::ZLat, r::RationalUnion)
+function rescale(L::ZZLat, r::RationalUnion)
   B = basis_matrix(L)
   gram_space = gram_matrix(ambient_space(L))
   Vr = quadratic_space(QQ, r*gram_space)
@@ -130,20 +130,20 @@ end
 ################################################################################
 
 @doc raw"""
-    gram_matrix(L::ZLat) -> QQMatrix
+    gram_matrix(L::ZZLat) -> QQMatrix
 
 Return the gram matrix of $L$.
 
 # Examples
 ```jldoctest
-julia> L = Zlattice(matrix(ZZ, [2 0; -1 2]));
+julia> L = integer_lattice(matrix(ZZ, [2 0; -1 2]));
 
 julia> gram_matrix(L)
 [ 4   -2]
 [-2    5]
 ```
 """
-function gram_matrix(L::ZLat)
+function gram_matrix(L::ZZLat)
   if isdefined(L, :gram_matrix)
     return L.gram_matrix
   end
@@ -160,7 +160,7 @@ function gram_matrix(L::ZLat)
   return G
 end
 
-gram_matrix_of_rational_span(L::ZLat) = gram_matrix(L)
+gram_matrix_of_rational_span(L::ZZLat) = gram_matrix(L)
 
 ################################################################################
 #
@@ -169,14 +169,14 @@ gram_matrix_of_rational_span(L::ZLat) = gram_matrix(L)
 ################################################################################
 
 @doc raw"""
-    rational_span(L::ZLat) -> QuadSpace
+    rational_span(L::ZZLat) -> QuadSpace
 
 Return the rational span of $L$, which is the quadratic space with Gram matrix
 equal to `gram_matrix(L)`.
 
 # Examples
 ```jldoctest
-julia> L = Zlattice(matrix(ZZ, [2 0; -1 2]));
+julia> L = integer_lattice(matrix(ZZ, [2 0; -1 2]));
 
 julia> rational_span(L)
 Quadratic space over
@@ -185,7 +185,7 @@ with Gram matrix
 [4 -2; -2 5]
 ```
 """
-function rational_span(L::ZLat)
+function rational_span(L::ZZLat)
   if isdefined(L, :rational_span)
     return L.rational_span
   else
@@ -202,93 +202,93 @@ end
 #
 ################################################################################
 
-function _biproduct(x::Vector{ZLat})
+function _biproduct(x::Vector{ZZLat})
   Bs = basis_matrix.(x)
   B = diagonal_matrix(Bs)
   return B
 end
 
 @doc raw"""
-    direct_sum(x::Vararg{ZLat}) -> ZLat, Vector{AbstractSpaceMor}
-    direct_sum(x::Vector{ZLat}) -> ZLat, Vector{AbstractSpaceMor}
+    direct_sum(x::Vararg{ZZLat}) -> ZZLat, Vector{AbstractSpaceMor}
+    direct_sum(x::Vector{ZZLat}) -> ZZLat, Vector{AbstractSpaceMor}
 
 Given a collection of $\mathbb Z$-lattices $L_1, \ldots, L_n$,
 return their direct sum $L := L_1 \oplus \ldots \oplus L_n$,
 together with the injections $L_i \to L$.
 (seen as maps between the corresponding ambient spaces).
 
-For objects of type `ZLat`, finite direct sums and finite direct products
+For objects of type `ZZLat`, finite direct sums and finite direct products
 agree and they are therefore called biproducts.
 If one wants to obtain `L` as a direct product with the projections $L \to L_i$,
 one should call `direct_product(x)`.
 If one wants to obtain `L` as a biproduct with the injections $L_i \to L$ and
 the projections $L \to L_i$, one should call `biproduct(x)`.
 """
-function direct_sum(x::Vector{ZLat})
+function direct_sum(x::Vector{ZZLat})
   @req length(x) >= 2 "Input must consist of at least two lattices"
   W, inj = direct_sum(ambient_space.(x))
   B = _biproduct(x)
   return lattice(W, B, check = false), inj
 end
 
-direct_sum(x::Vararg{ZLat}) = direct_sum(collect(x))
+direct_sum(x::Vararg{ZZLat}) = direct_sum(collect(x))
 
 @doc raw"""
-    direct_product(x::Vararg{ZLat}) -> ZLat, Vector{AbstractSpaceMor}
-    direct_product(x::Vector{ZLat}) -> ZLat, Vector{AbstractSpaceMor}
+    direct_product(x::Vararg{ZZLat}) -> ZZLat, Vector{AbstractSpaceMor}
+    direct_product(x::Vector{ZZLat}) -> ZZLat, Vector{AbstractSpaceMor}
 
 Given a collection of $\mathbb Z$-lattices $L_1, \ldots, L_n$,
 return their direct product $L := L_1 \times \ldots \times L_n$,
 together with the projections $L \to L_i$.
 (seen as maps between the corresponding ambient spaces).
 
-For objects of type `ZLat`, finite direct sums and finite direct products
+For objects of type `ZZLat`, finite direct sums and finite direct products
 agree and they are therefore called biproducts.
 If one wants to obtain `L` as a direct sum with the injections $L_i \to L$,
 one should call `direct_sum(x)`.
 If one wants to obtain `L` as a biproduct with the injections $L_i \to L$ and
 the projections $L \to L_i$, one should call `biproduct(x)`.
 """
-function direct_product(x::Vector{ZLat})
+function direct_product(x::Vector{ZZLat})
   @req length(x) >= 2 "Input must consist of at least two lattices"
   W, proj = direct_product(ambient_space.(x))
   B = _biproduct(x)
   return lattice(W, B, check = false), proj
 end
 
-direct_product(x::Vararg{ZLat}) = direct_product(collect(x))
+direct_product(x::Vararg{ZZLat}) = direct_product(collect(x))
 
 @doc raw"""
-    biproduct(x::Vararg{ZLat}) -> ZLat, Vector{AbstractSpaceMor}, Vector{AbstractSpaceMor}
-    biproduct(x::Vector{ZLat}) -> ZLat, Vector{AbstractSpaceMor}, Vector{AbstractSpaceMor}
+    biproduct(x::Vararg{ZZLat}) -> ZZLat, Vector{AbstractSpaceMor}, Vector{AbstractSpaceMor}
+    biproduct(x::Vector{ZZLat}) -> ZZLat, Vector{AbstractSpaceMor}, Vector{AbstractSpaceMor}
 
 Given a collection of $\mathbb Z$-lattices $L_1, \ldots, L_n$,
 return their biproduct $L := L_1 \oplus \ldots \oplus L_n$,
 together with the injections $L_i \to L$ and the projections $L \to L_i$.
 (seen as maps between the corresponding ambient spaces).
 
-For objects of type `ZLat`, finite direct sums and finite direct products
+For objects of type `ZZLat`, finite direct sums and finite direct products
 agree and they are therefore called biproducts.
 If one wants to obtain `L` as a direct sum with the injections $L_i \to L$,
 one should call `direct_sum(x)`.
 If one wants to obtain `L` as a direct product with the projections $L \to L_i$,
 one should call `direct_product(x)`.
 """
-function biproduct(x::Vector{ZLat})
+function biproduct(x::Vector{ZZLat})
   @req length(x) >= 2 "Input must consist of at least two lattices"
   W, inj, proj = biproduct(ambient_space.(x))
   B = _biproduct(x)
   return lattice(W, B, check = false), inj, proj
 end
 
-biproduct(x::Vararg{ZLat}) = biproduct(collect(x))
+biproduct(x::Vararg{ZZLat}) = biproduct(collect(x))
 
 @doc raw"""
-    orthogonal_submodule(L::ZLat, S::ZLat) -> ZLat
+    orthogonal_submodule(L::ZZLat, S::ZZLat) -> ZZLat
 
 Return the largest submodule of `L` orthogonal to `S`.
 """
-function orthogonal_submodule(L::ZLat, S::ZLat)
+function orthogonal_submodule(L::ZZLat, S::ZZLat)
   @assert ambient_space(L)==ambient_space(S) "L and S must have the same ambient space"
   B = basis_matrix(L)
   C = basis_matrix(S)
@@ -307,7 +307,7 @@ end
 #
 ################################################################################
 
-function Base.show(io::IO, L::ZLat)
+function Base.show(io::IO, L::ZZLat)
   print(io, "Quadratic lattice of rank ", rank(L),
             " and degree ", degree(L), " over the rationals")
 end
@@ -321,7 +321,7 @@ end
 # This is an internal function, which sets
 # L.automorphism_group_generators
 # L.automorphism_group_order
-function assert_has_automorphisms(L::ZLat; redo::Bool = false,
+function assert_has_automorphisms(L::ZZLat; redo::Bool = false,
                                            try_small::Bool = true)
 
   if !redo && isdefined(L, :automorphism_group_generators)
@@ -400,7 +400,7 @@ end
 
 # documented in ../Lattices.jl
 
-function automorphism_group_generators(L::ZLat; ambient_representation::Bool = true)
+function automorphism_group_generators(L::ZZLat; ambient_representation::Bool = true)
 
   @req rank(L) in [0, 2] || is_definite(L) "The lattice must be definite or of rank at most 2"
   assert_has_automorphisms(L)
@@ -435,7 +435,7 @@ end
 
 # documented in ../Lattices.jl
 
-function automorphism_group_order(L::ZLat)
+function automorphism_group_order(L::ZZLat)
   @req is_definite(L) "The lattice must be definite"
   assert_has_automorphisms(L)
   return L.automorphism_group_order
@@ -449,7 +449,7 @@ end
 
 # documented in ../Lattices.jl
 
-function is_isometric(L::ZLat, M::ZLat)
+function is_isometric(L::ZZLat, M::ZZLat)
   if rank(L) != rank(M)
     return false
   end
@@ -479,7 +479,7 @@ function is_isometric(L::ZLat, M::ZLat)
   return _is_isometric_indef(L, M)
 end
 
-function is_isometric_with_isometry(L::ZLat, M::ZLat; ambient_representation::Bool = false)
+function is_isometric_with_isometry(L::ZZLat, M::ZZLat; ambient_representation::Bool = false)
   @req is_definite(L) && is_definite(M) "The lattices must be definite"
 
   if rank(L) != rank(M)
@@ -584,7 +584,7 @@ end
 #
 ################################################################################
 
-function is_sublattice(M::ZLat, N::ZLat)
+function is_sublattice(M::ZZLat, N::ZZLat)
   if ambient_space(M) != ambient_space(N)
     return false
   end
@@ -599,13 +599,13 @@ function is_sublattice(M::ZLat, N::ZLat)
 end
 
 @doc raw"""
-    is_sublattice_with_relations(M::ZLat, N::ZLat) -> Bool, QQMatrix
+    is_sublattice_with_relations(M::ZZLat, N::ZZLat) -> Bool, QQMatrix
 
 Returns whether $N$ is a sublattice of $M$. In this case, the second return
 value is a matrix $B$ such that $B B_M = B_N$, where $B_M$ and $B_N$ are the
 basis matrices of $M$ and $N$ respectively.
 """
-function is_sublattice_with_relations(M::ZLat, N::ZLat)
+function is_sublattice_with_relations(M::ZZLat, N::ZZLat)
    if ambient_space(M) != ambient_space(N)
      return false, basis_matrix(M)
    end
@@ -632,11 +632,11 @@ Return the root lattice of type `R` given by `:A`, `:D` or `:E` with parameter `
 """
 function root_lattice(R::Symbol, n::Int)
   if R === :A
-    return Zlattice(gram = _root_lattice_A(n))
+    return integer_lattice(gram = _root_lattice_A(n))
   elseif R === :E
-    return Zlattice(gram = _root_lattice_E(n))
+    return integer_lattice(gram = _root_lattice_E(n))
   elseif R === :D
-    return Zlattice(gram = _root_lattice_D(n))
+    return integer_lattice(gram = _root_lattice_D(n))
   else
     error("Type (:$R) must be :A, :D or :E")
   end
@@ -713,17 +713,17 @@ end
 ################################################################################
 
 @doc raw"""
-    Zlattice(S::Symbol, n::RationalUnion = 1) -> Zlat
+    integer_lattice(S::Symbol, n::RationalUnion = 1) -> Zlat
 
 Given `S = :H` or `S = :U`, return a $\mathbb Z$-lattice admitting $n*J_2$ as
 Gram matrix in some basis, where $J_2$ is the 2-by-2 matrix with 0's on the
 main diagonal and 1's elsewhere.
 """
-function Zlattice(S::Symbol, n::RationalUnion = 1)
+function integer_lattice(S::Symbol, n::RationalUnion = 1)
   @req S === :H || S === :U "Only available for the hyperbolic plane"
   gram = n*identity_matrix(QQ, 2)
   gram = reverse_cols!(gram)
-  return Zlattice(gram = gram)
+  return integer_lattice(gram = gram)
 end
 
 @doc raw"""
@@ -749,7 +749,7 @@ julia> gram_matrix(L)
 [-13     0]
 ```
 """
-hyperbolic_plane_lattice(n::RationalUnion = 1) = Zlattice(:H, n)
+hyperbolic_plane_lattice(n::RationalUnion = 1) = integer_lattice(:H, n)
 
 ################################################################################
 #
@@ -759,7 +759,7 @@ hyperbolic_plane_lattice(n::RationalUnion = 1) = Zlattice(:H, n)
 
 # documented in ../Lattices.jl
 
-function dual(L::ZLat)
+function dual(L::ZZLat)
   G = gram_matrix(L)
   new_bmat = inv(G)*basis_matrix(L)
   return lattice(ambient_space(L), new_bmat, check = false)
@@ -772,14 +772,14 @@ end
 ################################################################################
 
 @doc raw"""
-    scale(L::ZLat) -> QQFieldElem
+    scale(L::ZZLat) -> QQFieldElem
 
 Return the scale of `L`.
 
 The scale of `L` is defined as the positive generator of the $\mathbb Z$-ideal
 generated by $\{\Phi(x, y) : x, y \in L\}$.
 """
-function scale(L::ZLat)
+function scale(L::ZZLat)
   if isdefined(L, :scale)
     return L.scale
   end
@@ -801,14 +801,14 @@ end
 ################################################################################
 
 @doc raw"""
-    norm(L::ZLat) -> QQFieldElem
+    norm(L::ZZLat) -> QQFieldElem
 
 Return the norm of `L`.
 
 The norm of `L` is defined as the positive generator of the $\mathbb Z$- ideal
 generated by $\{\Phi(x,x) : x \in L\}$.
 """
-function norm(L::ZLat)
+function norm(L::ZZLat)
   if isdefined(L, :norm)
     return L.norm
   end
@@ -828,14 +828,14 @@ end
 ################################################################################
 
 @doc raw"""
-    iseven(L::ZLat) -> Bool
+    iseven(L::ZZLat) -> Bool
 
 Return whether `L` is even.
 
 An integer lattice `L` in the rational quadratic space $(V,\Phi)$ is called even
 if $\Phi(x,x) \in 2\mathbb{Z}$ for all $x in L$.
 """
-iseven(L::ZLat) = is_integral(L) && iseven(numerator(norm(L)))
+iseven(L::ZZLat) = is_integral(L) && iseven(numerator(norm(L)))
 
 ################################################################################
 #
@@ -844,11 +844,11 @@ iseven(L::ZLat) = is_integral(L) && iseven(numerator(norm(L)))
 ################################################################################
 
 @doc raw"""
-    discriminant(L::ZLat) -> QQFieldElem
+    discriminant(L::ZZLat) -> QQFieldElem
 
 Return the discriminant of the rational span of `L`.
 """
-discriminant(L::ZLat) = discriminant(rational_span(L))
+discriminant(L::ZZLat) = discriminant(rational_span(L))
 
 ################################################################################
 #
@@ -857,11 +857,11 @@ discriminant(L::ZLat) = discriminant(rational_span(L))
 ################################################################################
 
 @doc raw"""
-    det(L::ZLat) -> QQFieldElem
+    det(L::ZZLat) -> QQFieldElem
 
 Return the determinant of the gram matrix of `L`.
 """
-function det(L::ZLat)
+function det(L::ZZLat)
   return det(gram_matrix(L))
 end
 
@@ -871,7 +871,7 @@ end
 #
 ################################################################################
 
-function rank(L::ZLat)
+function rank(L::ZZLat)
   return nrows(basis_matrix(L))
 end
 
@@ -882,11 +882,11 @@ end
 ################################################################################
 
 @doc raw"""
-    signature_tuple(L::ZLat) -> Tuple{Int,Int,Int}
+    signature_tuple(L::ZZLat) -> Tuple{Int,Int,Int}
 
 Return the number of (positive, zero, negative) inertia of `L`.
 """
-signature_tuple(L::ZLat) = signature_tuple(rational_span(L))
+signature_tuple(L::ZZLat) = signature_tuple(rational_span(L))
 
 ################################################################################
 #
@@ -896,7 +896,7 @@ signature_tuple(L::ZLat) = signature_tuple(rational_span(L))
 
 # so that abstract lattice functions also work with Z-lattices
 
-local_basis_matrix(L::ZLat, p) = basis_matrix(L)
+local_basis_matrix(L::ZZLat, p) = basis_matrix(L)
 
 ################################################################################
 #
@@ -904,7 +904,7 @@ local_basis_matrix(L::ZLat, p) = basis_matrix(L)
 #
 ################################################################################
 
-function intersect(M::ZLat, N::ZLat)
+function intersect(M::ZZLat, N::ZZLat)
   @req ambient_space(M) === ambient_space(N) "Lattices must have same ambient space"
   BM = basis_matrix(M)
   BN = basis_matrix(N)
@@ -925,7 +925,7 @@ end
 #
 ################################################################################
 
-function +(M::ZLat, N::ZLat)
+function +(M::ZZLat, N::ZZLat)
   @req ambient_space(M) === ambient_space(N) "Lattices must have same ambient space"
   BM = basis_matrix(M)
   BN = basis_matrix(N)
@@ -944,32 +944,32 @@ end
 ################################################################################
 
 @doc raw"""
-    is_locally_isometric(L::ZLat, M::ZLat, p::Int) -> Bool
+    is_locally_isometric(L::ZZLat, M::ZZLat, p::Int) -> Bool
 
 Return whether `L` and `M` are isometric over the `p`-adic integers.
 
 i.e. whether $L \otimes \Z_p \cong M\otimes \Z_p$.
 """
-function is_locally_isometric(L::ZLat, M::ZLat, p::Int)
+function is_locally_isometric(L::ZZLat, M::ZZLat, p::Int)
   return is_locally_isometric(L, M, ZZRingElem(p))
 end
 
-function is_locally_isometric(L::ZLat, M::ZLat, p::ZZRingElem)
+function is_locally_isometric(L::ZZLat, M::ZZLat, p::ZZRingElem)
   return genus(L, p) == genus(M, p)
 end
 
 ################################################################################
 #
-#  Conversion between ZLat and QuadLat
+#  Conversion between ZZLat and QuadLat
 #
 ################################################################################
 
-function _to_number_field_lattice(L::ZLat, K, V)
+function _to_number_field_lattice(L::ZZLat, K, V)
   LL = lattice(V, change_base_ring(K, basis_matrix(L)))
   return LL
 end
 
-function _to_number_field_lattice(L::ZLat;
+function _to_number_field_lattice(L::ZZLat;
                                   K::AnticNumberField = rationals_as_number_field()[1],
                                   V::QuadSpace = quadratic_space(K, gram_matrix(ambient_space(L))))
   return _to_number_field_lattice(L, K, V)
@@ -1003,11 +1003,11 @@ end
 ################################################################################
 
 @doc raw"""
-    mass(L::ZLat) -> QQFieldElem
+    mass(L::ZZLat) -> QQFieldElem
 
 Return the mass of the genus of `L`.
 """
-function mass(L::ZLat)
+function mass(L::ZZLat)
   @req is_definite(L) "L must be a definite lattice"
   return mass(genus(L))
 end
@@ -1019,17 +1019,17 @@ end
 ################################################################################
 
 @doc raw"""
-    genus_representatives(L::ZLat) -> Vector{ZLat}
+    genus_representatives(L::ZZLat) -> Vector{ZZLat}
 
 Return representatives for the isometry classes in the genus of `L`.
 """
-function genus_representatives(L::ZLat)
+function genus_representatives(L::ZZLat)
   s = denominator(scale(L))
   L = rescale(L, s)
   LL = _to_number_field_lattice(L)
   K = base_field(L)
   G = genus_representatives(LL)
-  res = ZLat[]
+  res = ZZLat[]
   for N in G
     push!(res, _to_ZLat(N, K = K))
   end
@@ -1043,7 +1043,7 @@ end
 ################################################################################
 
 # kept for testing
-function _maximal_integral_lattice(L::ZLat)
+function _maximal_integral_lattice(L::ZZLat)
   LL = _to_number_field_lattice(L)
   M = maximal_integral_lattice(LL)
   return _to_ZLat(M, V = ambient_space(L))
@@ -1051,14 +1051,14 @@ end
 
 
 @doc raw"""
-    maximal_even_lattice(L::ZLat, p) -> ZLat
+    maximal_even_lattice(L::ZZLat, p) -> ZZLat
 
 Given an even lattice `L` and a prime number `p` return an overlattice of `M`
 which is maximal at `p` and agrees locally with `L` at all other places.
 
 Recall that $L$ is called even if $\Phi(x,x) \in 2 \mathbb Z$ for all $x in L$.
 """
-function maximal_even_lattice(L::ZLat, p)
+function maximal_even_lattice(L::ZZLat, p)
   while true
     ok, L = is_maximal_even(L, p)
     if ok
@@ -1068,14 +1068,14 @@ function maximal_even_lattice(L::ZLat, p)
 end
 
 @doc raw"""
-    maximal_even_lattice(L::ZLat) -> ZLat
+    maximal_even_lattice(L::ZZLat) -> ZZLat
 
 Return a maximal even overlattice `M` of the even lattice `L`.
 
 Recall that $L$ is called even if $\Phi(x,x) \in 2 \mathbb Z$ for all $x in L$.
 Note that the genus of `M` is uniquely determined by the genus of `L`.
 """
-function maximal_even_lattice(L::ZLat)
+function maximal_even_lattice(L::ZZLat)
   @req iseven(L) "The lattice must be even"
   for p in prime_divisors(ZZ(det(L)))
     L = maximal_even_lattice(L, p)
@@ -1083,7 +1083,7 @@ function maximal_even_lattice(L::ZLat)
   return L
 end
 
-function maximal_integral_lattice(L::ZLat)
+function maximal_integral_lattice(L::ZZLat)
   @req denominator(norm(L)) == 1 "The quadratic form is not integral"
   L2 = rescale(L, 2)
   LL2 = maximal_even_lattice(L2)
@@ -1092,7 +1092,7 @@ end
 
 
 @doc raw"""
-    is_maximal_even(L::ZLat, p) -> Bool, ZLat
+    is_maximal_even(L::ZZLat, p) -> Bool, ZZLat
 
 Return if the (`p`-locally) even lattice `L` is maximal at `p` and an even overlattice `M`
 of `L` with $[M:L]=p$ if `L` is not maximal and $1$ else.
@@ -1100,7 +1100,7 @@ of `L` with $[M:L]=p$ if `L` is not maximal and $1$ else.
 Recall that $L$ is called even if $\Phi(x,x) \in 2 \mathbb{Z}$ for all $x in L$.
 """
 
-function is_maximal_even(L::ZLat, p)
+function is_maximal_even(L::ZZLat, p)
   @req denominator(scale(L)) == 1 "The bilinear form is not integral"
   @req p != 2 || mod(ZZ(norm(L)),2) == 0 "The bilinear form is not even"
 
@@ -1257,11 +1257,11 @@ end
 ################################################################################
 
 @doc raw"""
-    *(a::RationalUnion, L::ZLat) -> ZLat
+    *(a::RationalUnion, L::ZZLat) -> ZZLat
 
 Return the lattice $aM$ inside the ambient space of $M$.
 """
-function Base.:(*)(a::RationalUnion, L::ZLat)
+function Base.:(*)(a::RationalUnion, L::ZZLat)
   @assert has_ambient_space(L)
   if is_zero(a)
     B = zero_matrix(QQ, 0, degree(L))
@@ -1271,7 +1271,7 @@ function Base.:(*)(a::RationalUnion, L::ZLat)
   return lattice_in_same_ambient_space(L, B, check = false)
 end
 
-function Base.:(*)(L::ZLat, a::RationalUnion)
+function Base.:(*)(L::ZZLat, a::RationalUnion)
   return a * L
 end
 
@@ -1285,7 +1285,7 @@ end
 Return `true` if both lattices have the same ambient quadratic space
 and the same underlying module.
 """
-function Base.:(==)(L1::ZLat, L2::ZLat)
+function Base.:(==)(L1::ZZLat, L2::ZZLat)
   V1 = ambient_space(L1)
   V2 = ambient_space(L2)
   if V1 != V2
@@ -1297,7 +1297,7 @@ function Base.:(==)(L1::ZLat, L2::ZLat)
 end
 
 @doc raw"""
-    local_modification(M::ZLat, L::ZLat, p)
+    local_modification(M::ZZLat, L::ZZLat, p)
 
 Return a local modification of `M` that matches `L` at `p`.
 
@@ -1313,7 +1313,7 @@ OUTPUT:
 an integral lattice `M'` in the ambient space of `M` such that `M` and `M'` are locally equal at all
 completions except at `p` where `M'` is locally isometric to the lattice `L`.
 """
-function local_modification(M::ZLat, L::ZLat, p)
+function local_modification(M::ZZLat, L::ZZLat, p)
   # notation
   d = denominator(inv(gram_matrix(L)))
   level = valuation(d,p)
@@ -1348,8 +1348,8 @@ end
 ################################################################################
 
 @doc raw"""
-    kernel_lattice(L::ZLat, f::MatElem;
-                   ambient_representation::Bool = true) -> ZLat
+    kernel_lattice(L::ZZLat, f::MatElem;
+                   ambient_representation::Bool = true) -> ZZLat
 
 Given a $\mathbf{Z}$-lattice $L$ and a matrix $f$ inducing an endomorphism of
 $L$, return $\ker(f)$ is a sublattice of $L$.
@@ -1358,7 +1358,7 @@ If `ambient_representation` is `true` (the default), the endomorphism is
 represented with respect to the ambient space of $L$. Otherwise, the
 endomorphism is represented with respect to the basis of $L$.
 """
-function kernel_lattice(L::ZLat, f::MatElem; ambient_representation::Bool = true)
+function kernel_lattice(L::ZZLat, f::MatElem; ambient_representation::Bool = true)
   bL = basis_matrix(L)
   if ambient_representation
     if !is_square(bL)
@@ -1381,10 +1381,10 @@ end
 ################################################################################
 
 @doc raw"""
-    invariant_lattice(L::ZLat, G::Vector{MatElem};
-                      ambient_representation::Bool = true) -> ZLat
-    invariant_lattice(L::ZLat, G::MatElem;
-                      ambient_representation::Bool = true) -> ZLat
+    invariant_lattice(L::ZZLat, G::Vector{MatElem};
+                      ambient_representation::Bool = true) -> ZZLat
+    invariant_lattice(L::ZZLat, G::MatElem;
+                      ambient_representation::Bool = true) -> ZZLat
 
 Given a $\mathbf{Z}$-lattice $L$ and a list of matrices $G$ inducing
 endomorphisms of $L$ (or just one matrix $G$), return the lattice $L^G$,
@@ -1394,7 +1394,7 @@ If `ambient_representation` is `true` (the default), the endomorphism is
 represented with respect to the ambient space of $L$. Otherwise, the
 endomorphism is represented with respect to the basis of $L$.
 """
-function invariant_lattice(L::ZLat, G::Vector{<:MatElem};
+function invariant_lattice(L::ZZLat, G::Vector{<:MatElem};
                            ambient_representation::Bool = true)
   if length(G) == 0
     return L
@@ -1410,16 +1410,16 @@ function invariant_lattice(L::ZLat, G::Vector{<:MatElem};
   return M
 end
 
-function invariant_lattice(L::ZLat, G::MatElem;
+function invariant_lattice(L::ZZLat, G::MatElem;
                            ambient_representation::Bool = true)
   return kernel_lattice(L, G - 1, ambient_representation = ambient_representation)
 end
 
 @doc raw"""
-    coinvariant_lattice(L::ZLat, G::Vector{MatElem};
-                        ambient_representation::Bool = true) -> ZLat
-    coinvariant_lattice(L::ZLat, G::MatElem;
-                        ambient_representation::Bool = true) -> ZLat
+    coinvariant_lattice(L::ZZLat, G::Vector{MatElem};
+                        ambient_representation::Bool = true) -> ZZLat
+    coinvariant_lattice(L::ZZLat, G::MatElem;
+                        ambient_representation::Bool = true) -> ZZLat
 
 Given a $\mathbf{Z}$-lattice $L$ and a list of matrices $G$ inducing
 endomorphisms of $L$ (or just one matrix $G$), return the orthogonal
@@ -1430,7 +1430,7 @@ If `ambient_representation` is `true` (the default), the endomorphism is
 represented with respect to the ambient space of $L$. Otherwise, the
 endomorphism is represented with respect to the basis of $L$.
 """
-coinvariant_lattice(L::ZLat, G::Union{MatElem, Vector{<:MatElem}}; ambient_representation::Bool = true) =
+coinvariant_lattice(L::ZZLat, G::Union{MatElem, Vector{<:MatElem}}; ambient_representation::Bool = true) =
   orthogonal_submodule(L, invariant_lattice(L, G, ambient_representation = ambient_representation))
 
 ################################################################################
@@ -1440,22 +1440,22 @@ coinvariant_lattice(L::ZLat, G::Union{MatElem, Vector{<:MatElem}}; ambient_repre
 ################################################################################
 
 @doc raw"""
-    Base.in(v::Vector, L::ZLat) -> Bool
+    Base.in(v::Vector, L::ZZLat) -> Bool
 
 Return whether the vector `v` lies in the lattice `L`.
 """
-function Base.in(v::Vector, L::ZLat)
+function Base.in(v::Vector, L::ZZLat)
   @req length(v) == degree(L) "The vector should have the same length as the degree of the lattice."
   V = matrix(QQ, 1, length(v), v)
   return V in L
 end
 
 @doc raw"""
-    Base.in(v::QQMatrix, L::ZLat) -> Bool
+    Base.in(v::QQMatrix, L::ZZLat) -> Bool
 
 Return whether the row span of `v` lies in the lattice `L`.
 """
-function Base.in(v::QQMatrix, L::ZLat)
+function Base.in(v::QQMatrix, L::ZZLat)
   @req ncols(v) == degree(L) "The vector should have the same length as the degree of the lattice."
   @req nrows(v) == 1 "Must be a row vector."
   B = basis_matrix(L)
@@ -1464,7 +1464,7 @@ function Base.in(v::QQMatrix, L::ZLat)
 end
 
 @doc raw"""
-    is_primitive(L::ZLat, v::Union{Vector, QQMatrix}) -> Bool
+    is_primitive(L::ZZLat, v::Union{Vector, QQMatrix}) -> Bool
 
 Return whether the vector `v` is primitive in `L`.
 
@@ -1472,16 +1472,16 @@ A vector `v` in a $\mathbb Z$-lattice `L` is called primitive
 if for all `w` in `L` such that $v = dw$ for some integer `d`,
 then $d = \pm 1$.
 """
-is_primitive(::ZLat, ::Union{Vector, QQMatrix})
+is_primitive(::ZZLat, ::Union{Vector, QQMatrix})
 
-function is_primitive(L::ZLat, v::Vector{<: RationalUnion})
+function is_primitive(L::ZZLat, v::Vector{<: RationalUnion})
   @req v in L "v is not contained in L"
   is_zero(v) && return true
   M = lattice_in_same_ambient_space(L, matrix(QQ,1,length(v), v), check = false)
   return is_primitive(L, M)
 end
 
-function is_primitive(L::ZLat, v::QQMatrix)
+function is_primitive(L::ZZLat, v::QQMatrix)
   @req v in L "v is not contained in L"
   is_zero(v) && return true
   M = lattice_in_same_ambient_space(L, v, check = false)
@@ -1489,7 +1489,7 @@ function is_primitive(L::ZLat, v::QQMatrix)
 end
 
 @doc raw"""
-    divisibility(L::ZLat, v::Union{Vector, QQMatrix}) -> QQFieldElem
+    divisibility(L::ZZLat, v::Union{Vector, QQMatrix}) -> QQFieldElem
 
 Return the divisibility of `v` with respect to `L`.
 
@@ -1498,16 +1498,16 @@ we call the divisibility of `v` with the respect to `L` the
 non-negative generator of the fractional $\mathbb Z$-ideal
 $\Phi(v, L)$.
 """
-divisibility(::ZLat, ::Union{Vector, QQMatrix})
+divisibility(::ZZLat, ::Union{Vector, QQMatrix})
 
-function divisibility(L::ZLat, v::Vector{<: RationalUnion})
+function divisibility(L::ZZLat, v::Vector{<: RationalUnion})
   @req length(v) == degree(L) "The vector should have the same length as the degree of the lattice"
   imv = matrix(QQ, 1, length(v), v)*gram_matrix(ambient_space(L))*transpose(basis_matrix(L))
   imv = fractional_ideal(ZZ, vec(collect(imv)))
   return gen(imv)
 end
 
-function divisibility(L::ZLat, v::QQMatrix)
+function divisibility(L::ZZLat, v::QQMatrix)
   @req ncols(v) == degree(L) "The vector should have the same length as the degree of the lattice"
   @req nrows(v) == 1 "v must be a row vector"
   imv = v*gram_matrix(ambient_space(L))*transpose(basis_matrix(L))
@@ -1522,7 +1522,7 @@ end
 ################################################################################
 
 @doc raw"""
-    lll(L::ZLat, same_ambient::Bool = true) -> ZLat
+    lll(L::ZZLat, same_ambient::Bool = true) -> ZZLat
 
 Given an integral $\mathbb Z$-lattice `L` with basis matrix `B`, compute a basis
 `C` of `L` such that the gram matrix $G_C$ of `L` with respect to `C` is LLL-reduced.
@@ -1531,7 +1531,7 @@ By default, it creates the lattice in the same ambient space as `L`. This
 can be disabled by setting `same_ambient = false`.
 Works with both definite and indefinite lattices.
 """
-function lll(L::ZLat; same_ambient::Bool = true)
+function lll(L::ZZLat; same_ambient::Bool = true)
   rank(L) == 0 && return L
   def = is_definite(L)
   G = gram_matrix(L)
@@ -1560,9 +1560,9 @@ function lll(L::ZLat; same_ambient::Bool = true)
   end
   if same_ambient
     B2 = U*basis_matrix(L)
-    return lattice(ambient_space(L), B2, check = false)::ZLat
+    return lattice(ambient_space(L), B2, check = false)::ZZLat
   else
-    return Zlattice(gram = G2)
+    return integer_lattice(gram = G2)
   end
 end
 
@@ -1573,7 +1573,7 @@ end
 ################################################################################
 
 @doc raw"""
-    root_lattice_recognition(L::ZLat)
+    root_lattice_recognition(L::ZZLat)
 
 Return the ADE type of the root sublattice of `L`.
 
@@ -1591,7 +1591,7 @@ For more recognizable gram matrices use [`root_lattice_recognition_fundamental`]
 # Examples
 
 ```jldoctest
-julia> L = Zlattice(gram=ZZ[4  0 0  0 3  0 3  0;
+julia> L = integer_lattice(gram=ZZ[4  0 0  0 3  0 3  0;
                             0 16 8 12 2 12 6 10;
                             0  8 8  6 2  8 4  5;
                             0 12 6 10 2  9 5  8;
@@ -1602,16 +1602,16 @@ julia> L = Zlattice(gram=ZZ[4  0 0  0 3  0 3  0;
 Quadratic lattice of rank 8 and degree 8 over the rationals
 
 julia> R = root_lattice_recognition(L)
-([(:A, 1), (:D, 6)], ZLat[Quadratic lattice of rank 1 and degree 8 over the rationals, Quadratic lattice of rank 6 and degree 8 over the rationals])
+([(:A, 1), (:D, 6)], ZZLat[Quadratic lattice of rank 1 and degree 8 over the rationals, Quadratic lattice of rank 6 and degree 8 over the rationals])
 ```
 """
-function root_lattice_recognition(L::ZLat)
+function root_lattice_recognition(L::ZZLat)
   irr = irreducible_components(root_sublattice(L))
   return Tuple{Symbol, Int}[ADE_type(gram_matrix(i)) for i in irr], irr
 end
 
 @doc raw"""
-    irreducible_components(L::ZLat)
+    irreducible_components(L::ZZLat)
 
 Return the irreducible components ``L_i`` of the positive definite lattice ``L``.
 
@@ -1620,7 +1620,7 @@ This yields a maximal orthogonal splitting of `L` as
 L = \bigoplus_i L_i.
 ```
 """
-function irreducible_components(L::ZLat)
+function irreducible_components(L::ZZLat)
   @req is_definite(L) "L must be definite"
   if is_positive_definite(L)
     return _irreducible_components_pos_def(L)
@@ -1628,13 +1628,13 @@ function irreducible_components(L::ZLat)
   Lpos = rescale(L, -1)
   irr = _irreducible_components_pos_def(Lpos)
   V = ambient_space(L)
-  return ZLat[lattice(V, basis_matrix(i), check = false) for i in irr]
+  return ZZLat[lattice(V, basis_matrix(i), check = false) for i in irr]
 end
 
-function _irreducible_components_pos_def(L::ZLat, upper_bound=nothing)
+function _irreducible_components_pos_def(L::ZZLat, upper_bound=nothing)
   components1 =  _irreducible_components_gram(L)
-  components2 = ZLat[]
-  irreducible = ZLat[]
+  components2 = ZZLat[]
+  irreducible = ZZLat[]
   # special for root lattices
   for c in components1
     if all(abs(i)==2 for i in diagonal(gram_matrix(c)))
@@ -1669,13 +1669,13 @@ end
 # finds the irreducible components of the graph of the gram matrix
 # if it has only 2 on the diagonal, this is good enough
 # otherwise it may be insufficient
-function _irreducible_components_gram(L::ZLat)
+function _irreducible_components_gram(L::ZZLat)
   L = lll(L)
   V = ambient_space(L)
   B = basis_matrix(L)
   B = [B[i,:] for i in 1:nrows(B)]
   C = QQMatrix[]
-  components = ZLat[]
+  components = ZZLat[]
   while length(B) > 0
     basis = QQMatrix[]
     b = pop!(B)
@@ -1743,7 +1743,7 @@ function _irreducible_components_short_vectors(L, ub)
 end
 
 @doc raw"""
-    root_lattice_recognition_fundamental(L::ZLat)
+    root_lattice_recognition_fundamental(L::ZZLat)
 
 Return the ADE type of the root sublattice of `L`
 as well as the corresponding irreducible root sublattices
@@ -1762,7 +1762,7 @@ Output:
 # Examples
 
 ```jldoctest
-julia> L = Zlattice(gram=ZZ[4  0 0  0 3  0 3  0;
+julia> L = integer_lattice(gram=ZZ[4  0 0  0 3  0 3  0;
                             0 16 8 12 2 12 6 10;
                             0  8 8  6 2  8 4  5;
                             0 12 6 10 2  9 5  8;
@@ -1785,10 +1785,10 @@ julia> gram_matrix(R[1])
 
 ```
 """
-function root_lattice_recognition_fundamental(L::ZLat)
+function root_lattice_recognition_fundamental(L::ZZLat)
   V = ambient_space(L)
   ADE,components = root_lattice_recognition(L)
-  components_new = ZLat[]
+  components_new = ZZLat[]
   basis = zero_matrix(QQ,0,degree(L))
   for i in 1:length(ADE)
     ade = ADE[i]
@@ -1851,7 +1851,7 @@ function _ADE_type_with_isometry_irreducible(L)
 end
 
 @doc raw"""
-    root_sublattice(L::ZLat) -> ZLat
+    root_sublattice(L::ZZLat) -> ZZLat
 
 Return the sublattice spanned by the roots
 of length at most $2$.
@@ -1867,7 +1867,7 @@ vectors `x` of `L` with $|x^2|\leq 2$.
 
 # Examples
 ```jldoctest
-julia> L = Zlattice(gram = ZZ[2 0; 0 4]);
+julia> L = integer_lattice(gram = ZZ[2 0; 0 4]);
 
 julia> root_sublattice(L)
 Quadratic lattice of rank 1 and degree 2 over the rationals
@@ -1877,7 +1877,7 @@ julia> basis_matrix(root_sublattice(L))
 
 ```
 """
-function root_sublattice(L::ZLat)
+function root_sublattice(L::ZZLat)
   V = ambient_space(L)
   @req is_integral(L) "L must be integral"
   @req is_definite(L) "L must be definite"
@@ -1897,7 +1897,7 @@ end
 ################################################################################
 
 @doc raw"""
-    primitive_closure(M::ZLat, N::ZLat) -> ZLat
+    primitive_closure(M::ZZLat, N::ZZLat) -> ZZLat
 
 Given two $\mathbb Z$-lattices `M` and `N` with $N \subseteq \mathbb{Q} M$,
 return the primitive closure $M \cap \mathbb{Q} N$ of `N` in `M`.
@@ -1925,7 +1925,7 @@ false
 
 ```
 """
-function primitive_closure(M::ZLat, N::ZLat)
+function primitive_closure(M::ZZLat, N::ZZLat)
   @req ambient_space(M) === ambient_space(N) "Lattices must be in the same ambient space"
 
   ok, B = can_solve_with_solution(basis_matrix(M), basis_matrix(N), side = :left)
@@ -1938,7 +1938,7 @@ function primitive_closure(M::ZLat, N::ZLat)
 end
 
 @doc raw"""
-    is_primitive(M::ZLat, N::ZLat) -> Bool
+    is_primitive(M::ZZLat, N::ZZLat) -> Bool
 
 Given two $\mathbb Z$-lattices $N \subseteq M$, return whether `N` is a
 primitive sublattice of `M`.
@@ -1970,14 +1970,14 @@ julia> is_primitive(M, N)
 true
 ```
 """
-function is_primitive(M::ZLat, N::ZLat)
+function is_primitive(M::ZZLat, N::ZZLat)
   @req is_sublattice(M, N) "N must be a sublattice of M"
 
   return primitive_closure(M, N) == N
 end
 
 @doc raw"""
-    glue_map(L::ZLat, S::ZLat, R::ZLat; check=true)
+    glue_map(L::ZZLat, S::ZZLat, R::ZZLat; check=true)
                            -> Tuple{TorQuadModuleMor, TorQuadModuleMor, TorQuadModuleMor}
 
 Given three integral $\mathbb Z$-lattices `L`, `S` and `R`, with `S` and `R`
@@ -2031,7 +2031,7 @@ julia> is_bijective(glue)
 true
 ```
 """
-function glue_map(L::ZLat, S::ZLat, R::ZLat; check=true)
+function glue_map(L::ZZLat, S::ZZLat, R::ZZLat; check=true)
   if check
     @req is_integral(L) "The lattices must be integral"
     @req is_primitive(L, S) && is_primitive(L, R) "S and R must be primitive in L"
@@ -2070,7 +2070,7 @@ function glue_map(L::ZLat, S::ZLat, R::ZLat; check=true)
 end
 
 @doc raw"""
-    overlattice(glue_map::TorQuadModuleMor) -> ZLat
+    overlattice(glue_map::TorQuadModuleMor) -> ZZLat
 
 Given the glue map of a primitive extension of $\mathbb Z$-lattices
 $S+R \subseteq L$, return `L`.
@@ -2121,7 +2121,7 @@ end
 ################################################################################
 
 @doc raw"""
-    is_primary_with_prime(L::ZLat) -> Bool, ZZRingElem
+    is_primary_with_prime(L::ZZLat) -> Bool, ZZRingElem
 
 Given a $\mathbb Z$-lattice `L`, return whether `L` is primary, that is whether `L`
 is integral and its discriminant group (see [`discriminant_group`](@ref)) is a
@@ -2131,7 +2131,7 @@ second output.
 Note that for unimodular lattices, this function returns `(true, 1)`. If the
 lattice is not primary, the second return value is `-1` by default.
 """
-function is_primary_with_prime(L::ZLat)
+function is_primary_with_prime(L::ZZLat)
   @req is_integral(L) "L must be integral"
   d = ZZ(abs(det(L)))
   if d == 1
@@ -2145,28 +2145,28 @@ function is_primary_with_prime(L::ZLat)
 end
 
 @doc raw"""
-    is_primary(L::ZLat, p::Union{Integer, ZZRingElem}) -> Bool
+    is_primary(L::ZZLat, p::Union{Integer, ZZRingElem}) -> Bool
 
 Given an integral $\mathbb Z$-lattice `L` and a prime number `p`,
 return whether `L` is `p`-primary, that is whether its discriminant group
 (see [`discriminant_group`](@ref)) is a `p`-group.
 """
-function is_primary(L::ZLat, p::Union{Integer, ZZRingElem})
+function is_primary(L::ZZLat, p::Union{Integer, ZZRingElem})
   bool, q = is_primary_with_prime(L)
   return bool && q == p
 end
 
 @doc raw"""
-    is_unimodular(L::ZLat) -> Bool
+    is_unimodular(L::ZZLat) -> Bool
 
 Given an integral $\mathbb Z$-lattice `L`, return whether `L` is unimodular,
 that is whether its discriminant group (see [`discriminant_group`](@ref))
 is trivial.
 """
-is_unimodular(L::ZLat) = is_primary(L, 1)
+is_unimodular(L::ZZLat) = is_primary(L, 1)
 
 @doc raw"""
-    is_elementary_with_prime(L::ZLat) -> Bool, ZZRingElem
+    is_elementary_with_prime(L::ZZLat) -> Bool, ZZRingElem
 
 Given a $\mathbb Z$-lattice `L`, return whether `L` is elementary, that is whether
 `L` is integral and its discriminant group (see [`discriminant_group`](@ref)) is
@@ -2176,7 +2176,7 @@ returned as second output.
 Note that for unimodular lattices, this function returns `(true, 1)`. If the lattice
 is not elementary, the second return value is `-1` by default.
 """
-function is_elementary_with_prime(L::ZLat)
+function is_elementary_with_prime(L::ZZLat)
   bool, p = is_primary_with_prime(L)
   bool || return false, ZZ(-1)
   if !is_integer(p*scale(dual(L)))
@@ -2186,13 +2186,13 @@ function is_elementary_with_prime(L::ZLat)
 end
 
 @doc raw"""
-    is_elementary(L::ZLat, p::Union{Integer, ZZRingElem}) -> Bool
+    is_elementary(L::ZZLat, p::Union{Integer, ZZRingElem}) -> Bool
 
 Given an integral $\mathbb Z$-lattice `L` and a prime number `p`, return whether
 `L` is `p`-elementary, that is whether its discriminant group
 (see [`discriminant_group`](@ref)) is an elementary `p`-group.
 """
-function is_elementary(L::ZLat, p::Union{Integer, ZZRingElem})
+function is_elementary(L::ZZLat, p::Union{Integer, ZZRingElem})
   bool, q = is_elementary_with_prime(L)
   return bool && q == p
 end
@@ -2275,7 +2275,7 @@ function _decompose_in_reflections(G::QQMatrix, T::QQMatrix, p)
 end
 
 
-function _is_isometric_indef(L::ZLat, M::ZLat)
+function _is_isometric_indef(L::ZZLat, M::ZZLat)
   @req rank(L)>=3 "Strong approximation needs rank at least 3"
   @req degree(L)==rank(L) "Lattice needs to be full for now"
 
@@ -2299,7 +2299,7 @@ function _is_isometric_indef(L::ZLat, M::ZLat)
   return is_zero(isS(r))
 end
 
-function _is_isometric_indef_approx(L::ZLat, M::ZLat)
+function _is_isometric_indef_approx(L::ZZLat, M::ZZLat)
   # move to same ambient space
   qL = ambient_space(L)
   diag, trafo = Hecke._gram_schmidt(gram_matrix(qL), identity)
@@ -2373,11 +2373,11 @@ function _is_isometric_indef_approx(L::ZLat, M::ZLat)
 end
 
 @doc raw"""
-    index(L::ZLat, M::ZLat) -> IntExt
+    index(L::ZZLat, M::ZZLat) -> IntExt
 
 Return the index $[L:M]=|L/M|$ of $M$ in $L$.
 """
-function index(L::ZLat, M::ZLat)
+function index(L::ZZLat, M::ZZLat)
   b, M = is_sublattice_with_relations(L, M)
   b || error("M must be a sublattice of L to have a well defined index [L:M]")
   if rank(L)>rank(M)
@@ -2475,7 +2475,7 @@ function highest_root(ADE::Symbol, n)
   return w
 end
 
-function _weyl_vector(R::ZLat)
+function _weyl_vector(R::ZZLat)
   weyl = matrix(ZZ,1,rank(R),ones(1,rank(R)))*inv(gram_matrix(R))
   return weyl*basis_matrix(R)
 end
@@ -2486,13 +2486,13 @@ end
 Return the Leech lattice.
 """
 function leech_lattice()
-  R = Zlattice(gram=2*identity_matrix(ZZ,24))
+  R = integer_lattice(gram=2*identity_matrix(ZZ,24))
   N = maximal_even_lattice(R) # niemeier lattice
   return leech_lattice(N)[1]
 end
 
 @doc raw"""
-    leech_lattice(niemeier_lattice::ZLat) -> ZLat, QQMatrix, Int
+    leech_lattice(niemeier_lattice::ZZLat) -> ZZLat, QQMatrix, Int
 
 Return a triple `L, v, h` where `L` is the Leech lattice.
 
@@ -2504,7 +2504,7 @@ This implements the 23 holy constructions of the Leech lattice in [CS99](@cite).
 
 # Examples
 ```jldoctest leech
-julia> R = Zlattice(gram=2 * identity_matrix(ZZ, 24));
+julia> R = integer_lattice(gram=2 * identity_matrix(ZZ, 24));
 
 julia> N = maximal_even_lattice(R) # Some Niemeier lattice
 Quadratic lattice of rank 24 and degree 24 over the rationals
@@ -2549,7 +2549,7 @@ true
 
 ```
 """
-function leech_lattice(niemeier_lattice::ZLat)
+function leech_lattice(niemeier_lattice::ZZLat)
   # construct the leech lattice from one of the 23 holy constructions in SPLAG
   # we follow a mix of Ebeling and SPLAG
   # there seem to be some signs wrong in Ebeling?
@@ -2570,7 +2570,7 @@ function leech_lattice(niemeier_lattice::ZLat)
   @hassert :Lattice 1 all(h == coxeter_number(i...) for i in ade)
   rhoB = solve_left(basis_matrix(N), rho)
   v = QQ(1, h) * transpose(rhoB)
-  A = Zlattice(gram=gram_matrix(N))
+  A = integer_lattice(gram=gram_matrix(N))
   c = QQ(2 + 2//h)
   vv = vec(collect(v))
   sv = [matrix(QQ, 1, 24, vv - i)*basis_matrix(N) for (i, _) in Hecke.close_vectors(A, vv, c, c, check=false)]

--- a/src/QuadForm/ShortVectors.jl
+++ b/src/QuadForm/ShortVectors.jl
@@ -1,7 +1,7 @@
 export short_vectors, short_vectors_iterator, shortest_vectors, kissing_number
 
 @doc raw"""
-    short_vectors(L::ZLat, [lb = 0], ub, [elem_type = ZZRingElem]; check::Bool = true)
+    short_vectors(L::ZZLat, [lb = 0], ub, [elem_type = ZZRingElem]; check::Bool = true)
                                        -> Vector{Tuple{Vector{elem_type}, QQFieldElem}}
 
 Returns all tuples `(v, n)` such that `n = v G v^t` satisfies `lb <= n <= ub`, where `G` is the
@@ -17,7 +17,7 @@ See also [`short_vectors_iterator`](@ref) for an iterator version.
 short_vectors
 
 @doc raw"""
-    short_vectors_iterator(L::ZLat, [lb = 0], ub,
+    short_vectors_iterator(L::ZZLat, [lb = 0], ub,
                            [elem_type = ZZRingElem]; check::Bool = true)
                                     -> Tuple{Vector{elem_type}, QQFieldElem} (iterator)
 
@@ -33,10 +33,10 @@ See also [`short_vectors`](@ref).
 """
 short_vectors_iterator
 
-function short_vectors(L::ZLat, ub, elem_type::Type{S} = ZZRingElem; check::Bool = true) where {S}
+function short_vectors(L::ZZLat, ub, elem_type::Type{S} = ZZRingElem; check::Bool = true) where {S}
   if check
     @req ub >= 0 "the upper bound must be non-negative"
-    @req is_definite(L) && (rank(L)==0 || gram_matrix(L)[1, 1]>0) "Zlattice must be positive definite"
+    @req is_definite(L) && (rank(L)==0 || gram_matrix(L)[1, 1]>0) "integer_lattice must be positive definite"
   end
   if rank(L) == 0
     return Tuple{Vector{S}, QQFieldElem}[]
@@ -45,20 +45,20 @@ function short_vectors(L::ZLat, ub, elem_type::Type{S} = ZZRingElem; check::Bool
   return _short_vectors_gram(Vector, _G, ub, S)
 end
 
-function short_vectors_iterator(L::ZLat, ub, elem_type::Type{S} = ZZRingElem; check::Bool = true) where {S}
+function short_vectors_iterator(L::ZZLat, ub, elem_type::Type{S} = ZZRingElem; check::Bool = true) where {S}
   if check
     @req ub >= 0 "the upper bound must be non-negative"
-    @req is_definite(L) && (rank(L)==0 || gram_matrix(L)[1, 1]>0) "Zlattice must be positive definite"
+    @req is_definite(L) && (rank(L)==0 || gram_matrix(L)[1, 1]>0) "integer_lattice must be positive definite"
   end
   _G = gram_matrix(L)
   return _short_vectors_gram(LatEnumCtx, _G, ub, S)
 end
 
-function short_vectors(L::ZLat, lb, ub, elem_type::Type{S} = ZZRingElem; check=true) where {S}
+function short_vectors(L::ZZLat, lb, ub, elem_type::Type{S} = ZZRingElem; check=true) where {S}
   if check
     @req lb >= 0 "the lower bound must be non-negative"
     @req ub >= 0 "the upper bound must be non-negative"
-    @req is_definite(L) && (rank(L)==0 || gram_matrix(L)[1, 1]>0) "Zlattice must be positive definite"
+    @req is_definite(L) && (rank(L)==0 || gram_matrix(L)[1, 1]>0) "integer_lattice must be positive definite"
   end
   if rank(L) == 0
     return Tuple{Vector{S}, QQFieldElem}[]
@@ -67,11 +67,11 @@ function short_vectors(L::ZLat, lb, ub, elem_type::Type{S} = ZZRingElem; check=t
   return _short_vectors_gram(Vector, _G, lb, ub, S)
 end
 
-function short_vectors_iterator(L::ZLat, lb, ub, elem_type::Type{S} = ZZRingElem; check=true) where {S}
+function short_vectors_iterator(L::ZZLat, lb, ub, elem_type::Type{S} = ZZRingElem; check=true) where {S}
   if check
     @req lb >= 0 "the lower bound must be non-negative"
     @req ub >= 0 "the upper bound must be non-negative"
-    @req is_definite(L) && (rank(L) == 0 || gram_matrix(L)[1, 1]>0) "Zlattice must be positive definite"
+    @req is_definite(L) && (rank(L) == 0 || gram_matrix(L)[1, 1]>0) "integer_lattice must be positive definite"
   end
   _G = gram_matrix(L)
   return _short_vectors_gram(LatEnumCtx, _G, lb, ub, S)
@@ -84,7 +84,7 @@ end
 ################################################################################
 
 @doc raw"""
-    shortest_vectors(L::ZLat, [elem_type = ZZRingElem]; check::Bool = true)
+    shortest_vectors(L::ZZLat, [elem_type = ZZRingElem]; check::Bool = true)
                                                -> QQFieldElem, Vector{elem_type}, QQFieldElem}
 
 Returns the list of shortest non-zero vectors. Note that the vectors are
@@ -94,12 +94,12 @@ It is assumed and checked that `L` is positive definite.
 
 See also [`minimum`](@ref).
 """
-shortest_vectors(L::ZLat, ::ZZRingElem)
+shortest_vectors(L::ZZLat, ::ZZRingElem)
 
-function shortest_vectors(L::ZLat, elem_type::Type{S} = ZZRingElem; check::Bool = true) where {S}
+function shortest_vectors(L::ZZLat, elem_type::Type{S} = ZZRingElem; check::Bool = true) where {S}
   if check
     @req rank(L) > 0 "Lattice must have positive rank"
-    @req is_definite(L) && (rank(L) == 0 || gram_matrix(L)[1,1]>0) "Zlattice must be positive definite"
+    @req is_definite(L) && (rank(L) == 0 || gram_matrix(L)[1,1]>0) "integer_lattice must be positive definite"
   end
   _G = gram_matrix(L)
   min, V = _shortest_vectors_gram(_G)
@@ -114,11 +114,11 @@ end
 ################################################################################
 
 @doc raw"""
-    minimum(L::ZLat)
+    minimum(L::ZZLat)
 
 Return the minimum squared length among the non-zero vectors in `L`.
 """
-function minimum(L::ZLat)
+function minimum(L::ZZLat)
   @req rank(L) > 0 "Lattice must have positive rank"
   if !isdefined(L, :minimum)
     shortest_vectors(L)
@@ -134,14 +134,14 @@ end
 ################################################################################
 
 @doc raw"""
-    kissing_number(L::ZLat)
+    kissing_number(L::ZZLat)
 
 Return the Kissing number of the sphere packing defined by `L`.
 
 This is the number of non-overlapping spheres touching any
 other given sphere.
 """
-function kissing_number(L::ZLat)
+function kissing_number(L::ZZLat)
   @req rank(L) > 0 "Lattice must have positive rank"
   return 2 * length(shortest_vectors(L))
 end

--- a/src/QuadForm/Spaces.jl
+++ b/src/QuadForm/Spaces.jl
@@ -50,7 +50,7 @@ function image(f::AbstractSpaceMor, L::AbstractLat)
   end
 end
 
-function image(f::AbstractSpaceMor, L::ZLat)
+function image(f::AbstractSpaceMor, L::ZZLat)
   V = domain(f)
   @req V==ambient_space(L) "L not in domain"
   W = codomain(f)
@@ -59,7 +59,7 @@ function image(f::AbstractSpaceMor, L::ZLat)
   return lattice(W, B, isbasis=isbasis, check=false)
 end
 
-function preimage(f::AbstractSpaceMor, L::ZLat)
+function preimage(f::AbstractSpaceMor, L::ZZLat)
   V = domain(f)
   W = codomain(f)
   @req W==ambient_space(L) "L not in codomain"

--- a/src/QuadForm/Torsion.jl
+++ b/src/QuadForm/Torsion.jl
@@ -13,7 +13,7 @@ export discriminant_group, torsion_quadratic_module, normal_form, genus, is_genu
 # compute the torsion quadratic module M/N
 
 @doc raw"""
-    torsion_quadratic_module(M::ZLat, N::ZLat; gens::Union{Nothing, Vector{<:Vector}} = nothing,
+    torsion_quadratic_module(M::ZZLat, N::ZZLat; gens::Union{Nothing, Vector{<:Vector}} = nothing,
                                                     snf::Bool = true,
                                                     modulus::QQFieldElem = QQFieldElem(0),
                                                     check::Bool = true) -> TorQuadModule
@@ -27,7 +27,7 @@ generators of the abelian group $M/N$.
 If `snf` is `true`, the underlying abelian group will be in Smith normal form.
 Otherwise, the images of the basis of $M$ will be used as the generators.
 """
-function torsion_quadratic_module(M::ZLat, N::ZLat; gens::Union{Nothing, Vector{<:Vector}} = nothing,
+function torsion_quadratic_module(M::ZZLat, N::ZZLat; gens::Union{Nothing, Vector{<:Vector}} = nothing,
                                                     snf::Bool = true,
                                                     modulus::QQFieldElem = QQFieldElem(0),
                                                     modulus_qf::QQFieldElem = QQFieldElem(0),
@@ -101,7 +101,7 @@ function torsion_quadratic_module(M::ZLat, N::ZLat; gens::Union{Nothing, Vector{
 end
 
 @doc raw"""
-    discriminant_group(L::ZLat) -> TorQuadModule
+    discriminant_group(L::ZZLat) -> TorQuadModule
 
 Return the discriminant group of `L`.
 
@@ -115,7 +115,7 @@ $$D \times D \to \Q / \Z \qquad (x,y) \mapsto \Phi(x,y) + \Z.$$
 If `L` is even, then the discriminant group is equipped with the discriminant
 quadratic form $D \to \Q / 2 \Z, x \mapsto \Phi(x,x) + 2\Z$.
 """
-@attr function discriminant_group(L::ZLat)::TorQuadModule
+@attr function discriminant_group(L::ZZLat)::TorQuadModule
   @req is_integral(L) "The lattice must be integral"
   if rank(L) == 0
     T = torsion_quadratic_module(dual(L), L, modulus = one(QQ), modulus_qf = QQ(2))
@@ -167,14 +167,14 @@ Return the underlying abelian group of `T`.
 abelian_group(T::TorQuadModule) = T.ab_grp
 
 @doc raw"""
-    cover(T::TorQuadModule) -> ZLat
+    cover(T::TorQuadModule) -> ZZLat
 
 For $T=M/N$ this returns $M$.
 """
 cover(T::TorQuadModule) = T.cover
 
 @doc raw"""
-    relations(T::TorQuadModule) -> ZLat
+    relations(T::TorQuadModule) -> ZZLat
 
 For $T=M/N$ this returns $N$.
 """
@@ -1385,7 +1385,7 @@ function torsion_quadratic_module(q::QQMatrix)
   Q = change_base_ring(FlintZZ, d * q)
   S, U, V = snf_with_transform(Q)
   D = change_base_ring(FlintQQ, U) * q * change_base_ring(FlintQQ, V)
-  L = Zlattice(1//d * identity_matrix(QQ, nrows(q)), gram = d^2 * q)
+  L = integer_lattice(1//d * identity_matrix(QQ, nrows(q)), gram = d^2 * q)
   denoms = [denominator(D[i, i]) for i in 1:ncols(D)]
   rels = diagonal_matrix(denoms) * U
   LL = lattice(ambient_space(L), 1//d * change_base_ring(QQ, rels))
@@ -1643,7 +1643,7 @@ torsion quadratic modules.
 
 # Examples
 ```jldoctest
-julia> L = Zlattice(gram=matrix(ZZ, [[2,-1,0,0],[-1,2,-1,-1],[0,-1,2,0],[0,-1,0,2]]));
+julia> L = integer_lattice(gram=matrix(ZZ, [[2,-1,0,0],[-1,2,-1,-1],[0,-1,2,0],[0,-1,0,2]]));
 
 julia> T = Hecke.discriminant_group(L);
 
@@ -1667,7 +1667,7 @@ function brown_invariant(T::TorQuadModule)
 end
 
 @doc raw"""
-    genus(T::TorQuadModule, signature_pair::Tuple{Int, Int}) -> ZGenus
+    genus(T::TorQuadModule, signature_pair::Tuple{Int, Int}) -> ZZGenus
 
 Return the genus of an integer lattice with discriminant group `T` and the
 given `signature_pair`. If no such genus exists, raise an error.
@@ -1690,7 +1690,7 @@ function genus(T::TorQuadModule, signature_pair::Tuple{Int, Int})
   end
   disc = order(T)
   determinant = ZZ(-1)^s_minus * disc
-  local_symbols = ZpGenus[]
+  local_symbols = LocalZZGenus[]
   P = prime_divisors(2 * disc)
   sort!(P) # expects primes in ascending order
   for p in P
@@ -1702,7 +1702,7 @@ function genus(T::TorQuadModule, signature_pair::Tuple{Int, Int})
       G_p = change_base_ring(ZZ, G_p)
       genus_p = genus(G_p, p, valuation(elementary_divisors(D)[end], p))
     else
-      genus_p = ZpGenus(p, Vector{Int}[])
+      genus_p = LocalZZGenus(p, Vector{Int}[])
     end
     rk = rank - length(elementary_divisors(D))
     if rk > 0
@@ -1791,8 +1791,8 @@ function genus(T::TorQuadModule, signature_pair::Tuple{Int, Int})
     for b1 in block1
       for b2 in block2
         sym2[1:3] = [b0, b1, b2]
-        local_symbols[1] = ZpGenus(2, sym2)
-        genus = ZGenus(signature_pair, local_symbols)
+        local_symbols[1] = LocalZZGenus(2, sym2)
+        genus = ZZGenus(signature_pair, local_symbols)
         if _isglobal_genus(genus)
           # make the symbol sparse again.
           i = 0
@@ -1805,8 +1805,8 @@ function genus(T::TorQuadModule, signature_pair::Tuple{Int, Int})
             end
             i = i + 1
           end
-          local_symbols[1] = ZpGenus(2, sym2)
-          genus = ZGenus(signature_pair, local_symbols)
+          local_symbols[1] = LocalZZGenus(2, sym2)
+          genus = ZZGenus(signature_pair, local_symbols)
           return genus
         end
       end

--- a/src/QuadForm/Types.jl
+++ b/src/QuadForm/Types.jl
@@ -6,7 +6,7 @@ export TorQuadModule
 export TorQuadModuleElem
 export TorQuadModuleMor
 export VecSpaceRes
-export ZLat
+export ZZLat
 
 ################################################################################
 #
@@ -182,7 +182,7 @@ end
 #
 ###############################################################################
 
-@attributes mutable struct ZLat <: AbstractLat{QQField}
+@attributes mutable struct ZZLat <: AbstractLat{QQField}
   space::QuadSpace{QQField, QQMatrix}
   rational_span::QuadSpace{QQField, QQMatrix}
   basis_matrix::QQMatrix
@@ -197,7 +197,7 @@ end
   scale::QQFieldElem
   norm::QQFieldElem
 
-  function ZLat(V::QuadSpace{QQField, QQMatrix}, B::QQMatrix)
+  function ZZLat(V::QuadSpace{QQField, QQMatrix}, B::QQMatrix)
     z = new()
     z.space = V
     z.basis_matrix = B
@@ -220,7 +220,7 @@ end
 ```jldoctest
 julia> A = matrix(ZZ, [[2,0,0,-1],[0,2,0,-1],[0,0,2,-1],[-1,-1,-1,2]]);
 
-julia> L = Zlattice(gram = A);
+julia> L = integer_lattice(gram = A);
 
 julia> T = Hecke.discriminant_group(L)
 Finite quadratic module over Integer Ring with underlying abelian group
@@ -272,8 +272,8 @@ then the coordinates with respec to the basis of `M` are given by
 """
 @attributes mutable struct TorQuadModule
   ab_grp::GrpAbFinGen             # underlying abelian group
-  cover::ZLat                     # ZLat -> ab_grp, x -> x * proj
-  rels::ZLat
+  cover::ZZLat                     # ZZLat -> ab_grp, x -> x * proj
+  rels::ZZLat
   proj::ZZMatrix                  # is a projection and respects the forms
   gens_lift::Vector{Vector{QQFieldElem}}
   gens_lift_mat::QQMatrix

--- a/src/RieSrf/Theta.jl
+++ b/src/RieSrf/Theta.jl
@@ -303,7 +303,7 @@ function shortest_vectors(M::arb_mat)
   n = nrows(M)
   d = zero_matrix(ZZ, n, n)
   round_scale!(d, M, p)
-  L = Zlattice(d)
+  L = integer_lattice(d)
   U = shortest_vectors(L)
   return map(matrix, [map(R, u)*M for u in U])
 end

--- a/test/AlgAssAbsOrd/Conjugacy/Conjugacy.jl
+++ b/test/AlgAssAbsOrd/Conjugacy/Conjugacy.jl
@@ -126,7 +126,7 @@ end
   # integral
 
   # the minimal polynomial of f if \Phi_5, mb is the "absolute representation matrix"
-  # of a primitive 5-root of the unity. Then, changing the basis of the ZLat on which
+  # of a primitive 5-root of the unity. Then, changing the basis of the ZZLat on which
   # f acts, we can recover basis for which the induced action of f on the correspodning
   # hermitian lattice is given by multiplication by a 5-th root of the unity.
   # There are 4 of them and f is of order (size) 8, which is 4 times 2, so we should

--- a/test/QuadForm/CloseVectors.jl
+++ b/test/QuadForm/CloseVectors.jl
@@ -1,5 +1,5 @@
 @testset "QuadForm/CloseVectors" begin
-  L = Zlattice(gram = matrix(QQ, 3, 3, [1, 0, 0,
+  L = integer_lattice(gram = matrix(QQ, 3, 3, [1, 0, 0,
                                         0, 1, 0,
                                         0, 0, 1]))
   v = [-1, 0, 0]
@@ -46,7 +46,7 @@
                                     [0, 0, -1], [0, 0, 1], [-1, 0, -1], [-1, 0, 1],
                                     [0, -1, -1], [0, -1, 1]])
 
-  L = Zlattice(matrix(QQ, 1, 1, [2]))
+  L = integer_lattice(matrix(QQ, 1, 1, [2]))
   cl = @inferred close_vectors(L, [0], 1)
   @test first.(cl) == [[0]]
   cl = @inferred collect(close_vectors_iterator(L, [0], 1))
@@ -67,13 +67,13 @@
   cl = @inferred collect(close_vectors_iterator(L, [0], 9//2, 9//2))
   @test isempty(cl)
 
-  L = Zlattice(matrix(QQ, 1, 1, [2]); gram = matrix(QQ, 1, 1, [1//2]))
+  L = integer_lattice(matrix(QQ, 1, 1, [2]); gram = matrix(QQ, 1, 1, [1//2]))
   cl = @inferred close_vectors(L, [0], 20)
   @test issetequal(first.(cl), Vector{ZZRingElem}[[i] for i in -3:3])
   cl = @inferred collect(close_vectors_iterator(L, [0], 20))
   @test issetequal(first.(cl), Vector{ZZRingElem}[[i] for i in -3:3])
 
-  L = Zlattice(gram = identity_matrix(QQ, 6))
+  L = integer_lattice(gram = identity_matrix(QQ, 6))
   v = [-1, 0, -1, 0, -2, 0]
   u = 14//3
   cl = close_vectors(L, v, u)
@@ -83,7 +83,7 @@
   @test length(unique(cl)) == 485
   @test all(x -> x[2] == inner_product(rational_span(L), QQ.(x[1] - v), QQ.(x[1] - v)) <= u, cl)
 
-  L = Zlattice(gram = identity_matrix(QQ, 6))
+  L = integer_lattice(gram = identity_matrix(QQ, 6))
   v = [-1, 0, -1, 0, -2, 0]
   u = 14//3
   cl = close_vectors(L, v, u)
@@ -103,7 +103,7 @@
   cl = collect(close_vectors_iterator(L, v, 3, 4))
   @test length(cl) == 412
 
-  L = Zlattice(matrix(QQ, 2, 2, [1, 0, 0, 2]))
+  L = integer_lattice(matrix(QQ, 2, 2, [1, 0, 0, 2]))
   v = [1, 1]
   u = 3
   cl = close_vectors(L, v, u)
@@ -121,13 +121,13 @@
   @test length(cl) == 7
   @test all(x -> x[2] == inner_product(rational_span(L), QQ.(x[1] - v), QQ.(x[1] - v)) <= u, cl)
 
-  L = Zlattice(;gram = QQ[0 0; 0 0])
+  L = integer_lattice(;gram = QQ[0 0; 0 0])
   @test_throws ArgumentError close_vectors(L, [1, 1], 1)
   @test_throws ArgumentError close_vectors_iterator(L, [1, 1], 1)
-  L = Zlattice(;gram = QQ[-1 0; 0 -1])
+  L = integer_lattice(;gram = QQ[-1 0; 0 -1])
   @test_throws ArgumentError close_vectors(L, [1, 1], 1)
   @test_throws ArgumentError close_vectors_iterator(L, [1, 1], 1)
-  L = Zlattice(;gram = QQ[1 0; 0 1])
+  L = integer_lattice(;gram = QQ[1 0; 0 1])
   @test_throws ArgumentError close_vectors(L, [1, 1, 1], 1)
   @test_throws ArgumentError close_vectors_iterator(L, [1, 1, 1], 1)
   @test_throws ArgumentError close_vectors(L, [1], 1)

--- a/test/QuadForm/Database.jl
+++ b/test/QuadForm/Database.jl
@@ -1,7 +1,7 @@
 @testset "Database" begin
   DB = Hecke.lattice_database()
   L = lattice(DB, 1)
-  @assert L isa ZLat
+  @assert L isa ZZLat
 
   DB = Hecke.quadratic_lattice_database()
   L = lattice(DB, 1)

--- a/test/QuadForm/IO.jl
+++ b/test/QuadForm/IO.jl
@@ -23,7 +23,7 @@
   # For Zlattices
   B = matrix(FlintQQ, 6, 7 ,[1, -1, 0, 0, 0, 0, 0, 0, 1, -1, 0, 0, 0, 0, 0, 0, 1, -1, 0, 0, 0, 0, 0, 0, 1, -1, 0, 0, 0, 0, 0, 0, 1, -1, 0, 0, 0, 0, 0, 0, 1, -1]);
   G = matrix(FlintQQ, 7, 7 ,[3, 2, 2, 2, 2, 2, 1, 2, 3, 2, 2, 2, 2, 1, 2, 2, 3, 2, 2, 2, 1, 2, 2, 2, 3, 2, 2, 1, 2, 2, 2, 2, 3, 2, 1, 2, 2, 2, 2, 2, 3, 1, 1, 1, 1, 1, 1, 1, 1]);
-  L = Zlattice(B, gram = G)
+  L = integer_lattice(B, gram = G)
 
   @test Hecke.to_hecke_string(L) isa String
   @test Hecke.to_magma_string(L) isa String

--- a/test/QuadForm/Lattices.jl
+++ b/test/QuadForm/Lattices.jl
@@ -325,7 +325,7 @@ end
     M = kernel_lattice(E8, cyclotomic_polynomial(n)(h))
     hM = solve_left(basis_matrix(M), basis_matrix(M)*h)
     @test is_cyclotomic_polynomial(minpoly(hM))
-    M = Zlattice(gram = gram_matrix(M))
+    M = integer_lattice(gram = gram_matrix(M))
     H, res = hermitian_structure_with_transfer_data(M, hM)
     @test rank(H) == divexact(rank(M), euler_phi(n))
     @test domain(res) === ambient_space(M)

--- a/test/QuadForm/Morphism.jl
+++ b/test/QuadForm/Morphism.jl
@@ -1,5 +1,5 @@
 @testset "Morphism" begin
-  L = Zlattice(gram = zero_matrix(ZZ, 0, 0))
+  L = integer_lattice(gram = zero_matrix(ZZ, 0, 0))
   @test_throws ArgumentError shortest_vectors(L)
   @test_throws ArgumentError shortest_vectors(L, Vector{Int})
   @test_throws ArgumentError minimum(L)
@@ -8,7 +8,7 @@
   @test (@inferred short_vectors(L, 1, 2)) == []
 
   G = ZZ[2 1 -1 -1 -1 1 1 -1 0 0 0 0 0 0 0 0; 1 2 -1 -1 -1 1 1 -1 0 0 0 0 0 0 0 0; -1 -1 2 0 1 0 -1 1 0 0 0 0 0 0 0 0; -1 -1 0 2 1 -1 0 0 0 0 0 0 0 0 0 0; -1 -1 1 1 2 0 -1 0 0 0 0 0 0 0 0 0; 1 1 0 -1 0 2 0 -1 0 0 0 0 0 0 0 0; 1 1 -1 0 -1 0 2 -1 0 0 0 0 0 0 0 0; -1 -1 1 0 0 -1 -1 2 0 0 0 0 0 0 0 0; 0 0 0 0 0 0 0 0 2 1 1 0 1 1 1 0; 0 0 0 0 0 0 0 0 1 2 1 0 1 1 0 0; 0 0 0 0 0 0 0 0 1 1 2 0 0 0 1 0; 0 0 0 0 0 0 0 0 0 0 0 2 1 0 -1 0; 0 0 0 0 0 0 0 0 1 1 0 1 4 1 0 1; 0 0 0 0 0 0 0 0 1 1 0 0 1 4 0 0; 0 0 0 0 0 0 0 0 1 0 1 -1 0 0 8 1; 0 0 0 0 0 0 0 0 0 0 0 0 1 0 1 18]
-  L = Zlattice(gram=G)
+  L = integer_lattice(gram=G)
   @test length(shortest_vectors(L)) == 127
 
   A2 = root_lattice(:A, 2)

--- a/test/QuadForm/Quad/GenusRep.jl
+++ b/test/QuadForm/Quad/GenusRep.jl
@@ -70,7 +70,7 @@
   @test is_locally_isometric(L, LL, p)
 
   # Rank 2 case
-  # This is the Zlattice with basis [1 2; 3 4]
+  # This is the integer_lattice with basis [1 2; 3 4]
 
   Qx, x = polynomial_ring(FlintQQ, "x", cached = false)
   f = x - 1;
@@ -101,14 +101,14 @@
   V = quadratic_space(QQ, G)
   L = lattice(V, B)
   @test length(genus_representatives(L)) == 2
-  @test length(genus_representatives(Zlattice(gram = gram_matrix(L)))) == 2
+  @test length(genus_representatives(integer_lattice(gram = gram_matrix(L)))) == 2
 
-  L = Zlattice(ZZ[4 3; 3 8])
+  L = integer_lattice(ZZ[4 3; 3 8])
   @test length(genus_representatives(L)) == 4
 
   B = matrix(FlintQQ, 5, 5 ,[1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1]);
   G = matrix(FlintQQ, 5, 5 ,[-2, 0, 0, 0, 0, 0, -4, -2, 2, 2, 0, -2, -4, 0, 0, 0, 2, 0, -4, 0, 0, 2, 0, 0, -4]);
-  L = Zlattice(B, gram = G);
+  L = integer_lattice(B, gram = G);
   @test length(genus_representatives(L))==1
 
 end
@@ -1096,7 +1096,7 @@ end
 @testset "Genus Representatives non-full rank, definite" begin
   B = matrix(FlintQQ, 5, 8 ,[0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 2, 2, 0, 0, 0, 0, 0, 0, 4, 0, 1, 0, 0, 0, 0, 0, 31//2, 3//2, 1//2, 1, 0, 0, 0, 0, 5//2, 3//2, 0, 0, 1//2]);
   G = matrix(FlintQQ, 8, 8 ,[16, -8, 0, 0, 0, 0, 0, 0, -8, 16, 0, 0, 0, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 6]);
-  L = Zlattice(B, gram = G);
+  L = integer_lattice(B, gram = G);
   Ns = @inferred genus_representatives(L) #this uses the automorphisms
 
   L2 = Hecke._to_number_field_lattice(L)

--- a/test/QuadForm/Quad/NormalForm.jl
+++ b/test/QuadForm/Quad/NormalForm.jl
@@ -5,7 +5,7 @@ function _test_normal_form(G, D, B, p, prec = 0)
 end
 
 function _test_normal_form_isometry(M, D, p)
-  return is_locally_isometric(Zlattice(gram = M), Zlattice(gram = D), p)
+  return is_locally_isometric(integer_lattice(gram = M), integer_lattice(gram = D), p)
 end
 
 function _test_normal_form_congruence(G, D, B, p, prec = 0)

--- a/test/QuadForm/Quad/Spaces.jl
+++ b/test/QuadForm/Quad/Spaces.jl
@@ -413,7 +413,7 @@
     @test is_isometric(q,r, p)
     @test is_isometric(q,r, infF)
     @test is_isometric(q,r)
-    L = Zlattice(gram=ZZ[1 1; 1 2])
+    L = integer_lattice(gram=ZZ[1 1; 1 2])
     g = genus(L)
     c1 = Hecke.isometry_class(ambient_space(L))
     c2 = Hecke.rational_isometry_class(g)

--- a/test/QuadForm/Quad/ZGenus.jl
+++ b/test/QuadForm/Quad/ZGenus.jl
@@ -1,4 +1,4 @@
-@testset "ZGenus" begin
+@testset "ZZGenus" begin
   A = matrix(ZZ, 2, 2, [1, 1, 1, 1])
   @test (false, 1) == Hecke._iseven(A)
   A = matrix(ZZ, 2, 2, [2, 1, 1, 2])
@@ -36,8 +36,8 @@
   @test Hecke._two_adic_symbol(A, 2) == [[0, 2, 3, 1, 4], [1, 1, 1, 1, 1], [2, 1, 1, 1, 1]]
 
   #equality testing
-  g1 = ZpGenus(2,[[0, 2, 7, 0, 0], [3, 1, 7, 1, 7]])
-  g2 = ZpGenus(2,[[0, 2, 3, 0, 0], [3, 1, 3, 1, 3]])
+  g1 = LocalZZGenus(2,[[0, 2, 7, 0, 0], [3, 1, 7, 1, 7]])
+  g2 = LocalZZGenus(2,[[0, 2, 3, 0, 0], [3, 1, 3, 1, 3]])
   @test g1 != g2
 
   g1 = genus(A, 3)
@@ -114,8 +114,8 @@
   @test size(Hecke._local_genera(2, 3, 1, 0, 2, true))[1]==4
   @test size(Hecke._local_genera(5, 2, 2, 0, 2, true))[1]==6
 
-  @test length(Zgenera((2,2), 10, even=true))==0  # check that a bug in catesian_product_iterator is fixed
-  @test 4 == length(Zgenera((4,0), 125, even=true))
+  @test length(integer_genera((2,2), 10, even=true))==0  # check that a bug in catesian_product_iterator is fixed
+  @test 4 == length(integer_genera((4,0), 125, even=true))
   G = genus(diagonal_matrix(map(ZZ,[2, 4, 18])))
   @test 36 == level(G)
   G = genus(diagonal_matrix(map(ZZ,[2, 4, 18])))
@@ -138,7 +138,7 @@
   A = diagonal_matrix(ZZRingElem[2, -4, 6, 8])
   G = genus(A)
   q1 = discriminant_group(G)
-  q2 = discriminant_group(Zlattice(gram=A))
+  q2 = discriminant_group(integer_lattice(gram=A))
 
   A = matrix(ZZ, 0, 0, [])
   g2 = genus(A, 2)
@@ -245,7 +245,7 @@
   @test !Hecke._isglobal_genus(G)
 
 
-  L = Zlattice(gram=matrix(ZZ, 2, 2, [0, 1, 1, 0]))
+  L = integer_lattice(gram=matrix(ZZ, 2, 2, [0, 1, 1, 0]))
   G = genus(L)
   g2 = genus(L, 2)
   g7 = genus(L, 7)
@@ -253,13 +253,13 @@
   @test local_symbol(G, 7) == g7
   q = discriminant_group(G) # corner case
   @test order(q) == 1
-  L2 = Zlattice(gram=2*ZZ[2 1; 1 2])
+  L2 = integer_lattice(gram=2*ZZ[2 1; 1 2])
   G2 = genus(L2)
   @test genus(direct_sum(L,L2)[1]) == direct_sum(G, G2)
   @test length(representatives(G2)) == 1
   @test representative(G2)===representative(G2) # caching
 
-  G = Zgenera((8,0), 1, even=true)[1]
+  G = integer_genera((8,0), 1, even=true)[1]
   @test mass(G) == 1//696729600
 
   G = genus(diagonal_matrix(ZZRingElem[1, 3, 9]),3)
@@ -281,7 +281,7 @@
   genus_orders_sage = [[1, 1], [1], [1, 1], [1, 1, 1, 1], [1, 1], [1, 1], [1, 1], [1, 1, 1], [1, 1, 1, 1, 1, 1], [1, 1], [1, 1], [1, 1, 1, 1], [1, 1], [1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1, 1], [1, 1], [1, 1, 1], [1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1], [1, 1], [1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 2, 2], [1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1], [1, 1, 1, 1], [1, 1], [1, 1, 1, 1, 1], [1, 1, 1, 1], [1, 2], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], [1, 2], [1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1], [1, 1], [1, 1, 1, 1], [1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1], [1, 1], [1, 1], [1, 1, 1, 1, 1, 1, 1, 1], [1, 1, 2, 2, 2, 2], [1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1], [1, 1, 1, 1], [1, 1], [1, 1], [1, 1, 1, 1, 1, 1, 1, 1], [1, 1], [1, 1], [1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1], [1, 1, 1, 1, 1, 1, 1, 1, 1], [1, 1], [1, 1], [1, 1, 1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [2, 2], [1, 1, 1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 2, 2, 2, 2], [1, 2], [1, 1], [1, 1, 1, 1, 1, 1, 1, 1], [1, 1, 1, 1], [1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1], [1, 1], [1, 1, 1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1], [1, 1], [1, 1, 1], [1, 1, 1, 1, 2, 2], [1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2], [1, 2], [1, 1, 1, 1], [1, 1], [1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1, 1], [1, 1], [1, 1], [1, 1, 1, 1, 1, 1, 1, 1], [1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1, 1], [1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1], [1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], [1, 1, 3, 3, 3, 3], [1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1], [1, 1], [1, 1, 1, 1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1], [1, 1, 1, 1, 1, 1, 1, 1], [1, 1, 1, 1], [1, 1], [1, 1, 1, 1, 1, 1, 1, 1], [1, 1, 1, 2, 2, 2], [1, 1], [1, 1, 1, 1], [1, 1], [1, 1, 1, 1, 1, 1, 1, 1], [1, 1, 2, 2], [2, 2], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], [1, 1, 2, 2], [1, 2], [1, 1, 1, 1, 1, 1], [1, 2, 2, 2], [1, 1], [1, 1, 1, 1, 1, 1], [1, 1], [1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 2, 2], [1, 1], [1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1], [1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1, 1], [1, 1], [1, 1], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], [1, 1, 3, 3, 4, 4], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1], [1, 1, 1, 1], [1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1, 1], [1, 1, 1, 1], [1, 2], [1, 1], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], [1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 2, 2], [1, 1, 1, 1], [1, 1], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], [1, 1], [1, 2], [1, 1, 1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2], [1, 2], [1, 1, 1, 1, 1, 1], [1, 1]]
 
   for d in 1:(long_test ? 199 : 50)
-    L = [length(representatives(G)) for G in Zgenera((1,1), d)]
+    L = [length(representatives(G)) for G in integer_genera((1,1), d)]
     @test genus_orders_sage[d] == sort!(L)
   end
 
@@ -305,7 +305,7 @@
   end
 
   for (sig,d) in sigdet
-    for G in Zgenera(sig, d)
+    for G in integer_genera(sig, d)
       L = representative(G)
       spL = ambient_space(L)
       b = B[rank(L)-1]
@@ -356,7 +356,7 @@
 
   for d in 1:(long_test ? 50 : 10)
     for sig in [(2,0),(3,0),(4,0)]
-      for G in Zgenera(sig,d)
+      for G in integer_genera(sig,d)
         m = mass(G)
         L = representative(G)
         @test genus(L)==G
@@ -387,7 +387,7 @@
 
   # primary and elementary
 
-  L = Zlattice(gram=matrix(ZZ, [[2, -1, 0, 0, 0, 0],[-1, 2, -1, -1, 0, 0],[0, -1, 2, 0, 0, 0],[0, -1, 0, 2, 0, 0],[0, 0, 0, 0, 6, 3],[0, 0, 0, 0, 3, 6]]))
+  L = integer_lattice(gram=matrix(ZZ, [[2, -1, 0, 0, 0, 0],[-1, 2, -1, -1, 0, 0],[0, -1, 2, 0, 0, 0],[0, -1, 0, 2, 0, 0],[0, 0, 0, 0, 6, 3],[0, 0, 0, 0, 3, 6]]))
   Lr = root_sublattice(L) #this is D4
   Ls = orthogonal_submodule(L, Lr)
   G = genus(L)
@@ -421,7 +421,7 @@ end
   sym2 = local_symbols(G)[1]
   @test automorphous_numbers(sym2) == [3, 5]
 
-  A = Zlattice(gram=ZZ[2 1 0; 1 2 0; 0 0 18])
+  A = integer_lattice(gram=ZZ[2 1 0; 1 2 0; 0 0 18])
   G = genus(A)
   sym = local_symbols(G)
   @test automorphous_numbers(sym[1]) == [1, 3, 5, 7]
@@ -449,14 +449,14 @@ end
   sym = local_symbols(G)
   @test automorphous_numbers(sym[1]) == [1, 2, 5]
 
-  L1 = Zlattice(gram=ZZ[6 3 0; 3 6 0; 0 0 2])
+  L1 = integer_lattice(gram=ZZ[6 3 0; 3 6 0; 0 0 2])
   g = genus(L1)
   # two classes in the improper spinor genus
   @test length(Hecke.proper_spinor_generators(g))==1
   @test !is_automorphous(g, 5)
 
   M1 = matrix(ZZ, 4, 4, [3,0,-1,1,0,3,-1,-1,-1,-1,6,0,1,-1,0,6])
-  L1 = Zlattice(gram=M1)
+  L1 = integer_lattice(gram=M1)
   g = genus(L1)
   @test Hecke.proper_spinor_generators(g) == [3]
   @test Hecke.improper_spinor_generators(g) == [] # unique in genus
@@ -470,7 +470,7 @@ end
   ZZ[64 0 32 0; 0 2 0 1; 32 0 32 0; 0 1 0 1],
   ZZ[64 32 48 40; 32 48 32 40; 48 32 39 35; 40 40 35 38],
   ZZ[16 12 0 0; 12 11 0 0; 0 0 16 4; 0 0 4 3]]
- L = [Zlattice(gram=g) for g in L]
+ L = [integer_lattice(gram=g) for g in L]
  G = [genus(i) for i in L]
  @test [length(Hecke.proper_spinor_generators(i)) == length(Hecke.improper_spinor_generators(i)) for i in G] == [1,0,1,0,1,1,0,0]
 
@@ -510,7 +510,7 @@ end
   G22 = direct_sum(G2, G)
   L2 = representative(G22)
   @test genus(L2) == G22
-  G = Zgenera((0,8), 1)[1]
+  G = integer_genera((0,8), 1)[1]
   G2 = rescale(G, -5)
   G3 = rescale(G, 7//92)
   G4 = rescale(G, -1//10000009)
@@ -530,30 +530,30 @@ end
   @test !is_isometric(repL2[1], repL2[2])
 
   # Enumeration
-  gen = @inferred Zgenera((1, 1), 4//3, min_scale = 1//18, max_scale = 12)
+  gen = @inferred integer_genera((1, 1), 4//3, min_scale = 1//18, max_scale = 12)
   @test length(gen) == 8
   @test all(g -> det(g) == -4//3, gen)
   @test all(g -> !is_integral(g), gen)
   @test all(g -> scale(g) in [1//9, 1//3, 2//9, 2//3], gen)
-  gen = @inferred Zgenera((1, 1), 4//3, min_scale = 1//18, max_scale = 12, even = true)
+  gen = @inferred integer_genera((1, 1), 4//3, min_scale = 1//18, max_scale = 12, even = true)
   @test isempty(gen)
-  @test_throws ArgumentError Zgenera((1,1), 4//3, min_scale = -1//18)
-  @test_throws ArgumentError Zgenera((1,1), 4//3, max_scale = -12)
-  gen1 = @inferred Zgenera((0,8), 5, even = true)
+  @test_throws ArgumentError integer_genera((1,1), 4//3, min_scale = -1//18)
+  @test_throws ArgumentError integer_genera((1,1), 4//3, max_scale = -12)
+  gen1 = @inferred integer_genera((0,8), 5, even = true)
   @test length(gen1) == 1
-  gen2 = @inferred Zgenera((0, 8), 5, min_scale = 1//5, even = true)
+  gen2 = @inferred integer_genera((0, 8), 5, min_scale = 1//5, even = true)
   @test length(gen2) == 1
   @test gen1 == gen2
-  gen3 = Zgenera((0,8), 5)
-  gen4 = Zgenera((0, 8), 5, min_scale = 1//5)
+  gen3 = integer_genera((0,8), 5)
+  gen4 = integer_genera((0, 8), 5, min_scale = 1//5)
   @test all(g -> g in gen4, gen3)
   @test all(g -> g in gen4, gen2)
-  @test isempty(Zgenera((0, 8), 1, min_scale = 2))
-  gen = @inferred Zgenera((0,8), 1, min_scale = 1//2, max_scale = 4)
+  @test isempty(integer_genera((0, 8), 1, min_scale = 2))
+  gen = @inferred integer_genera((0,8), 1, min_scale = 1//2, max_scale = 4)
   @test length(gen) == 53
 
   # Mass
-  gen = Zgenera((0,8), 16, even=true)
+  gen = integer_genera((0,8), 16, even=true)
   for g in gen
     k = rand(-50:50)
     while k == 0
@@ -580,7 +580,7 @@ end
   
   # Spinor genera
   M1 = matrix(ZZ, 4, 4, [3,0,-1,1,0,3,-1,-1,-1,-1,6,0,1,-1,0,6])
-  L = Zlattice(gram = M1)
+  L = integer_lattice(gram = M1)
   G = genus(L)
   G2 = rescale(G, 8//109)
   @test_throws ArgumentError Hecke.automorphous_numbers(local_symbol(G2, 109))

--- a/test/QuadForm/Quad/ZLattices.jl
+++ b/test/QuadForm/Quad/ZLattices.jl
@@ -114,21 +114,21 @@ end
 
   G = matrix(QQ, 2, 2, [2, 1, 1, 2])
   B = matrix(ZZ, 1, 2, [1, 0])
-  @test (@inferred Zlattice(B ;gram = G)) isa ZLat
-  @test (@inferred Zlattice(B)) isa ZLat
+  @test (@inferred integer_lattice(B ;gram = G)) isa ZZLat
+  @test (@inferred integer_lattice(B)) isa ZZLat
   B = matrix(QQ, 1, 2, [1, 0])
-  @test (@inferred Zlattice(B ;gram = G)) isa ZLat
-  @test (@inferred Zlattice(B)) isa ZLat
-  @test (@inferred Zlattice(B; gram = G, check=false)) isa ZLat
-  @test (@inferred Zlattice(gram = G, check=false)) isa ZLat
-  @test_throws ArgumentError Zlattice(gram = B)
+  @test (@inferred integer_lattice(B ;gram = G)) isa ZZLat
+  @test (@inferred integer_lattice(B)) isa ZZLat
+  @test (@inferred integer_lattice(B; gram = G, check=false)) isa ZZLat
+  @test (@inferred integer_lattice(gram = G, check=false)) isa ZZLat
+  @test_throws ArgumentError integer_lattice(gram = B)
 
   V = quadratic_space(FlintQQ, G)
   B = matrix(ZZ, 1, 2, [1, 0])
-  @test (@inferred lattice(V, B)) isa ZLat
+  @test (@inferred lattice(V, B)) isa ZZLat
   Lr1 = lattice(V, B)
   B = matrix(QQ, 1, 2, [1, 0])
-  @test (@inferred lattice(V, B)) isa ZLat
+  @test (@inferred lattice(V, B)) isa ZZLat
 
   B = matrix(GF(2), 1, 2, [1, 0])
   @test_throws MethodError lattice(V, B)
@@ -143,7 +143,7 @@ end
   @test (@inferred base_ring(Lr0)) isa ZZRing
 
   @test !(@inferred is_sublattice(Lr2, Lr1))
-  M = Zlattice(;gram = FlintQQ[2 2; 2 2])
+  M = integer_lattice(;gram = FlintQQ[2 2; 2 2])
   @test !(@inferred is_sublattice(Lr0, M))
   @test is_sublattice(Lr2, Lr0)
   @test is_sublattice(Lr1, lattice(V, QQ[2 0;]))
@@ -155,7 +155,7 @@ end
   # lattices of rank 0
 
   B = matrix(QQ, 0, 2, [])
-  @test (@inferred lattice(V, B)) isa ZLat
+  @test (@inferred lattice(V, B)) isa ZZLat
 
   # Gram matrix
 
@@ -193,7 +193,7 @@ end
 
   # root lattice recognition
 
-  L = Zlattice(gram=ZZ[4;])
+  L = integer_lattice(gram=ZZ[4;])
   LL, inj = direct_sum(L,L)
   i, j = inj
   @test LL == i(L)+j(L)
@@ -214,13 +214,13 @@ end
 
   B = matrix(FlintQQ, 6, 6 ,[1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1]);
   G = matrix(FlintQQ, 6, 6 ,[3, 1, -1, 1, 0, 0, 1, 3, 1, 1, 1, 1, -1, 1, 3, 0, 0, 1, 1, 1, 0, 4, 2, 2, 0, 1, 0, 2, 4, 2, 0, 1, 1, 2, 2, 4]);
-  L = Zlattice(B, gram = G);
+  L = integer_lattice(B, gram = G);
   R = root_lattice_recognition(L)
   @test (isempty(R[1]) && isempty(R[2]))
 
   B = matrix(FlintQQ, 19, 20 ,[1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, -1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
   G = matrix(FlintQQ, 20, 20 ,[-2, 0, 1, -1, -1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, 0, -4, 0, 0, 0, -1, -1, -2, -2, -2, 0, 0, 0, 0, 0, 0, 0, 0, -1, 0, 1, 0, -2, 1, 1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, 0, 1, -2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, 0, 1, 0, -2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, 0, 0, 0, -2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, 0, 0, 0, 0, -2, 0, -1, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -2, 0, 0, 0, 0, 0, -2, -1, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -2, 0, 0, 0, 0, -1, -1, -4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, -2, -1, 1, 1, 0, -1, -1, 0, -4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -2, -1, 1, -1, -1, -1, -1, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, -2, 1, -1, 0, -1, -1, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, -2, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, -1, 0, -2, -1, -1, -1, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, 0, 0, -1, -2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, -1, 0, -1, 0, -2, -1, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, -1, 1, -1, 0, -1, -2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, -1, 1, -1, 0, -1, -1, -2, 0, 0, 0, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -2, 0, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -2]);
-  rsL = Zlattice(B, gram = G);
+  rsL = integer_lattice(B, gram = G);
   @test length(root_lattice_recognition(rsL)[1]) == 4
   rsLp = rescale(rsL,-1)
   @test length(Hecke._irreducible_components_short_vectors(rsLp, 2))==4
@@ -236,7 +236,7 @@ end
   for (m, o) in lattices_and_aut_order
     n = length(m[1])
     G = matrix(FlintZZ, n, n, reduce(vcat, m))
-    L = Zlattice(gram = G)
+    L = integer_lattice(gram = G)
     Ge = automorphism_group_generators(L, ambient_representation = true)
     test_automorphisms(L, Ge, true)
     Ge = automorphism_group_generators(L, ambient_representation = false)
@@ -265,7 +265,7 @@ end
   l = number_of_lattices(D)
   for i in 1:min(l, 200)
     L = lattice(D, i)
-    L = Zlattice(gram = gram_matrix(L)) # to avoid caching
+    L = integer_lattice(gram = gram_matrix(L)) # to avoid caching
     Ge = automorphism_group_generators(L, ambient_representation = true)
     test_automorphisms(L, Ge, true)
     Ge = automorphism_group_generators(L, ambient_representation = false)
@@ -280,7 +280,7 @@ end
   @test all(m -> multiplicative_order(m) == 2, G)
   @test_throws ArgumentError automorphism_group_order(U)
 
-  g = Zgenera((1,1), 12)
+  g = integer_genera((1,1), 12)
   Lg = representative.(g)
   for L in Lg
     V = ambient_space(L)
@@ -294,14 +294,14 @@ end
   for (m, o) in lattices_and_aut_order
     n = length(m[1])
     G = matrix(FlintZZ, n, n, reduce(vcat, m))
-    L = Zlattice(gram = G)
+    L = integer_lattice(gram = G)
     X = _random_invertible_matrix(n, -3:3)
     @assert abs(det(X)) == 1
-    L2 = Zlattice(gram = X * G * transpose(X))
+    L2 = integer_lattice(gram = X * G * transpose(X))
     b, T = is_isometric_with_isometry(L, L2, ambient_representation = false)
     @test b
     @test T * gram_matrix(L2) * transpose(T) == gram_matrix(L)
-    L2 = Zlattice(X, gram = G)
+    L2 = integer_lattice(X, gram = G)
     b, T = is_isometric_with_isometry(L, L2, ambient_representation = false)
     @test b
     @test T * gram_matrix(L2) * transpose(T) == gram_matrix(L)
@@ -315,28 +315,28 @@ end
   l = number_of_lattices(D)
   for i in 1:min(l, 200)
     L = lattice(D, i)
-    L = Zlattice(gram = gram_matrix(L)) # to avoid caching
+    L = integer_lattice(gram = gram_matrix(L)) # to avoid caching
     n = rank(L)
     X = change_base_ring(FlintQQ, _random_invertible_matrix(n, -3:3))
     @assert abs(det(X)) == 1
-    L2 = Zlattice(gram = X * gram_matrix(L) * transpose(X))
+    L2 = integer_lattice(gram = X * gram_matrix(L) * transpose(X))
     b, T = is_isometric_with_isometry(L, L2, ambient_representation = false)
     @test b
     @test T * gram_matrix(L2) * transpose(T) == gram_matrix(L)
   end
 
   #discriminant of a lattice
-  L = Zlattice(ZZ[1 0; 0 1], gram = matrix(QQ, 2,2, [2, 1, 1, 2]))
+  L = integer_lattice(ZZ[1 0; 0 1], gram = matrix(QQ, 2,2, [2, 1, 1, 2]))
   @test discriminant(L) == -3
 
   G = matrix(ZZ, 2, 2, [2, 1, 1, 2])
-  L = Zlattice(gram=G)
+  L = integer_lattice(gram=G)
   @test norm(L)==2
   G = (1//4)*matrix(QQ, 2, 2, [2, 1, 1, 2])
-  L = Zlattice(gram=G)
+  L = integer_lattice(gram=G)
   @test norm(L)==1//2
   G = matrix(ZZ, 0, 0, [])
-  L = Zlattice(gram=G)
+  L = integer_lattice(gram=G)
   @test norm(L) == 0
   @test scale(L) == 0
 
@@ -390,7 +390,7 @@ end
          0 0 0 0 0 0 0 0 0 9 0 0;
          0 0 0 0 0 0 0 0 0 0 9 0;
          0 0 0 0 0 0 0 0 0 0 0 54]
-  L = Zlattice(gram = G)
+  L = integer_lattice(gram = G)
   LL = @inferred Hecke.maximal_integral_lattice(L)
   @test isone(norm(LL))
 
@@ -427,7 +427,7 @@ end
   M = kernel_lattice(L, f - 1, ambient_representation = false)
   @test basis_matrix(M) == QQ[1 1;]
 
-  L = Zlattice(QQ[1 0; 0 2])
+  L = integer_lattice(QQ[1 0; 0 2])
   f = matrix(QQ, 2, 2, [0, 1, 0, 0])
   @test_throws ErrorException kernel_lattice(L, f)
   M = kernel_lattice(L, f, ambient_representation = false)
@@ -515,7 +515,7 @@ end
   x2 = [2//1, 14//2, 5//1, 9//3]
   x4 = [2, 1, 0, 1, 2]
   v = [1//2]
-  l = Zlattice(matrix(QQ,1,1,[1//2;]))
+  l = integer_lattice(matrix(QQ,1,1,[1//2;]))
   @test !(x1 in L)
   @test_throws ArgumentError is_primitive(L, v)
   @test divisibility(L, x1) == 1//154
@@ -545,34 +545,34 @@ end
   E8 = root_lattice(:E, 8)
   @test mass(E8) == 1//automorphism_group_order(E8)
 
-  F23a = Zlattice(gram = matrix(ZZ,2,2,[2 1; 1 12]))
-  F23b = Zlattice(gram = matrix(ZZ,2,2,[4 1; 1 6]))
+  F23a = integer_lattice(gram = matrix(ZZ,2,2,[2 1; 1 12]))
+  F23b = integer_lattice(gram = matrix(ZZ,2,2,[4 1; 1 6]))
 
   @test mass(F23a) == mass(F23b) == 3//4
 
   # LLL-reduction
 
-  L = representative(Zgenera((0,16), 768, max_scale = 6, even=true)[2])
+  L = representative(integer_genera((0,16), 768, max_scale = 6, even=true)[2])
   LL = lll(L) # L and LL are equal since they are in the same space
   @test L == LL
 
   LL = lll(L, same_ambient = false) # L and LL are not equal, but isometric
   @test_broken false && is_isometric_with_isometry(L, LL)[1] # tests takes too long
 
-  L = representative(Zgenera((2,1), -1)[1])
+  L = representative(integer_genera((2,1), -1)[1])
   LL = lll(L)
   @test L == LL
   @test rescale(L, -1) == lll(rescale(L, -1))
 
-  L = representative(Zgenera((3,11), 1)[2])
+  L = representative(integer_genera((3,11), 1)[2])
   LL = lll(L)
   @test L == LL
 
-  L = representative(Zgenera((3,12), 3)[1])
+  L = representative(integer_genera((3,12), 3)[1])
   LL = lll(L)
   @test L == LL
 
-  L = Zlattice(gram=QQ[1//2;])
+  L = integer_lattice(gram=QQ[1//2;])
   @inferred lll(L)
 
   # Primitive extensions
@@ -626,7 +626,7 @@ end
 
   # primary and elementary lattices
 
-  L = Zlattice(gram=matrix(ZZ, [[2, -1, 0, 0, 0, 0],[-1, 2, -1, -1, 0, 0],[0, -1, 2, 0, 0, 0],[0, -1, 0, 2, 0, 0],[0, 0, 0, 0, 6, 3],[0, 0, 0, 0, 3, 6]]))
+  L = integer_lattice(gram=matrix(ZZ, [[2, -1, 0, 0, 0, 0],[-1, 2, -1, -1, 0, 0],[0, -1, 2, 0, 0, 0],[0, -1, 0, 2, 0, 0],[0, 0, 0, 0, 6, 3],[0, 0, 0, 0, 3, 6]]))
   @test_throws ArgumentError is_primary_with_prime(dual(L))
   bool, p = @inferred is_primary_with_prime(L)
   @test !bool && p == -1
@@ -651,8 +651,8 @@ end
 @testset "isometry testing" begin
   u = ZZ[-69 -46 -58 17; -81 -54 -68 20; -54 -36 -45 13; -241 -161 -203 60]
   @test abs(det(u))==1
-  L = Zlattice(gram=ZZ[0 2 0 0; 2 0 0 0; 0 0 2 1; 0 0 1 2])
-  M = Zlattice(gram=u*gram_matrix(L)*transpose(u))
+  L = integer_lattice(gram=ZZ[0 2 0 0; 2 0 0 0; 0 0 2 1; 0 0 1 2])
+  M = integer_lattice(gram=u*gram_matrix(L)*transpose(u))
   @test Hecke.is_isometric(L, M)
   f, r = Hecke._is_isometric_indef_approx(L, M);
   G = genus(L)
@@ -669,8 +669,8 @@ end
   @test !is_isometric_with_isometry(L1, L2)[1]
 
   # Example from Conway Sloane Chapter 15 p.393
-  L1 = Zlattice(gram=ZZ[2 1 0; 1 2 0; 0 0 18])
-  L2 = Zlattice(gram=ZZ[6 3 0; 3 6 0; 0 0 2])
+  L1 = integer_lattice(gram=ZZ[2 1 0; 1 2 0; 0 0 18])
+  L2 = integer_lattice(gram=ZZ[6 3 0; 3 6 0; 0 0 2])
   @test genus(L1)==genus(L2)
   @test !Hecke.is_isometric(L1, L2)
 end
@@ -689,7 +689,7 @@ end
 
 @testset "Constructor checks" begin
   m = matrix(QQ, 2, 1, [1; -4])
-  @test_throws ArgumentError Zlattice(m)
+  @test_throws ArgumentError integer_lattice(m)
 
   L = root_lattice(:E, 7)
   v = zero_matrix(QQ, 1, degree(L))
@@ -704,7 +704,7 @@ end
 let
   B = matrix(FlintQQ, 6, 6 ,[1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1])
   G = matrix(FlintQQ, 6, 6 ,[876708188094148315826780735392810, 798141405233250328867679564294410, -352823337641433300965521329447720, 326768950610851461363580717982402, -690595881941554449465975342845028, 433433545243019702766746394677218, 798141405233250328867679564294410, 867615301468758683549323652197099, -301315621373858240463110267500961, 316796431934778296047626373086339, -725765288914917260527454069649226, 505082964151083450666500945258490, -352823337641433300965521329447720, -301315621373858240463110267500961, 809946152369211852531731702980788, -343784636213856787915462553587466, 84764902049682607076640678540130, -613908853150167850995565570653796, 326768950610851461363580717982402, 316796431934778296047626373086339, -343784636213856787915462553587466, 219957919673551825679009958633894, -226934633316066727073394927118195, 298257387132139131540277459301842, -690595881941554449465975342845028, -725765288914917260527454069649226, 84764902049682607076640678540130, -226934633316066727073394927118195, 671443408734467545153681225010914, -277626128761200144008657217470664, 433433545243019702766746394677218, 505082964151083450666500945258490, -613908853150167850995565570653796, 298257387132139131540277459301842, -277626128761200144008657217470664, 640432299215298238271419741190578])
-  L = Zlattice(B, gram = G)
+  L = integer_lattice(B, gram = G)
   @test automorphism_group_order(L) == 2
   G = [ ZZ[15 0 2 0; 0 30 0 4; 2 0 32 0; 0 4 0 64],
         ZZ[0 15 0 2; 15 0 2 0; 0 2 0 32; 2 0 32 0]];

--- a/test/QuadForm/ShortVectors.jl
+++ b/test/QuadForm/ShortVectors.jl
@@ -45,7 +45,7 @@
                      2448, 4320, 2982, 2402, 2364, 512, 256, 306 ]
 
   # Floating point bounds
-  L = Zlattice(gram = QQ[1//2 0; 0 1//3])
+  L = integer_lattice(gram = QQ[1//2 0; 0 1//3])
   v = short_vectors(L, 0.1, 0.6)
   @test length(v) == 2
   v = short_vectors(L, 0.4, 0.6)
@@ -53,7 +53,7 @@
   @test v[1][1] == [1, 0]
   @test v[1][2] == 1//2
 
-  L = Zlattice(gram = QQ[1//2 0; 0 1//3])
+  L = integer_lattice(gram = QQ[1//2 0; 0 1//3])
   v = collect(short_vectors_iterator(L, 0.1, 0.6))
   @test length(v) == 2
   v = collect(short_vectors_iterator(L, 0.4, 0.6))
@@ -63,30 +63,30 @@
 
   G = QQ[37284162112275300417246466355574714960 -13475345948269524138620045643237003610;
          -13475345948269524138620045643237003610 4870297148658720162079534168117444310]
-  L = Zlattice(;gram = G)
+  L = integer_lattice(;gram = G)
   @test minimum(L) == 35600528619523312710
 
   gram = QQ[1 0 0 1; 0 1 0 0; 0 0 1 0; 1 0 0 13//10]
   delta = 9//10
-  L = Zlattice(;gram = gram)
+  L = integer_lattice(;gram = gram)
   sv = @inferred short_vectors_iterator(L, delta, Int)
   @test collect(sv) == Tuple{Vector{Int64}, QQFieldElem}[([1, 0, 0, -1], 3//10)]
   sv = @inferred short_vectors_iterator(L, delta, ZZRingElem)
   @test collect(sv) == Tuple{Vector{ZZRingElem}, QQFieldElem}[([1, 0, 0, -1], 3//10)]
 
-  L = Zlattice(;gram = identity_matrix(ZZ, 0))
+  L = integer_lattice(;gram = identity_matrix(ZZ, 0))
   sv = @inferred short_vectors(L, 1)
   @test collect(sv) == Tuple{Vector{ZZRingElem}, QQFieldElem}[]
   sv = @inferred short_vectors_iterator(L, 1)
   @test collect(sv) == Tuple{Vector{ZZRingElem}, QQFieldElem}[]
 
-  L = Zlattice(;gram = identity_matrix(ZZ, 0))
+  L = integer_lattice(;gram = identity_matrix(ZZ, 0))
   sv = @inferred short_vectors(L, 0, 1)
   @test collect(sv) == Tuple{Vector{ZZRingElem}, QQFieldElem}[]
   sv = @inferred short_vectors_iterator(L, 0, 1)
   @test collect(sv) == Tuple{Vector{ZZRingElem}, QQFieldElem}[]
 
-  L = Zlattice(;gram = identity_matrix(ZZ, 2))
+  L = integer_lattice(;gram = identity_matrix(ZZ, 2))
   sv = @inferred shortest_vectors(L)
   @test length(sv) == 2
 end

--- a/test/QuadForm/Torsion.jl
+++ b/test/QuadForm/Torsion.jl
@@ -4,7 +4,7 @@
   T = Hecke.TorQuadModule(A)
   @test order(T) == 1
   # discriminant_group group of a non full lattice
-  L = Zlattice(2*identity_matrix(ZZ,2))
+  L = integer_lattice(2*identity_matrix(ZZ,2))
   S = lattice(ambient_space(L),basis_matrix(L)[1,:])
   @test order(discriminant_group(S)) == 4
   @test discriminant_group(S) === discriminant_group(S)
@@ -14,7 +14,7 @@
                         [0, 0, 2, -1],
                         [-1 ,-1 ,-1 ,2]])
 
-  L = Zlattice(gram = D4_gram)
+  L = integer_lattice(gram = D4_gram)
   T = @inferred discriminant_group(L)
   @test elem_type(T) == typeof(gens(T)[1])
   @test order(T) == 4
@@ -28,7 +28,7 @@
   @test order(D1)==2
 
   q1 = discriminant_group(root_lattice(:D,4))
-  q2 = discriminant_group(Zlattice(gram=ZZ[0 2; 2 0]))
+  q2 = discriminant_group(integer_lattice(gram=ZZ[0 2; 2 0]))
   @test Hecke.gram_matrix_quadratic(q1) != Hecke.gram_matrix_quadratic(q2)
   @test Hecke.gram_matrix_bilinear(q1) == Hecke.gram_matrix_bilinear(q2)
 
@@ -67,7 +67,7 @@
   TT, mTT = @inferred sub(T, [T([1, 1//2, 1//2, 1])])
   @test order(TT) == 2
 
-  L = Zlattice(ZZ[1 0; 0 1])
+  L = integer_lattice(ZZ[1 0; 0 1])
   M = lattice(ambient_space(L), ZZ[2 0; 0 3])
   T = @inferred torsion_quadratic_module(L, M, gens = [[1, 1]])
   @test order(T) == 6
@@ -78,10 +78,10 @@
   @test_throws ArgumentError torsion_quadratic_module(L, lattice(ambient_space(L), QQ[1//2 0; 0 0]))
 
   #primary part of a TorQuadModule
-  L = Zlattice(matrix(ZZ, [[2,0,0],[0,2,0],[0,0,2]]))
+  L = integer_lattice(matrix(ZZ, [[2,0,0],[0,2,0],[0,0,2]]))
   T = Hecke.discriminant_group(L)
   @test basis_matrix(Hecke.cover(Hecke.primary_part(T,ZZRingElem(2))[1])) == matrix(QQ, 3, 3, [1//2, 0, 0, 0, 1//2, 0, 0, 0, 1//2])
-  L1 = Zlattice(identity_matrix(ZZ, 3))
+  L1 = integer_lattice(identity_matrix(ZZ, 3))
   T1 = torsion_quadratic_module((1//6)*L1, L1)
   @test gram_matrix(Hecke.cover(Hecke.primary_part(T1,ZZRingElem(2))[1])) == matrix(QQ, 3, 3, [1//4, 0, 0, 0, 1//4, 0, 0, 0, 1//4])
   @test ambient_space(Hecke.cover(Hecke.primary_part(T1, exponent(T1))[1]))==ambient_space(Hecke.cover(T1))
@@ -89,12 +89,12 @@
   @test gram_matrix(Hecke.cover(Hecke.primary_part(T1, exponent(T1))[1])) == gram_matrix(Hecke.cover(T1))
 
   #orthogonal submodule to a TorQuadModule
-  L = Zlattice(matrix(ZZ, [[2,0,0],[0,2,0],[0,0,2]]))
+  L = integer_lattice(matrix(ZZ, [[2,0,0],[0,2,0],[0,0,2]]))
   T = Hecke.discriminant_group(L)
   S, i = sub(T, gens(T))
   @test all([preimage(i,i(s))==s for s in gens(S)])
   @test basis_matrix(Hecke.cover(Hecke.orthogonal_submodule(T, S)[1])) == basis_matrix(L)
-  L1 = Zlattice(identity_matrix(ZZ,10))
+  L1 = integer_lattice(identity_matrix(ZZ,10))
   T1 = torsion_quadratic_module(L1, 3*L1)
   S1, _ = sub(T1, gens(T1)[1:5])
   @test ambient_space(Hecke.cover(Hecke.orthogonal_submodule(T1, S1)[1])) == ambient_space(L1)
@@ -118,19 +118,19 @@
 
 
   #test for normal form
-  L1 = Zlattice(gram=matrix(ZZ, [[-2,0,0],[0,1,0],[0,0,4]]))
+  L1 = integer_lattice(gram=matrix(ZZ, [[-2,0,0],[0,1,0],[0,0,4]]))
   T1 = Hecke.discriminant_group(L1)
   @test Hecke.gram_matrix_quadratic(normal_form(T1)[1]) == matrix(QQ, 2, 2, [1//2,0,0,1//4])
 
-  L = Zlattice(gram=QQ[-2 -1 -1 -1 1 1 1 -1 0 0 0 0 0 0 0 0; -1 -2 0 -1 0 0 0 -1 0 0 0 0 0 0 0 0; -1 0 -2 -1 1 1 1 0 0 0 0 0 0 0 0 0; -1 -1 -1 -2 1 1 1 0 0 0 0 0 0 0 0 0; 1 0 1 1 -2 -1 -1 0 0 0 0 0 0 0 0 0; 1 0 1 1 -1 -2 -1 0 0 0 0 0 0 0 0 0; 1 0 1 1 -1 -1 -2 0 0 0 0 0 0 0 0 0; -1 -1 0 0 0 0 0 -2 0 0 0 0 0 0 0 0; 0 0 0 0 0 0 0 0 -2 0 0 0 0 0 0 0; 0 0 0 0 0 0 0 0 0 -2 0 0 0 0 0 0; 0 0 0 0 0 0 0 0 0 0 -2 0 0 0 0 0; 0 0 0 0 0 0 0 0 0 0 0 -2 0 0 0 0; 0 0 0 0 0 0 0 0 0 0 0 0 -2 0 0 0; 0 0 0 0 0 0 0 0 0 0 0 0 0 -2 0 0; 0 0 0 0 0 0 0 0 0 0 0 0 0 0 -2 0; 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 -2])
+  L = integer_lattice(gram=QQ[-2 -1 -1 -1 1 1 1 -1 0 0 0 0 0 0 0 0; -1 -2 0 -1 0 0 0 -1 0 0 0 0 0 0 0 0; -1 0 -2 -1 1 1 1 0 0 0 0 0 0 0 0 0; -1 -1 -1 -2 1 1 1 0 0 0 0 0 0 0 0 0; 1 0 1 1 -2 -1 -1 0 0 0 0 0 0 0 0 0; 1 0 1 1 -1 -2 -1 0 0 0 0 0 0 0 0 0; 1 0 1 1 -1 -1 -2 0 0 0 0 0 0 0 0 0; -1 -1 0 0 0 0 0 -2 0 0 0 0 0 0 0 0; 0 0 0 0 0 0 0 0 -2 0 0 0 0 0 0 0; 0 0 0 0 0 0 0 0 0 -2 0 0 0 0 0 0; 0 0 0 0 0 0 0 0 0 0 -2 0 0 0 0 0; 0 0 0 0 0 0 0 0 0 0 0 -2 0 0 0 0; 0 0 0 0 0 0 0 0 0 0 0 0 -2 0 0 0; 0 0 0 0 0 0 0 0 0 0 0 0 0 -2 0 0; 0 0 0 0 0 0 0 0 0 0 0 0 0 0 -2 0; 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 -2])
   D = discriminant_group(L)
   nf = QQ[0 1//2 0 0 0 0 0 0 0 0; 1//2 0 0 0 0 0 0 0 0 0; 0 0 0 1//2 0 0 0 0 0 0; 0 0 1//2 0 0 0 0 0 0 0; 0 0 0 0 0 1//2 0 0 0 0; 0 0 0 0 1//2 0 0 0 0 0; 0 0 0 0 0 0 0 1//2 0 0; 0 0 0 0 0 0 1//2 0 0 0; 0 0 0 0 0 0 0 0 1//2 0; 0 0 0 0 0 0 0 0 0 3//2]
   @test Hecke.gram_matrix_quadratic(normal_form(D)[1]) == nf
 
 
-  L1 = Zlattice(gram=ZZ[-4 0 0; 0 4 0; 0 0 -2])
+  L1 = integer_lattice(gram=ZZ[-4 0 0; 0 4 0; 0 0 -2])
   AL1 = discriminant_group(L1)
-  L2 = Zlattice(gram=ZZ[-4 0 0; 0 -4 0; 0 0 2])
+  L2 = integer_lattice(gram=ZZ[-4 0 0; 0 -4 0; 0 0 2])
   AL2 = discriminant_group(L2)
   n1 = normal_form(AL1)[1]
   g1 = QQ[1//2   0   0;
@@ -139,7 +139,7 @@
   @test Hecke.gram_matrix_quadratic(n1) == g1
   n2 = normal_form(AL2)[1]
   @test Hecke.gram_matrix_quadratic(n2) == g1
-  L3 = Zlattice(gram=matrix(ZZ, [[2,0,0,-1],[0,2,0,-1],[0,0,2,-1],[-1,-1,-1,2]]))
+  L3 = integer_lattice(gram=matrix(ZZ, [[2,0,0,-1],[0,2,0,-1],[0,0,2,-1],[-1,-1,-1,2]]))
   T=torsion_quadratic_module((1//6)*dual(L3), L3)
   n3 = normal_form(T)[1]
   g3 = QQ[1//6 1//12      0     0     0     0     0     0;
@@ -162,30 +162,30 @@
   @test Hecke.gram_matrix_quadratic(nf) == QQ[1//2 0 0 0; 0 1//2 0 0; 0 0 3//16 0; 0 0 0 7//16]
 
   #test for brown invariant
-  L1 = Zlattice(gram=matrix(ZZ, [[2,-1,0,0],[-1,2,-1,-1],[0,-1,2,0],[0,-1,0,2]]))
+  L1 = integer_lattice(gram=matrix(ZZ, [[2,-1,0,0],[-1,2,-1,-1],[0,-1,2,0],[0,-1,0,2]]))
   T1 = discriminant_group(L1)
   @test Hecke.brown_invariant(T1) == 4
-  L2 = Zlattice(matrix(ZZ, 2,2,[4,2,2,4]))
+  L2 = integer_lattice(matrix(ZZ, 2,2,[4,2,2,4]))
   T2 = Hecke.discriminant_group(L2)
   @test Hecke.brown_invariant(T2) == 2
-  L3 = Zlattice(gram=matrix(ZZ, [[1,0,0],[0,1,0],[0,0,1]]))
+  L3 = integer_lattice(gram=matrix(ZZ, [[1,0,0],[0,1,0],[0,0,1]]))
   T3 = torsion_quadratic_module((1//10)*L3, L3)
   @test_throws ArgumentError Hecke.brown_invariant(T3)
 
 
   #test for genus
-  L = Zlattice(gram=diagonal_matrix(ZZRingElem[1,2,3,4]))
+  L = integer_lattice(gram=diagonal_matrix(ZZRingElem[1,2,3,4]))
   D = discriminant_group(L)
   @test genus(D, (4,0)) == genus(L)
-  L1 = Zlattice(gram=matrix(ZZ, [[2, -1, 0, 0, 0, 0],[-1, 2, -1, -1, 0, 0],[0, -1, 2, 0, 0, 0],[0, -1, 0, 2, 0, 0],[0, 0, 0, 0, 6, 3],[0, 0, 0, 0, 3, 6]]))
+  L1 = integer_lattice(gram=matrix(ZZ, [[2, -1, 0, 0, 0, 0],[-1, 2, -1, -1, 0, 0],[0, -1, 2, 0, 0, 0],[0, -1, 0, 2, 0, 0],[0, 0, 0, 0, 6, 3],[0, 0, 0, 0, 3, 6]]))
   T1 = discriminant_group(L1)
   @test genus(T1, (6,0)) == genus(L1)
 
   #test for is_genus
-  L = Zlattice(gram=diagonal_matrix(ZZRingElem[1,2,3,4]))
+  L = integer_lattice(gram=diagonal_matrix(ZZRingElem[1,2,3,4]))
   D = discriminant_group(L)
   @test is_genus(D, (4,0))
-  L1 = Zlattice(gram=matrix(ZZ, [[2, -1, 0, 0, 0, 0],[-1, 2, -1, -1, 0, 0],[0, -1, 2, 0, 0, 0],[0, -1, 0, 2, 0, 0],[0, 0, 0, 0, 6, 3],[0, 0, 0, 0, 3, 6]]))
+  L1 = integer_lattice(gram=matrix(ZZ, [[2, -1, 0, 0, 0, 0],[-1, 2, -1, -1, 0, 0],[0, -1, 2, 0, 0, 0],[0, -1, 0, 2, 0, 0],[0, 0, 0, 0, 6, 3],[0, 0, 0, 0, 3, 6]]))
   T1 = discriminant_group(L1)
   @test is_genus(T1, (6,0)) == true
   @test is_genus(T1, (4,2)) == false
@@ -202,7 +202,7 @@
   @test all(g == i(j(g)) for g in gens(N))
 
   # iterator
-  gen = Zgenera((0,6), 2^3*3^3*5^2)
+  gen = integer_genera((0,6), 2^3*3^3*5^2)
   disc = discriminant_group.(gen)
   @test all(T -> length(collect(T)) == order(T), disc)
 
@@ -215,7 +215,7 @@
 
   # isometry
 
-  L = Zlattice(gram=matrix(ZZ, [[2, -1, 0, 0, 0, 0],[-1, 2, -1, -1, 0, 0],[0, -1, 2, 0, 0, 0],[0, -1, 0, 2, 0, 0],[0, 0, 0, 0, 6, 3],[0, 0, 0, 0, 3, 6]]))
+  L = integer_lattice(gram=matrix(ZZ, [[2, -1, 0, 0, 0, 0],[-1, 2, -1, -1, 0, 0],[0, -1, 2, 0, 0, 0],[0, -1, 0, 2, 0, 0],[0, 0, 0, 0, 6, 3],[0, 0, 0, 0, 3, 6]]))
   T = discriminant_group(L)
   N, S = normal_form(T)
   bool, phi = @inferred is_isometric_with_isometry(T, N)
@@ -293,7 +293,7 @@
 
   B = matrix(FlintQQ, 3, 3 ,[1, 1, 0, 1, -1, 0, 0, 1, -1])
   G = matrix(FlintQQ, 3, 3 ,[1, 0, 0, 0, 1, 0, 0, 0, 1])
-  L1 = Zlattice(B, gram = G)
+  L1 = integer_lattice(B, gram = G)
   qL1 = discriminant_group(L1)
   Z = torsion_quadratic_module(QQ[1;])
   @test_throws ArgumentError direct_sum(qL1, Z)
@@ -301,7 +301,7 @@
 
   B = matrix(FlintQQ, 4, 4 ,[2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2, 0, 1, 1, 1, 1])
   G = matrix(FlintQQ, 4, 4 ,[1//2, 0, 0, 0, 0, 1//2, 0, 0, 0, 0, 1//2, 0, 0, 0, 0, 1//2])
-  L2 = Zlattice(B, gram = G)
+  L2 = integer_lattice(B, gram = G)
   qL2 = discriminant_group(L2)
   Z = torsion_quadratic_module(QQ[2;])
   q, _ = @inferred direct_product(qL2, Z)
@@ -320,7 +320,7 @@
 
   # primary/elementary
 
-  L = Zlattice(gram=matrix(ZZ, [[2, -1, 0, 0, 0, 0],[-1, 2, -1, -1, 0, 0],[0, -1, 2, 0, 0, 0],[0, -1, 0, 2, 0, 0],[0, 0, 0, 0, 6, 3],[0, 0, 0, 0, 3, 6]]))
+  L = integer_lattice(gram=matrix(ZZ, [[2, -1, 0, 0, 0, 0],[-1, 2, -1, -1, 0, 0],[0, -1, 2, 0, 0, 0],[0, -1, 0, 2, 0, 0],[0, 0, 0, 0, 6, 3],[0, 0, 0, 0, 3, 6]]))
   T = discriminant_group(L)
   Tsub, _ = sub(T, [2*T[1], 3*T[2]])
   @test_throws ArgumentError is_primary_with_prime(Tsub)
@@ -360,7 +360,7 @@
   @test is_isometric_with_isometry(qq + domain(qqqinq), q)[1]
 
   # Smith normal form
-  L = Zlattice(gram=matrix(ZZ, [[2, -1, 0, 0, 0, 0],[-1, 2, -1, -1, 0, 0],[0, -1, 2, 0, 0, 0],[0, -1, 0, 2, 0, 0],[0, 0, 0, 0, 6, 3],[0, 0, 0, 0, 3, 6]]))
+  L = integer_lattice(gram=matrix(ZZ, [[2, -1, 0, 0, 0, 0],[-1, 2, -1, -1, 0, 0],[0, -1, 2, 0, 0, 0],[0, -1, 0, 2, 0, 0],[0, 0, 0, 0, 6, 3],[0, 0, 0, 0, 3, 6]]))
   T = discriminant_group(L)
   Tsub, _ = sub(T, [T[1]+T[2], T[1]-T[2]])
   @test !is_snf(Tsub)

--- a/test/QuadForm/indefiniteLLL.jl
+++ b/test/QuadForm/indefiniteLLL.jl
@@ -114,66 +114,66 @@
   gamma_G8 = find_gamma(change_base_ring(QQ,G8))
   @test  gamma_H8 <= gamma_G8
 
-  L = Zlattice(gram = G8)
+  L = integer_lattice(gram = G8)
   L2 = lattice(ambient_space(L), U8*basis_matrix(L))
   L3 = lattice(ambient_space(L2), UU8*basis_matrix(L2))
   @test L == L3
 
-  gen1 = Zgenera((1,1),1)
+  gen1 = integer_genera((1,1),1)
   L1 = representative(gen1[1])
   H1,U1 = Hecke.lll_gram_indef_with_transform(change_base_ring(ZZ,gram_matrix(L1)))
   Lat1 = lattice(ambient_space(L1),U1*basis_matrix(L1))
   @test L1 == Lat1
 
-  gen2 = Zgenera((2,1),1)
+  gen2 = integer_genera((2,1),1)
   L2 = representative(gen2[1])
   H2,U2 = Hecke.lll_gram_indef_with_transform(change_base_ring(ZZ,gram_matrix(L2)))
   Lat2 = lattice(ambient_space(L2),U2*basis_matrix(L2))
   @test L2 == Lat2
 
-  gen3 = Zgenera((2,2),1)
+  gen3 = integer_genera((2,2),1)
   L3 = representative(gen3[1])
   H3,U3 = Hecke.lll_gram_indef_with_transform(change_base_ring(ZZ,gram_matrix(L3)))
   Lat3 = lattice(ambient_space(L3),U3*basis_matrix(L3))
   @test L3 == Lat3
 
-  gen4 = Zgenera((2,3),1)
+  gen4 = integer_genera((2,3),1)
   L4 = representative(gen4[1])
   H4,U4 = Hecke.lll_gram_indef_with_transform(change_base_ring(ZZ,gram_matrix(L4)))
   Lat4 = lattice(ambient_space(L4),U4*basis_matrix(L4))
   @test L4 == Lat4
 
-  gen5 = Zgenera((1,5),1)
+  gen5 = integer_genera((1,5),1)
   L5 = representative(gen5[1])
   H5,U5 = Hecke.lll_gram_indef_with_transform(change_base_ring(ZZ,gram_matrix(L5)))
   Lat5 = lattice(ambient_space(L5),U5*basis_matrix(L5))
   @test L5 == Lat5
 
-  gen6 = Zgenera((4,2),1)
+  gen6 = integer_genera((4,2),1)
   L6 = representative(gen6[1])
   H6,U6 = Hecke.lll_gram_indef_with_transform(change_base_ring(ZZ,gram_matrix(L6)))
   Lat6 = lattice(ambient_space(L6),U6*basis_matrix(L6))
   @test L6 == Lat6
 
-  gen7 = Zgenera((1,3),1)
+  gen7 = integer_genera((1,3),1)
   L7 = representative(gen7[1])
   H7,U7 = Hecke.lll_gram_indef_with_transform(change_base_ring(ZZ,gram_matrix(L7)))
   Lat7 = lattice(ambient_space(L7),U7*basis_matrix(L7))
   @test L7 == Lat7
 
-  gen8 = Zgenera((1,2),1)
+  gen8 = integer_genera((1,2),1)
   L8 = representative(gen8[1])
   H8,U8 = Hecke.lll_gram_indef_with_transform(change_base_ring(ZZ,gram_matrix(L8)))
   Lat8 = lattice(ambient_space(L8),U8*basis_matrix(L8))
   @test L8 == Lat8
 
-  gen9 = Zgenera((3,3),1)
+  gen9 = integer_genera((3,3),1)
   L9 = representative(gen9[1])
   H9,U9 = Hecke.lll_gram_indef_with_transform(change_base_ring(ZZ,gram_matrix(L9)))
   Lat9 = lattice(ambient_space(L9),U9*basis_matrix(L9))
   @test L9 == Lat9
 
-  gen10 = Zgenera((1,3),1)
+  gen10 = integer_genera((1,3),1)
   L10 = representative(gen10[1])
   H10,U10 = Hecke.lll_gram_indef_with_transform(change_base_ring(ZZ,gram_matrix(L10)))
   Lat10 = lattice(ambient_space(L10),U10*basis_matrix(L10))


### PR DESCRIPTION
Here are the changes:
- `ZLat` -> `ZZLat`
- `ZGenus` -> `ZZGenus`
- `ZpGenus` -> `LocalZZGenus`
- `Zlattice` -> `integer_lattice`
- `Zgenera` -> `integer_genera`

I have added the aliases regarding those changes, for backwards compatibility (and not to break Oscar).