### PR TITLE
Correctly reduce rows in `pseudo_hnf_kb`

### DIFF
--- a/src/NumFieldOrd/NfRelOrd/FracIdeal.jl
+++ b/src/NumFieldOrd/NfRelOrd/FracIdeal.jl
@@ -95,12 +95,12 @@ end
 
 Returns the ideal $d*a$ where $d$ is the denominator of $a$.
 """
-function numerator(a::NfRelOrdFracIdl; copy::Bool = true) # copy for compatibility with NfOrdFracIdl (it doesn't do anything here)
+function numerator(a::NfRelOrdFracIdl; copy::Bool = true) # copy for compatibility with NfOrdFracIdl (it only does something if isone(denominator(a)) here)
   d = denominator(a)
-  PM = basis_pmatrix(a)
   if isone(d)
-    return ideal_type(order(a))(order(a), PM)
+    return ideal_type(order(a))(order(a), basis_pmatrix(a, copy = copy))
   end
+  PM = basis_pmatrix(a)
   for i = 1:degree(order(a))
     PM.coeffs[i] = PM.coeffs[i]*d
     PM.coeffs[i] = simplify(PM.coeffs[i])

--- a/test/NfOrd/LinearAlgebra.jl
+++ b/test/NfOrd/LinearAlgebra.jl
@@ -177,4 +177,16 @@
   gens = Vector{Hecke.NfRelElem{nf_elem}}[map(E, [-6*b + 7, 37//2*b + 21//2, -3//2*b + 5//2]), map(E, [b + 2, 1, 0])]
   pm = pseudo_hnf(pseudo_matrix(matrix(gens)), :lowerleft)
   @test Hecke._spans_subset_of_pseudohnf(pm, pm, :lowerleft)
+
+  # issue 1112
+  K, a = CyclotomicRealSubfield(8, "a");
+  Kt, t = K["t"];
+  E, b = number_field(t^2 - a * t + 1, "b");
+  V = hermitian_space(E, gram_matrix(root_lattice(:E, 8)));
+  L = lattice(V);
+  L2 = dual(L);
+  M = pseudo_matrix(L2)
+  H = pseudo_hnf(M, :lowerleft)
+  @test all(is_one, H.coeffs)
+  @test is_one(H.matrix)
 end


### PR DESCRIPTION
Fixes #1112 

The only meaningful change is the added row reduction in line 1389. I also added some comments (apparently I wasn't a big fan 6 years ago) and restructured the code a little bit.
Sorry for the wrong implementation.

I did not touch `is_pseudo_hnf`. It does not test whether the entries above the diagonal are reduced, but there is no documentation whether it should and it is an internal function any way.