### PR TITLE
Fix (html) docs `QuadForm/`

### DIFF
--- a/docs/src/quad_forms/Zgenera.md
+++ b/docs/src/quad_forms/Zgenera.md
@@ -63,7 +63,8 @@ is_integral(G::ZZGenus)
 [`discriminant_group(::ZZGenus)`](@ref)
 
 ### Primary genera
-```docs
+
+```@docs
 is_primary_with_prime(G::ZZGenus)
 is_primary(G::ZZGenus, p::Union{Integer, ZZRingElem})
 is_elementary_with_prime(G::ZZGenus)

--- a/docs/src/quad_forms/basics.md
+++ b/docs/src/quad_forms/basics.md
@@ -90,7 +90,7 @@ is_negative_definite(::AbstractSpace)
 is_definite(::AbstractSpace)
 ```
 
-Note that the `ishermitian` function tests whether the space is non-quadratic.
+Note that the `is_hermitian` function tests whether the space is non-quadratic.
 
 ### Examples
 
@@ -129,7 +129,7 @@ Q = quadratic_space(K, K[0 1; 1 0]);
 H = hermitian_space(E, 3);
 gram_matrix(Q, K[1 1; 2 0])
 gram_matrix(H, E[1 0 0; 0 1 0; 0 0 1])
-inner_product(Q, [1, 1], [0, 2])
+inner_product(Q, K[1  1], K[0  2])
 orthogonal_basis(H)
 diagonal(Q), diagonal(H)
 ```
@@ -219,9 +219,9 @@ sum of a finite collection of spaces. Note that the corresponding copies
 of the original spaces in the direct sum are pairwise orthogonal.
 
 ```@docs
-direct_sum(x::Vector{AbstractSpace})
-direct_product(x::Vector{AbstractSpace})
-biproduct(x::Vector{AbstractSpace})
+direct_sum(::Vector{AbstractSpace})
+direct_product(::Vector{AbstractSpace})
+biproduct(::Vector{AbstractSpace})
 ```
 
 ### Example
@@ -232,8 +232,8 @@ E, b = cyclotomix_field_as_cm_extensions(7);
 H = hermitian_space(E, 3);
 H2 = hermitian_space(E, E[-1 0 0; 0 1 0; 0 0 -1]);
 H3, inj, proj = biproduct(H, H2)
-isone(compose(inj[1], proj[1]))
-iszero(compose(inj[1], proj[2]))
+is_one(matrix(compose(inj[1], proj[1])))
+is_zero(matrix(compose(inj[1], proj[2])))
 ```
 ## Orthogonality operations
 
@@ -282,8 +282,9 @@ is_isotropic(H, p)
 Let $(V, \Phi)$ be a space over $E/K$ and let $\mathfrak p$ be a prime ideal
 of $\mathcal O_K$. $V$ is said to be *hyperbolic* locally at $\mathfrak p$ if
 the completion $V_{\mathfrak p}$ of $V$ can be decomposed as an orthogonal sum
-of dimension 2 spaces with Gram matrices of the form
-$$\left(\begin{array}{cc} 0&1\\1&0 \end{array}\right)$$.
+of hyperbolic planes. The hyperbolic plane is the space $(H, \Psi)$ of rank 2
+over $E/K$ such that there exists a basis $e_1, e_2$ of $H$ such that
+$\Psi(e_1, e_1) = \Psi(e_2, e_2) = 0$ and $\Psi(e_1, e_2) = 1$.
 
 ```@docs
 is_locally_hyperbolic(::HermSpace, ::NfOrdIdl)

--- a/docs/src/quad_forms/discriminant_group.md
+++ b/docs/src/quad_forms/discriminant_group.md
@@ -71,7 +71,7 @@ is_anti_isometric_with_anti_isometry(T::TorQuadModule, U::TorQuadModule)
 ```
 
 ### Primary and elementary modules
-```docs
+```@docs
 is_primary_with_prime(T::TorQuadModule)
 is_primary(T::TorQuadModule, p::Union{Integer, ZZRingElem})
 is_elementary_with_prime(T::TorQuadModule)
@@ -79,7 +79,7 @@ is_elementary(T::TorQuadModule, p::Union{Integer, ZZRingElem})
 ```
 
 ### Smith normal form
-```docs
+```@docs
 snf(T::TorQuadModule)
 is_snf(T::TorQuadModule)
 ```

--- a/docs/src/quad_forms/genusherm.md
+++ b/docs/src/quad_forms/genusherm.md
@@ -369,7 +369,7 @@ if $L'$ is a lattice over $E/K$ in the genus of $L$ (i.e. they are in the same g
 then $L'$ is isometric to one of the $L_i$'s, and these representatives are pairwise
 non-isometric. Then we define the *mass* of the genus $G(L)$ of $L$ to be
 ```math
-   \textnormal{mass}(G(L)) := \sum_{i=1}^n\frac{1}{\#\textnormal{Aut}(L_i)}.
+   \text{mass}(G(L)) := \sum_{i=1}^n\frac{1}{\#\text{Aut}(L_i)}.
 ```
 Note that since $L$ is definite, any lattice in the genus of $L$ is also definite, and the
 definition makes sense.
@@ -419,8 +419,7 @@ E, b = number_field(t^2 - a, "b");
 OK = maximal_order(K);
 p = prime_decomposition(OK, 2)[1][1];
 g1 = genus(HermLat, E, p, [(0, 1, 1, 0), (2, 2, -1, 1)], type = :det);
-infp = infinite_places(E);
-SEK = unique([r.base_field_place for r in infp if isreal(r.base_field_place) && !isreal(r)]);
+SEK = unique([restrict(r, K) for r in infinite_places(E) if isreal(restrict(r, K)) && !isreal(r)]);
 G1 = genus([g1], [(SEK[1], 1)]);
 L1 = representative(g1)
 L1 in g1
@@ -450,8 +449,7 @@ E, b = number_field(t^2 - a, "b");
 OK = maximal_order(K);
 p = prime_decomposition(OK, 2)[1][1];
 g1 = genus(HermLat, E, p, [(0, 1, 1, 0), (2, 2, -1, 1)], type = :det);
-infp = infinite_places(E);
-SEK = unique([r.base_field_place for r in infp if isreal(r.base_field_place) && !isreal(r)]);
+SEK = unique([restrict(r, K) for r in infinite_places(E) if isreal(restrict(r, K)) && !isreal(r)]);
 G1 = genus([g1], [(SEK[1], 1)]);
 D = matrix(E, 3, 3, [5//2*a - 4, 0, 0, 0, a, a, 0, a, -4*a + 8]);
 gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [1, 0, 0]), map(E, [a, 0, 0]), map(E, [b, 0, 0]), map(E, [a*b, 0, 0]), map(E, [0, 1, 0]), map(E, [0, a, 0]), map(E, [0, b, 0]), map(E, [0, a*b, 0]), map(E, [0, 0, 1]), map(E, [0, 0, a]), map(E, [0, 0, b]), map(E, [0, 0, a*b])];
@@ -479,9 +477,8 @@ K, a = CyclotomicRealSubfield(8, "a");
 Kt, t = K["t"];
 E, b = number_field(t^2 - a * t + 1);
 p = prime_decomposition(maximal_order(K), 2)[1][1];
-hermitian_local_genera(E, p, 4, 2, 4)
-infp = infinite_places(E);
-SEK = unique([r.base_field_place for r in infp if isreal(r.base_field_place) && !isreal(r)]);
+hermitian_local_genera(E, p, 4, 2, 0, 4)
+SEK = unique([restrict(r, K) for r in infinite_places(E) if isreal(restrict(r, K)) && !isreal(r)]);
 hermitian_genera(E, 3, Dict(SEK[1] => 1, SEK[2] => 1), 30 * maximal_order(E))
 ```
 

--- a/docs/src/quad_forms/integer_lattices.md
+++ b/docs/src/quad_forms/integer_lattices.md
@@ -57,8 +57,6 @@ ambient_space(L::ZZLat)
 basis_matrix(L::ZZLat)
 gram_matrix(L::ZZLat)
 rational_span(L::ZZLat)
-base_ring(::ZZLat)
-base_field(::ZZLat)
 ```
 
 ## Invariants
@@ -163,15 +161,15 @@ maximal_integral_lattice(L::ZZLat)
 
 ### Sublattices defined by endomorphisms
 ```@docs
-kernel_lattice(L::ZZLat, f::MatElem; ambient_representation::Bool = true)
-invariant_lattice(L::ZZLat, G::Vector{<:MatElem};
-                           ambient_representation::Bool = true)
+kernel_lattice(L::ZZLat, f::MatElem)
+invariant_lattice(L::ZZLat, G::Vector{<:MatElem})
+coinvariant_lattice(::ZZLat, ::Union{MatElem, Vector{<:MatElem}})
 ```
 
 ### Computing embeddings
 ```@docs
-embed(S::ZZLat, G::ZZGenus, primitive::Bool=true)
-embed_in_unimodular(S::ZZLat, pos, neg; primitive=true, even=true)
+embed(S::ZZLat, G::ZZGenus)
+embed_in_unimodular(::ZZLat, ::IntegerUnion, ::IntegerUnion)
 ```
 
 ## LLL, Short and Close Vectors

--- a/docs/src/quad_forms/lattices.md
+++ b/docs/src/quad_forms/lattices.md
@@ -262,9 +262,9 @@ are also direct products in this context. They are also sometimes called biprodu
 Depending on the user usage, it is possible to call one of the following functions.
 
 ```@docs
-direct_sum(x::Vector{AbstractLat})
-direct_product(x::Vector{AbstractLat})
-biproduct(x::Vector{AbstractLat})
+direct_sum(::Vector{AbstractLat})
+direct_product(::Vector{AbstractLat})
+biproduct(::Vector{AbstractLat})
 ```
 
 ---
@@ -280,8 +280,6 @@ Let $L$ be a lattice over $E/K$, in the space $(V, \Phi)$. We define:
 ```math
    \lbrack L^{\#} \colon L \rbrack_{\mathcal O_E} := \langle \left\{ \sigma \mid \sigma \in \text{Hom}_{\mathcal O_E}(L^{\#}, L) \right\} \rangle_{\mathcal O_E}.
 ```
-
-Note that these are fractional ideals of $\mathcal O_E$.
 
 ```@docs
 norm(::AbstractLat)
@@ -373,8 +371,9 @@ is_isotropic(Lquad, p)
 ## Automorphisms for definite lattices
 Let $L$ and $L'$ be two lattices over the same extension $E/K$, inside their
 respective ambient spaces $(V, \Phi)$ and $(V', \Phi')$. Similarly to homomorphisms
-of spaces, we define a *homomorphism of lattices* from $L$ to $L'$ to be an $E$-module
-homomorphism $f \colon L \to L'$ such that for all $x,y \in L$, one has
+of spaces, we define a *homomorphism of lattices* from $L$ to $L'$ to be an
+$\mathcal{O}_E$-module$ homomorphism $f \colon L \to L'$ such that for all
+$x,y \in L$, one has
 
 ```math
    \Phi'(f(x), f(y)) = \Phi(x,y).

--- a/src/QuadForm/Herm/Genus.jl
+++ b/src/QuadForm/Herm/Genus.jl
@@ -86,7 +86,7 @@ scale(G::HermLocalGenus, i::Int) = G.data[i][1]
 
 Given a local genus symbol `g` for hermitian lattices over $E/K$ at a prime
 $\mathfrak p$ of $\mathcal O_K$, return the scale of the Jordan block of minimum
-$\mathfrak P$-valuation, where $\mathfrakP$ is a prime ideal of $\mathcal O_E$
+$\mathfrak P$-valuation, where $\mathfrak{P}$ is a prime ideal of $\mathcal O_E$
 lying over $\mathfrak p$.
 """
 scale(g::HermLocalGenus) = prime(g)^(scale(g, i))

--- a/src/QuadForm/Lattices.jl
+++ b/src/QuadForm/Lattices.jl
@@ -732,7 +732,7 @@ end
 ################################################################################
 
 @doc raw"""
-    norm(L::AbstractLat) -> NfOrdFracIdl
+    norm(L::AbstractLat) -> NfAbsOrdFracIdl
 
 Return the norm of the lattice `L`. This is a fractional ideal of the fixed field
 of `L`.
@@ -1922,7 +1922,7 @@ direct_product(x::Vararg{AbstractLat}) = direct_product(collect(x))
 
 Given a collection of quadratic or hermitian lattices $L_1, \ldots, L_n$,
 return their biproduct $L := L_1 \oplus \ldots \oplus L_n$, together with
-the injections $L_i \toL$ and the projections $L \to L_i$ (seen as maps
+the injections $L_i \to L$ and the projections $L \to L_i$ (seen as maps
 between the corresponding ambient spaces).
 
 For objects of type `AbstractLat`, finite direct sums and finite direct

--- a/src/QuadForm/Quad/ZGenus.jl
+++ b/src/QuadForm/Quad/ZGenus.jl
@@ -2552,7 +2552,7 @@ end
 ################################################################################
 
 @doc raw"""
-    embed(S::ZZLat, G::Genus, primitive=true) -> Bool, embedding
+    embed(S::ZZLat, G::Genus, primitive::Bool=true) -> Bool, embedding
 
 Return a (primitive) embedding of the integral lattice `S` into some lattice in the genus of `G`.
 
@@ -2574,7 +2574,7 @@ function embed(S::ZZLat, G::ZZGenus, primitive::Bool=true)
 end
 
 @doc raw"""
-    embed_in_unimodular(S::ZZLat, pos, neg, primitive=true, even=true) -> Bool, L, S', iS, iR
+    embed_in_unimodular(S::ZZLat, pos::Int, neg::Int, primitive=true, even=true) -> Bool, L, S', iS, iR
 
 Return a (primitive) embedding of the integral lattice `S` into some
 (even) unimodular lattice of signature `(pos, neg)`.
@@ -2598,7 +2598,7 @@ julia> is_primitive(LK3, iNS)
 true
 ```
 """
-function embed_in_unimodular(S::ZZLat, pos, neg; primitive=true, even=true)
+function embed_in_unimodular(S::ZZLat, pos::IntegerUnion, neg::IntegerUnion; primitive=true, even=true)
   @vprint :Lattice 1 "computing embedding in L_$(n) \n"
   pS,kS, nS = signature_tuple(S)
   @req kS == 0 "S must be non-degenerate"

--- a/src/QuadForm/Quad/ZLattices.jl
+++ b/src/QuadForm/Quad/ZLattices.jl
@@ -8,7 +8,7 @@ export *,+, basis_matrix, ambient_space, base_ring, base_field, root_lattice,
 
 # scope & verbose scope: :Lattice
 @doc raw"""
-    basis_matrix(L::ZZLat)
+    basis_matrix(L::ZZLat) -> QQMatrix
 
 Return the basis matrix $B$ of the integer lattice $L$.
 
@@ -626,7 +626,7 @@ function is_sublattice_with_relations(M::ZZLat, N::ZZLat)
 ################################################################################
 
 @doc raw"""
-    root_lattice(R::Symbol, n::Int)
+    root_lattice(R::Symbol, n::Int) -> ZZLat
 
 Return the root lattice of type `R` given by `:A`, `:D` or `:E` with parameter `n`.
 """
@@ -713,7 +713,7 @@ end
 ################################################################################
 
 @doc raw"""
-    integer_lattice(S::Symbol, n::RationalUnion = 1) -> Zlat
+    integer_lattice(S::Symbol, n::RationalUnion = 1) -> ZZlat
 
 Given `S = :H` or `S = :U`, return a $\mathbb Z$-lattice admitting $n*J_2$ as
 Gram matrix in some basis, where $J_2$ is the 2-by-2 matrix with 0's on the
@@ -727,7 +727,7 @@ function integer_lattice(S::Symbol, n::RationalUnion = 1)
 end
 
 @doc raw"""
-    hyperbolic_plane_lattice(n::RationalUnion = 1)
+    hyperbolic_plane_lattice(n::RationalUnion = 1) -> ZZLat
 
 Return the hyperbolic plane with intersection form of scale `n`, that is,
 the unique (up to isometry) even unimodular hyperbolic $\mathbb Z$-lattice
@@ -948,7 +948,7 @@ end
 
 Return whether `L` and `M` are isometric over the `p`-adic integers.
 
-i.e. whether $L \otimes \Z_p \cong M\otimes \Z_p$.
+i.e. whether $L \otimes \mathbb{Z}_p \cong M\otimes \mathbb{Z}_p$.
 """
 function is_locally_isometric(L::ZZLat, M::ZZLat, p::Int)
   return is_locally_isometric(L, M, ZZRingElem(p))
@@ -1611,7 +1611,7 @@ function root_lattice_recognition(L::ZZLat)
 end
 
 @doc raw"""
-    irreducible_components(L::ZZLat)
+    irreducible_components(L::ZZLat) -> Vector{ZZLat}
 
 Return the irreducible components ``L_i`` of the positive definite lattice ``L``.
 
@@ -2481,7 +2481,7 @@ function _weyl_vector(R::ZZLat)
 end
 
 @doc raw"""
-    leech_lattice()
+    leech_lattice() -> ZZLat
 
 Return the Leech lattice.
 """

--- a/src/QuadForm/ShortVectors.jl
+++ b/src/QuadForm/ShortVectors.jl
@@ -114,7 +114,7 @@ end
 ################################################################################
 
 @doc raw"""
-    minimum(L::ZZLat)
+    minimum(L::ZZLat) -> QQFieldElem
 
 Return the minimum squared length among the non-zero vectors in `L`.
 """
@@ -134,7 +134,7 @@ end
 ################################################################################
 
 @doc raw"""
-    kissing_number(L::ZZLat)
+    kissing_number(L::ZZLat) -> Int
 
 Return the Kissing number of the sphere packing defined by `L`.
 

--- a/src/QuadForm/Spaces.jl
+++ b/src/QuadForm/Spaces.jl
@@ -26,6 +26,8 @@ function hom(V::AbstractSpace, W::AbstractSpace, B::MatElem; check::Bool = false
   return AbstractSpaceMor(V, W, B)
 end
 
+matrix(f::AbstractSpaceMor) = f.matrix
+
 function image(f::AbstractSpaceMor, v::Vector)
   V = domain(f)
   w = matrix(base_ring(V), 1, length(v), v) * f.matrix
@@ -137,7 +139,7 @@ Return the fixed field of the space `V`.
 fixed_field(::AbstractSpace)
 
 @doc raw"""
-    involution(V::AbstractSpace) -> NumField
+    involution(V::AbstractSpace) -> NumFieldMor
 
 Return the involution of the space `V`.
 """
@@ -167,7 +169,7 @@ Return whether the space `V` is quadratic.
 is_quadratic(::AbstractSpace)
 
 @doc raw"""
-    ishermitian(V::AbstractSpace) -> Bool
+    is_hermitian(V::AbstractSpace) -> Bool
 
 Return whether the space `V` is hermitian.
 """
@@ -580,8 +582,8 @@ end
 # to non rational subfields
 @doc raw"""
     restrict_scalars(V::AbstractSpace, K::QQField,
-                                  alpha::FieldElem = one(base_ring(V)))
-                                                          -> QuadSpace, AbstractSpaceRes
+                                       alpha::FieldElem = one(base_ring(V)))
+                                                    -> QuadSpace, AbstractSpaceRes
 
 Given a space $(V, \Phi)$ and a subfield `K` of the base algebra `E` of `V`, return the
 quadratic space `W` obtained by restricting the scalars of $(V, \alpha\Phi)$ to `K`,

--- a/src/QuadForm/Torsion.jl
+++ b/src/QuadForm/Torsion.jl
@@ -2,7 +2,9 @@ export discriminant_group, torsion_quadratic_module, normal_form, genus, is_genu
        is_degenerate, cover, relations, orthogonal_submodule, brown_invariant,
        modulus_bilinear_form, modulus_quadratic_form, is_isometric_with_isometry,
        is_anti_isometric_with_anti_isometry, has_complement, radical_bilinear,
-       radical_quadratic, is_semi_regular, trivial_morphism, abelian_group_homomorphism
+       radical_quadratic, is_semi_regular, trivial_morphism, abelian_group_homomorphism,
+       value_module, value_module_quadratic_form, gram_matrix_bilinear,
+       gram_matrix_quadratic, quadratic_product
 
 ################################################################################
 #
@@ -110,10 +112,10 @@ group `D = dual(L)/L`.
 
 It comes equipped with the discriminant bilinear form
 
-$$D \times D \to \Q / \Z \qquad (x,y) \mapsto \Phi(x,y) + \Z.$$
+$$D \times D \to \mathbb{Q} / \mathbb{Z} \qquad (x,y) \mapsto \Phi(x,y) + \mathbb{Z}.$$
 
 If `L` is even, then the discriminant group is equipped with the discriminant
-quadratic form $D \to \Q / 2 \Z, x \mapsto \Phi(x,x) + 2\Z$.
+quadratic form $D \to \mathbb{Q} / 2 \mathbb{Z}, x \mapsto \Phi(x,x) + 2\mathbb{Z}$.
 """
 @attr function discriminant_group(L::ZZLat)::TorQuadModule
   @req is_integral(L) "The lattice must be integral"
@@ -181,14 +183,14 @@ For $T=M/N$ this returns $N$.
 relations(T::TorQuadModule) = T.rels
 
 @doc raw"""
-    value_module(T::TorQuadModule)
+    value_module(T::TorQuadModule) -> QmodnZ
 
 Return the value module `Q/nZ` of the bilinear form of `T`.
 """
 value_module(T::TorQuadModule) = T.value_module
 
 @doc raw"""
-    value_module_quadratic_form(T::TorQuadModule)
+    value_module_quadratic_form(T::TorQuadModule) -> QmodnZ
 
 Return the value module `Q/mZ` of the quadratic form of `T`.
 """
@@ -529,7 +531,7 @@ function Base.:(*)(a::TorQuadModuleElem, b::TorQuadModuleElem)
 end
 
 @doc raw"""
-    inner_product(a::TorQuadModuleElem, b::TorQuadModuleElem)
+    inner_product(a::TorQuadModuleElem, b::TorQuadModuleElem) -> QmodnZElem
 
 Return the inner product of `a` and `b`.
 """
@@ -542,13 +544,13 @@ inner_product(a::TorQuadModuleElem, b::TorQuadModuleElem)=(a*b)
 ################################################################################
 
 @doc raw"""
-    quadratic_product(a::TorQuadModuleElem)
+    quadratic_product(a::TorQuadModuleElem) -> QmodnZElem
 
 Return the quadratic product of `a`.
 
 It is defined in terms of a representative:
-for $b + M \in M/N=T$ this returns
-$\Phi(b,b) + n \Z$..
+for $b + M \in M/N=T$, this returns
+$\Phi(b,b) + n \mathbb{Z}$.
 """
 function quadratic_product(a::TorQuadModuleElem)
   T = parent(a)

--- a/src/QuadForm/Types.jl
+++ b/src/QuadForm/Types.jl
@@ -230,12 +230,12 @@ Gram matrix of the quadratic form with values in Q/2Z
 [1//2      1]
 ```
 
-We represent torsion quadratic modules as quotients of $\Z$-lattices
+We represent torsion quadratic modules as quotients of $\mathbb{Z}$-lattices
 by a full rank sublattice.
 
-We store them as a $\Z$-lattice `M` together with a projection `p : M -> A`
+We store them as a $\mathbb{Z}$-lattice `M` together with a projection `p : M -> A`
 onto an abelian group `A`. The bilinear structure of `A` is induced via `p`,
-that is `<a, b> = <p^-1(a), p^-1(a)>` with values in $\Q/n\Z$, where $n$
+that is `<a, b> = <p^-1(a), p^-1(a)>` with values in $\mathbb{Q}/n\mathbb{Z}$, where $n$
 is the modulus and depends on the kernel of `p`.
 
 Elements of A are basically just elements of the underlying abelian group.
@@ -265,7 +265,7 @@ julia> lift(d)
  1
 ```
 
-N.B. Since there are no elements of $\Z$-latties, we think of elements of `M` as
+N.B. Since there are no elements of $\mathbb{Z}$-lattices, we think of elements of `M` as
 elements of the ambient vector space. Thus if `v::Vector` is such an element
 then the coordinates with respec to the basis of `M` are given by
 `solve_left(basis_matrix(M), v)`.


### PR DESCRIPTION
I could not build the documentation locally, hopefully this will fix all the mistakes and bugs I have found in the html documentation for this section of the manual (the goal being to clear things up before next week summer school).