### PR TITLE
Export some functions in `sparse/HNF.jl`

### DIFF
--- a/src/Sparse/HNF.jl
+++ b/src/Sparse/HNF.jl
@@ -1,3 +1,5 @@
+export reduce_full, find_row_starting_with, hnf_extend!, hnf_kannan_bachem
+
 ################################################################################
 #
 #  Reduction of sparse rows modulo sparse upper triangular matrices


### PR DESCRIPTION
https://docs.oscar-system.org/dev/Hecke/sparse/intro/ contains some functions that are not exported. This PR exports all of those, that are defined in `sparse/HNF.jl`.