### PR TITLE
Do not check multiplication table from matrix algebra

### DIFF
--- a/src/AlgAss/AlgMat.jl
+++ b/src/AlgAss/AlgMat.jl
@@ -569,7 +569,7 @@ end
 
 function AlgAss(A::AlgMat{T, S}) where {T, S}
   K = base_ring(A)
-  B = AlgAss(K, multiplication_table(A))
+  B = AlgAss(K, multiplication_table(A); check=false)
   B.is_simple = A.is_simple
   B.issemisimple = A.issemisimple
   AtoB = hom(A, B, identity_matrix(K, dim(A)), identity_matrix(K, dim(A)))


### PR DESCRIPTION
Verifying large multiplication tables needs lots of time. If we just created it from a matrix algebra, I see no need to check it.