### PR TITLE
Change return argument order of `is_prime_power_with_data`

### DIFF
--- a/src/QuadForm/Torsion.jl
+++ b/src/QuadForm/Torsion.jl
@@ -2095,7 +2095,7 @@ function is_primary_with_prime(T::TorQuadModule)
   if is_empty(ed)
     return true, ZZ(1)
   end
-  bool, p, _ = is_prime_power_with_data(elementary_divisors(T)[end])
+  bool, _, p = is_prime_power_with_data(elementary_divisors(T)[end])
   bool || return false, ZZ(-1)
   return bool, p
 end


### PR DESCRIPTION
Downstream sibling PR to https://github.com/Nemocas/Nemo.jl/pull/1484.

This should fix all uses of `is_prime_power_with_data` in Hecke, after the Nemo-PR has been merged.