### PR TITLE
Make inner_product work for more input types

### DIFF
--- a/src/QuadForm/Quad/Spaces.jl
+++ b/src/QuadForm/Quad/Spaces.jl
@@ -122,8 +122,19 @@ end
 @inline _temp2(V::QuadSpace{S, T}) where {S, T} = V.temp2::elem_type(S)
 
 # Internal version
-function _inner_product!(res, V, v::Vector, w::Vector, temp1 = deepcopy(v),
-                                                       temp2 = base_ring(V)())
+function _inner_product!(res, V::MatElem{T}, _v::Vector, _w::Vector,
+                         temp1 = deepcopy(v), temp2 = base_ring(V)()) where {T}
+  if eltype(_v) === T
+    v = _v
+  else
+    v = map(base_ring(V), _v)::Vector{T}
+  end
+  if eltype(_w) === T
+    w = _w
+  else
+    w = map(base_ring(V), _w)::Vector{T}
+  end
+
   mul!(temp1, v, V)
   zero!(res)
   for i in 1:length(v)

--- a/src/QuadForm/Quad/Spaces.jl
+++ b/src/QuadForm/Quad/Spaces.jl
@@ -122,19 +122,23 @@ end
 @inline _temp2(V::QuadSpace{S, T}) where {S, T} = V.temp2::elem_type(S)
 
 # Internal version
-function _inner_product!(res, V::MatElem{T}, _v::Vector, _w::Vector,
-                         temp1 = deepcopy(v), temp2 = base_ring(V)()) where {T}
-  if eltype(_v) === T
-    v = _v
-  else
-    v = map(base_ring(V), _v)::Vector{T}
-  end
-  if eltype(_w) === T
-    w = _w
-  else
-    w = map(base_ring(V), _w)::Vector{T}
-  end
 
+function _inner_product!(res, V::MatElem{T}, _v::Vector, _w::Vector,
+                         temp1, temp2) where {T}
+  v = map(base_ring(V), _v)::Vector{T}
+  w = map(base_ring(V), _w)::Vector{T}
+  return _inner_product!(res, V, v, w, temp1, temp2)
+end
+
+function _inner_product!(res, V::MatElem{T}, _v::Vector, _w::Vector) where {T}
+  R = base_ring(V)
+  temp1 = [R() for i in 1:length(_v)]
+  temp2 = R()
+  return _inner_product!(ves, V, _v, _w, temp1, temp2)
+end
+
+function _inner_product!(res, V::MatElem{T}, v::Vector{T}, w::Vector{T},
+                         temp1 = deepcopy(v), temp2 = base_ring(V)()) where {T}
   mul!(temp1, v, V)
   zero!(res)
   for i in 1:length(v)

--- a/test/QuadForm/Quad/Spaces.jl
+++ b/test/QuadForm/Quad/Spaces.jl
@@ -22,6 +22,9 @@
   w = QQ[1 1;]
   p = @inferred inner_product(q, v, w)
   @test p == v * gram_matrix(q) * transpose(w)
+  for T in [Int, BigInt, fmpz, Rational{BigInt}, Rational{Int}]
+    @test inner_product(q, [1, 1], [1, 2]) == 3
+  end
 
   Qx, x = polynomial_ring(FlintQQ, "x")
   K1, a1 = number_field(x^2 - 2, "a1")


### PR DESCRIPTION
This makes
```
inner_product(V, [1, 1], [1, 2])
```
work.