### PR TITLE
Use `VarName` for GF constructors

### DIFF
--- a/src/Misc/FiniteField.jl
+++ b/src/Misc/FiniteField.jl
@@ -12,8 +12,8 @@ function FlintFiniteField(p::ZZRingElem; cached::Bool = true)
   return k, k(1)
 end
 
-GF(p::Integer, k::Int, s::Union{AbstractString,Symbol}=:o; cached::Bool = true) = FlintFiniteField(p, k, s, cached = cached)[1]
-GF(p::ZZRingElem, k::Int, s::Union{AbstractString,Symbol}=:o; cached::Bool = true) = FlintFiniteField(p, k, s, cached = cached)[1]
+GF(p::Integer, k::Int, s::VarName=:o; cached::Bool = true) = FlintFiniteField(p, k, s, cached = cached)[1]
+GF(p::ZZRingElem, k::Int, s::VarName=:o; cached::Bool = true) = FlintFiniteField(p, k, s, cached = cached)[1]
 
 ##
 ## rand for Flint-Finite fields

--- a/test/Misc/FiniteField.jl
+++ b/test/Misc/FiniteField.jl
@@ -127,7 +127,9 @@ end
 @testset "FqPolyRepField" begin
 
   for p in [31, 11, 101]
-    F = FiniteField(ZZRingElem(p), 2, "a")[1]
+    _ = FiniteField(ZZRingElem(p), 2, "a")[1]
+    _ = FiniteField(ZZRingElem(p), 2, 'a')[1]
+    F = FiniteField(ZZRingElem(p), 2, :a)[1]
     G, mG = unit_group(F)
     #Test generator
     g = mG(G[1])
@@ -169,7 +171,9 @@ end
 @testset "FqField" begin
 
   for p in [31, 11, 101]
-    F = Hecke.Nemo._GF(ZZRingElem(p), 2, "a")
+    _ = Hecke.Nemo._GF(ZZRingElem(p), 2, "a")
+    _ = Hecke.Nemo._GF(ZZRingElem(p), 2, 'a')
+    F = Hecke.Nemo._GF(ZZRingElem(p), 2, :a)
     G, mG = unit_group(F)
     #Test generator
     g = mG(G[1])


### PR DESCRIPTION
Resolves oscar-system/Oscar.jl#862.

This has to wait for corresponding changes in Nemo (nemocas/Nemo.jl#1444 and nemocas/Nemo.jl#1454).