### PR TITLE
Remove unnecessary check

### DIFF
--- a/src/QuadForm/Torsion.jl
+++ b/src/QuadForm/Torsion.jl
@@ -2075,7 +2075,6 @@ Note that in the case of trivial groups, this function returns `(true, 1)`. If
 `T` is not primary, the second return value is `-1` by default.
 """
 function is_primary_with_prime(T::TorQuadModule)
-  @req !is_degenerate(T) "T must be non-degenerate"
   ed = elementary_divisors(T)
   if is_empty(ed)
     return true, ZZ(1)

--- a/test/QuadForm/Torsion.jl
+++ b/test/QuadForm/Torsion.jl
@@ -323,7 +323,7 @@
   L = integer_lattice(gram=matrix(ZZ, [[2, -1, 0, 0, 0, 0],[-1, 2, -1, -1, 0, 0],[0, -1, 2, 0, 0, 0],[0, -1, 0, 2, 0, 0],[0, 0, 0, 0, 6, 3],[0, 0, 0, 0, 3, 6]]))
   T = discriminant_group(L)
   Tsub, _ = sub(T, [2*T[1], 3*T[2]])
-  @test_throws ArgumentError is_primary_with_prime(Tsub)
+  @test !is_primary_with_prime(Tsub)[1]
   bool, p = @inferred is_primary_with_prime(T)
   @test !bool && p == -1
   @test is_primary(primary_part(T, 2)[1], 2)


### PR DESCRIPTION
According to the documentation (and what was planned at first), we only care about the underlying abelian group structure. So in fine, being degenerate or not is not mportant. I have some cases where I would be glad to detect the abelian group structure even in the degenerate case (for instance for gluings)