### PR TITLE
Increase precision to isolate roots in `n_positive_roots`

### DIFF
--- a/src/Misc/Poly.jl
+++ b/src/Misc/Poly.jl
@@ -856,7 +856,7 @@ function _n_positive_roots_sqf(f::PolyElem{nf_elem}, P::NumFieldEmb; start_prec:
     try
       rts = roots(g)
     catch e
-      startswith(e.msg, "unable to isolate all roots") || rethrow()
+      e isa ErrorException && startswith(e.msg, "unable to isolate all roots") || rethrow()
       prec *= 2
       continue
     end

--- a/src/Misc/Poly.jl
+++ b/src/Misc/Poly.jl
@@ -853,7 +853,14 @@ function _n_positive_roots_sqf(f::PolyElem{nf_elem}, P::NumFieldEmb; start_prec:
       coeffs[i + 1] = evaluate(coeff(f, i), P, prec)
     end
     g = Cx(coeffs)
-    rts = real.(Hecke.roots(g))
+    try
+      rts = Hecke.roots(g)
+    catch e
+      startswith(e.msg, "unable to isolate all roots") || rethrow()
+      prec *= 2
+      continue
+    end
+    rts = real.(rts)
     if any(contains_zero, rts)
       prec = 2 * prec
     else

--- a/src/Misc/Poly.jl
+++ b/src/Misc/Poly.jl
@@ -854,7 +854,7 @@ function _n_positive_roots_sqf(f::PolyElem{nf_elem}, P::NumFieldEmb; start_prec:
     end
     g = Cx(coeffs)
     try
-      rts = Hecke.roots(g)
+      rts = roots(g)
     catch e
       startswith(e.msg, "unable to isolate all roots") || rethrow()
       prec *= 2

--- a/test/Misc/Poly.jl
+++ b/test/Misc/Poly.jl
@@ -147,3 +147,12 @@ end
   f = x^8 + 319*x^7 + 1798*x^6 + 1177*x^5 + 1083*x^4 + 2070*x^3 + 2075*x^2 + 1937*x + 1896
   @test collect(Hecke.lazy_factor(f)) == [f]
 end
+
+@testset "isolating roots" begin
+  QQx, x = QQ[:x]
+  QQ1, _ = number_field(x-1)
+  P = only(infinite_places(QQ1))
+  QQ1y, y = QQ1[:y]
+  n = Hecke.n_positive_roots((y-1//10000)*(y-2//10000)*(y-100), Hecke.embedding(P))
+  @test n == 3
+end


### PR DESCRIPTION
A `schur_index` computation failed for me, due to `n_positive_roots` failing if two roots are rather close by. This proposal simply doubles the precision in that case. See the added test for an example.