### PR TITLE
Change the order of arguments in `MapFromFunc`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Hecke"
 uuid = "3e1990a7-5d81-5526-99ce-9ba3ff248f21"
-version = "0.18.16"
+version = "0.19.0"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"

--- a/examples/FieldEnumeration/cubic.jl
+++ b/examples/FieldEnumeration/cubic.jl
@@ -42,9 +42,9 @@ function induce_action(phi::Hecke.NfToNfMor, mR::T) where T <: Map{GrpAbFinGen,
 Hecke.FacElemMon{Hecke.NfOrdIdlSet}}
 #function induce_action(phi::Hecke.NfToNfMor, mR::Hecke.MapRayClassGrpFacElem{Hecke.GrpAbFinGen})
   lp, x = Hecke.find_gens(
-        Hecke.MapFromFunc(x->preimage(mR, FacElem(Dict(x=>1))),
-                          base_ring(codomain(mR)),
-                          domain(mR)),
+        Hecke.MapFromFunc(base_ring(codomain(mR)),
+                          domain(mR),
+                          x->preimage(mR, FacElem(Dict(x=>1)))),
         PrimesSet(100, -1))
   return hom(x, GrpAbFinGenElem[preimage(mR, Hecke.induce_image(p, phi)) for p = lp])
 end

--- a/examples/Round2.jl
+++ b/examples/Round2.jl
@@ -311,7 +311,7 @@ function radical_basis_power(O::Order, p::RingElem)
     F, mF = t
   else
     F = t
-    mF = MapFromFunc(x->F(x), y->lift(y), parent(p), F)
+    mF = MapFromFunc(parent(p), F, x->F(x), y->lift(y))
   end
 #  @assert characteristic(F) == 0 || (isfinite(F) && characteristic(F) > degree(O))
   q = characteristic(F)
@@ -345,7 +345,7 @@ function radical_basis_trace(O::Order, p::RingElem)
     R, mR = t
   else
     R = t
-    mR = MapFromFunc(x->R(x), y->lift(y), parent(p), R)
+    mR = MapFromFunc(parent(p), R, x->R(x), y->lift(y))
   end
 
   TT = map_entries(mR, T)
@@ -362,7 +362,7 @@ function radical_basis_power_non_perfect(O::Order, p::RingElem)
     F, mF = t
   else
     F = t
-    mF = MapFromFunc(x->F(x), y->lift(y), parent(p), F)
+    mF = MapFromFunc(parent(p), F, x->F(x), y->lift(y))
   end
   @assert isa(F, Generic.RationalFunctionField) && characteristic(F) != 0
   q = characteristic(F)
@@ -488,7 +488,7 @@ function Hecke.pmaximal_overorder(O::Order, p::RingElem)
     R, mR = t
   else
     R = t
-    mR = MapFromFunc(x->R(x), y->lift(y), parent(p), R)
+    mR = MapFromFunc(parent(p), R, x->R(x), y->lift(y))
   end
 #  @assert characteristic(F) == 0 || (isfinite(F) && characteristic(F) > degree(O))
   if characteristic(R) == 0 || characteristic(R) > degree(O)
@@ -588,7 +588,7 @@ end
 
 function Hecke.residue_field(R::QQPolyRing, p::QQPolyRingElem)
   K, _ = number_field(p)
-  return K, MapFromFunc(x->K(x), y->R(y), R, K)
+  return K, MapFromFunc(R, K, x->K(x), y->R(y))
 end
 
 function (F::Generic.FunctionField{T})(p::PolyElem{<:AbstractAlgebra.Generic.RationalFunctionFieldElem{T}}) where {T}
@@ -659,7 +659,7 @@ function Hecke.residue_field(R::Loc{ZZRingElem}, p::LocElem{ZZRingElem})
   pp = numerator(data(p))
   @assert is_prime(pp) && isone(denominator(p))
   F = GF(pp)
-  return F, MapFromFunc(x->F(data(x)), y->R(lift(y)), R, F)
+  return F, MapFromFunc(R, F, x->F(data(x)), y->R(lift(y)))
 end
 
 Hecke.is_domain_type(::Type{LocElem{ZZRingElem}}) = true
@@ -1059,13 +1059,14 @@ function Nemo.residue_field(a::HessQR, b::HessQRElem)
   F = GF(b.c)
   Ft, t = RationalFunctionField(F, String(var(a.R)), cached = false)
   R = parent(numerator(t))
-  return Ft, MapFromFunc(x->F(x.c)*Ft(map_coefficients(F, x.f, parent = R))//Ft(map_coefficients(F, x.g, parent = R)),
-                         y->HessQRElem(a, ZZRingElem(1), map_coefficients(lift, numerator(y)), map_coefficients(lift, denominator(y))), a, Ft)
+  return Ft, MapFromFunc(a, Ft,
+                         x->F(x.c)*Ft(map_coefficients(F, x.f, parent = R))//Ft(map_coefficients(F, x.g, parent = R)),
+                         y->HessQRElem(a, ZZRingElem(1), map_coefficients(lift, numerator(y)), map_coefficients(lift, denominator(y))))
 end
 
 function Nemo.residue_ring(a::HessQR, b::HessQRElem)
   F = residue_ring(FlintZZ, b.c)
-  return F, MapFromFunc(x->F(x.c), y->a(lift(y)), a, F)
+  return F, MapFromFunc(a, F, x->F(x.c), y->a(lift(y)))
 end
 
 function Hecke.factor(a::HessQRElem)

--- a/src/FunField/DegreeLocalization.jl
+++ b/src/FunField/DegreeLocalization.jl
@@ -482,7 +482,7 @@ function residue_field(K::KInftyRing{T}, a::KInftyElem{T}) where {T <: FieldElem
   F = base_ring(K.K)
   @assert degree(a) == -1
   #TODO: can be optimized, see blurb of euc. div. above
-  return F, MapFromFunc(x -> leading_coefficient(numerator(mod(x, a))), y-> K(y), K, F)
+  return F, MapFromFunc(K, F, x -> leading_coefficient(numerator(mod(x, a))), y-> K(y))
 end
 #TODO: residue_ring is probably "just" poly of deg < n, think about it
 

--- a/src/FunField/HessQR.jl
+++ b/src/FunField/HessQR.jl
@@ -337,8 +337,9 @@ function Nemo.residue_field(a::HessQR, b::HessQRElem)
   F = GF(b.c)
   Ft, t = RationalFunctionField(F, String(var(a.R)), cached = false)
   R = parent(numerator(t))
-  return Ft, MapFromFunc(x->F(x.c)*Ft(map_coefficients(F, x.f, parent = R))//Ft(map_coefficients(F, x.g, parent = R)),
-                         y->HessQRElem(a, ZZRingElem(1), map_coefficients(z -> lift(ZZ, z), numerator(y)), map_coefficients(z -> lift(ZZ, z), denominator(y))), a, Ft)
+  return Ft, MapFromFunc(a, Ft,
+                         x->F(x.c)*Ft(map_coefficients(F, x.f, parent = R))//Ft(map_coefficients(F, x.g, parent = R)),
+                         y->HessQRElem(a, ZZRingElem(1), map_coefficients(z -> lift(ZZ, z), numerator(y)), map_coefficients(z -> lift(ZZ, z), denominator(y))))
 end
 
 function Nemo.residue_ring(a::HessQR, b::HessQRElem)
@@ -346,9 +347,9 @@ function Nemo.residue_ring(a::HessQR, b::HessQRElem)
   Fx, x = polynomial_ring(F, cached = false)
   Q = fraction_field(Fx, cached = false)
   return Q, MapFromFunc(
+     a, Q,
      x->map_coefficients(F, x.c*x.f, parent = Fx)//map_coefficients(F, x.g, parent = Fx),
-     y->HessQRElem(a, ZZRingElem(1), lift(parent(b.f), numerator(y, false)), lift(parent(b.f), denominator(y, false))),
-     a, Q)
+     y->HessQRElem(a, ZZRingElem(1), lift(parent(b.f), numerator(y, false)), lift(parent(b.f), denominator(y, false))))
 end
 
 function +(a::FracElem{T}, b::FracElem{T}) where T <: PolyElem{<:ResElem{S}} where S <: Hecke.IntegerUnion

--- a/src/GenOrd/Auxiliary.jl
+++ b/src/GenOrd/Auxiliary.jl
@@ -51,7 +51,7 @@ function hnf_modular(M::MatElem{T}, d::T, is_prime::Bool = false) where {T}
       R, mR = x
     else
       R = x
-      mR = MapFromFunc(x->R(x), x->lift(x), parent(d), R)
+      mR = MapFromFunc(parent(d), R, x->R(x), x->lift(x))
     end
     r, h = rref(map_entries(mR, M))
     H = map_entries(x->preimage(mR, x), h[1:r, :])
@@ -61,7 +61,7 @@ function hnf_modular(M::MatElem{T}, d::T, is_prime::Bool = false) where {T}
       R, mR = x
     else
       R = x
-      mR = MapFromFunc(x->R(x), x->lift(x), parent(d), R)
+      mR = MapFromFunc(parent(d), R, x->R(x), x->lift(x))
     end
     r, h = rref(map_entries(mR, M))
     H = map_entries(x->preimage(mR, x), hnf(map_entries(mR, M)))
@@ -99,13 +99,13 @@ end
 
 function Hecke.residue_field(R::QQPolyRing, p::QQPolyRingElem)
   K, _ = number_field(p)
-  return K, MapFromFunc(x->K(x), y->R(y), R, K)
+  return K, MapFromFunc(R, K, x -> K(x), y -> R(y))
 end
 
 function Hecke.residue_field(R::PolyRing{T}, p::PolyElem{T}) where {T <: NumFieldElem}
   @assert parent(p) === R
   K, _ = number_field(p)
-  return K, MapFromFunc(x -> K(x), y -> R(y), R, K)
+  return K, MapFromFunc(R, K, x -> K(x), y -> R(y))
 end
 
 function (F::Generic.FunctionField{T})(p::PolyElem{<:AbstractAlgebra.Generic.RationalFunctionFieldElem{T}}) where {T <: FieldElem}
@@ -177,7 +177,7 @@ function Hecke.residue_field(R::Loc{ZZRingElem}, p::LocElem{ZZRingElem})
   pp = numerator(data(p))
   @assert is_prime(pp) && isone(denominator(p))
   F = GF(pp)
-  return F, MapFromFunc(x->F(data(x)), y->R(lift(ZZ, y)), R, F)
+  return F, MapFromFunc(R, F, x->F(data(x)), y->R(lift(ZZ, y)))
 end
 
 Hecke.is_domain_type(::Type{LocElem{ZZRingElem}}) = true

--- a/src/GenOrd/GenOrd.jl
+++ b/src/GenOrd/GenOrd.jl
@@ -494,7 +494,7 @@ function ring_of_multipliers(O::GenOrd, I::MatElem{T}, p::T, is_prime::Bool = fa
       R, mR = x
     else
       R = x
-      mR = MapFromFunc(x->R(x), x->lift(x), parent(p), R)
+      mR = MapFromFunc(parent(p), R, x->R(x), x->lift(x))
     end
     ref = x->rref(x)[2]
   else
@@ -503,10 +503,10 @@ function ring_of_multipliers(O::GenOrd, I::MatElem{T}, p::T, is_prime::Bool = fa
       R, mR = x
     else
       R = x
-      mR = MapFromFunc(x->R(x), x->lift(x), parent(p), R)
+      mR = MapFromFunc(parent(p), R, x->R(x), x->lift(x))
     end
 #    R = parent(p)
-#    mR = MapFromFunc(x->x, x->x, R, R)
+#    mR = MapFromFunc(R, R, x->x, x->x)
     ref = hnf
   end
   m = map_entries(mR, m)
@@ -598,7 +598,7 @@ function Hecke.pmaximal_overorder(O::GenOrd, p::RingElem, is_prime::Bool = false
     R, mR = t
   else
     R = t
-    mR = MapFromFunc(x->R(x), y->lift(y), parent(p), R)
+    mR = MapFromFunc(parent(p), R, x->R(x), y->lift(y))
   end
 #  @assert characteristic(F) == 0 || (isfinite(F) && characteristic(F) > degree(O))
   if characteristic(R) == 0 || characteristic(R) > degree(O)
@@ -785,7 +785,7 @@ function radical_basis_power(O::GenOrd, p::RingElem)
     F, mF = t
   else
     F = t
-    mF = MapFromFunc(x->F(x), y->lift(y), parent(p), F)
+    mF = MapFromFunc(parent(p), F, x->F(x), y->lift(y))
   end
 #  @assert characteristic(F) == 0 || (isfinite(F) && characteristic(F) > degree(O))
   q = characteristic(F)
@@ -819,7 +819,7 @@ function radical_basis_trace(O::GenOrd, p::RingElem)
     R, mR = t
   else
     R = t
-    mR = MapFromFunc(x->R(x), y->lift(y), parent(p), R)
+    mR = MapFromFunc(parent(p), R, x->R(x), y->lift(y))
   end
 
   TT = map_entries(mR, T)
@@ -836,7 +836,7 @@ function radical_basis_power_non_perfect(O::GenOrd, p::RingElem)
     F, mF = t
   else
     F = t
-    mF = MapFromFunc(x->F(x), y->lift(y), parent(p), F)
+    mF = MapFromFunc(parent(p), F, x->F(x), y->lift(y))
   end
   @assert isa(F, Generic.RationalFunctionField) && characteristic(F) != 0
   q = characteristic(F)

--- a/src/GenOrd/Ideal.jl
+++ b/src/GenOrd/Ideal.jl
@@ -578,7 +578,7 @@ end
 
 function Hecke.residue_field(R::fpPolyRing, p::fpPolyRingElem)
   K, _ = FiniteField(p,"o")
-  return K, MapFromFunc(x->K(x), y->R(y), R, K)
+  return K, MapFromFunc(R, K, x->K(x), y->R(y))
 end
 
 function Hecke.residue_field(R::FqPolyRing, p::FqPolyRingElem)
@@ -697,7 +697,7 @@ function Hecke.pradical(O::GenOrd, p::RingElem)
     R, mR = t
   else
     R = t
-    mR = MapFromFunc(x->R(x), y->lift(y), parent(p), R)
+    mR = MapFromFunc(parent(p), R, x->R(x), y->lift(y))
   end
 #  @assert characteristic(F) == 0 || (isfinite(F) && characteristic(F) > degree(O))
   if characteristic(R) == 0 || characteristic(R) > degree(O)

--- a/src/GrpAb/Dual.jl
+++ b/src/GrpAb/Dual.jl
@@ -227,7 +227,7 @@ function dual(G::GrpAbFinGen, u::QmodnZElem)
   QZ = parent(u)
   R, phi = hom(G, H)
   R::GrpAbFinGen
-  ex = MapFromFunc(x -> x[1]*u, y -> H(ZZRingElem[numerator(y.elt) * div(o, denominator(y.elt))]), H, parent(u))
+  ex = MapFromFunc(H, parent(u), x -> x[1]*u, y -> H(ZZRingElem[numerator(y.elt) * div(o, denominator(y.elt))]))
   local mu
   let phi = phi, G = G, QZ = QZ, u = u
     function mu(r::GrpAbFinGenElem)
@@ -243,7 +243,7 @@ function dual(G::GrpAbFinGen, u::QmodnZElem)
       return preimage(phi, g)
     end
   end
-  return R, MapFromFunc(mu, nu, R, MapParent(G, parent(u), "homomorphisms"))
+  return R, MapFromFunc(R, MapParent(G, parent(u), "homomorphisms"), mu, nu)
 end
 
 parent(f::GrpAbFinGenToQmodnZ) = MapParent(domain(f), codomain(f), "homomorphisms")

--- a/src/GrpAb/GrpAbFinGen.jl
+++ b/src/GrpAb/GrpAbFinGen.jl
@@ -925,7 +925,7 @@ function tensor_product(G::GrpAbFinGen...; task::Symbol = :map)
     return reverse(g[p[1]])
   end
 
-  return T, MapFromFunc(pure, inv_pure, TupleParent(Tuple([g[0] for g = G])), T)
+  return T, MapFromFunc(TupleParent(Tuple([g[0] for g = G])), T, pure, inv_pure)
 end
 
 ⊗(G::GrpAbFinGen...) = tensor_product(G..., task = :none)

--- a/src/GrpAb/Map.jl
+++ b/src/GrpAb/Map.jl
@@ -612,7 +612,7 @@ function hom(G::GrpAbFinGen, H::GrpAbFinGen; task::Symbol = :map)
     local m = transpose(vcat([preimage(mH, r(mG(sG[i]))).coeff for i = 1:ngens(sG)]))
     return R([divexact(m[i], c[i]) for i = 1:ngens(R)])
   end
-  return R, MapFromFunc(phi, ihp, R, MapParent(G, H, "homomorphisms"))
+  return R, MapFromFunc(R, MapParent(G, H, "homomorphisms"), phi, ihp)
 end
 
 ################################################################################

--- a/src/LocalField/Conjugates.jl
+++ b/src/LocalField/Conjugates.jl
@@ -617,5 +617,5 @@ function completion(K::AnticNumberField, ca::qadic)
     end
     return r#*K(p)^valuation(x)
   end
-  return parent(ca), MapFromFunc(inj, lif, K, parent(ca))
+  return parent(ca), MapFromFunc(K, parent(ca), inj, lif)
 end

--- a/src/LocalField/LocalField.jl
+++ b/src/LocalField/LocalField.jl
@@ -447,7 +447,7 @@ function residue_field(K::LocalField{S, EisensteinLocalField}) where {S <: Field
     @assert parent(a) === ks
     return setprecision(K(mks\(a)), precision(K))
   end
-  mp = MapFromFunc(proj, lift, K, ks)
+  mp = MapFromFunc(K, ks, proj, lift)
 
   K.residue_field_map = mp
 
@@ -485,7 +485,7 @@ function residue_field(K::LocalField{S, UnramifiedLocalField}) where {S <: Field
      end
      return sum(col)
    end
-   mp = MapFromFunc(proj, lift, K, kk)
+   mp = MapFromFunc(K, kk, proj, lift)
    K.residue_field_map = mp
   return kk, mp
 end

--- a/src/LocalField/neq.jl
+++ b/src/LocalField/neq.jl
@@ -1080,7 +1080,7 @@ function one_unit_group(K::LocalField)
       return G(ex)
     end
   end
-  return G, MapFromFunc(from_G, to_G, G, K)
+  return G, MapFromFunc(G, K, from_G, to_G)
 end
 
 function teichmuller(a::LocalFieldElem)
@@ -1133,7 +1133,7 @@ function unit_group(K::LocalField)
     return inj[1](v*Z[1]) + inj[2](preimage(mu, r)) + inj[3](preimage(mU, x))
   end
 
-  return G, MapFromFunc(from_G, to_G, G, K)
+  return G, MapFromFunc(G, K, from_G, to_G)
 end
 
 #=
@@ -1157,7 +1157,7 @@ function unit_group(R::QadicRing)
     return inj[1](preimage(mu, r)) + inj[2](preimage(mU, x))
   end
 
-  return G, MapFromFunc(from_G, to_G, G, K)
+  return G, MapFromFunc(G, K, from_G, to_G)
 end
 
 =#

--- a/src/LocalField/qAdic.jl
+++ b/src/LocalField/qAdic.jl
@@ -32,7 +32,7 @@ function residue_field(Q::FlintQadicField)
     end
     return z
   end
-  mk = MapFromFunc(pro, lif, Q, k)
+  mk = MapFromFunc(Q, k, pro, lif)
   set_attribute!(Q, :ResidueFieldMap => mk)
   return k, mk
 end
@@ -50,7 +50,7 @@ function residue_field(Q::FlintPadicField)
     z = Q(lift(x))
     return z
   end
-  return k, MapFromFunc(pro, lif, Q, k)
+  return k, MapFromFunc(Q, k, pro, lif)
 end
 
 coefficient_field(Q::FlintQadicField) = coefficient_ring(Q)

--- a/src/Map/MapType.jl
+++ b/src/Map/MapType.jl
@@ -136,7 +136,7 @@ end
 ###########################################################
 
 """
-    MapFromFunc(f, [g], D, C)
+    MapFromFunc(D, C, f, [g])
 
 Creates the map `D -> C, x -> f(x)` given the callable
 object `f`. If `g` is provided, it is assumed to satisfy
@@ -147,14 +147,14 @@ object `f`. If `g` is provided, it is assumed to satisfy
 ```jldoctest
 julia> F = GF(2);
 
-julia> f = MapFromFunc(x -> F(numerator(x)) * inv(F(denominator(x))), QQ, F)
+julia> f = MapFromFunc(QQ, F, x -> F(numerator(x)) * inv(F(denominator(x))))
 Map from
 Rational field to Finite field of characteristic 2 defined by a julia-function
 
 julia> f(QQ(1//3))
 1
 
-julia> f = MapFromFunc(x -> F(numerator(x)) * inv(F(denominator(x))), y -> QQ(lift(y)),  QQ, F)
+julia> f = MapFromFunc(QQ, F, x -> F(numerator(x)) * inv(F(denominator(x))), y -> QQ(lift(y)),)
 Map from
 Rational field to Finite field of characteristic 2 defined by a julia-function with inverse
 
@@ -167,14 +167,14 @@ mutable struct MapFromFunc{R, T} <: Map{R, T, HeckeMap, MapFromFunc}
   f
   g
 
-  function MapFromFunc{R, T}(f, D::R, C::T) where {R, T}
+  function MapFromFunc{R, T}(D::R, C::T, f) where {R, T}
     n = new{R, T}()
     n.header = Hecke.MapHeader(D, C, f)
     n.f = f
     return n
   end
 
-  function MapFromFunc{R, T}(f, g, D::R, C::T) where {R, T}
+  function MapFromFunc{R, T}(D::R, C::T, f, g) where {R, T}
     n = new{R, T}()
     n.header = Hecke.MapHeader(D, C, f, g)
     n.f = f
@@ -213,19 +213,19 @@ function Base.show(io::IO, M::MapFromFunc)
   end
 end
 
-function MapFromFunc(f, D, C)
-  return MapFromFunc{typeof(D), typeof(C)}(f, D, C)
+function MapFromFunc(D, C, f)
+  return MapFromFunc{typeof(D), typeof(C)}(D, C, f)
 end
 
-function MapFromFunc(f, g, D, C)
-  return MapFromFunc{typeof(D), typeof(C)}(f, g, D, C)
+function MapFromFunc(D, C, f, g)
+  return MapFromFunc{typeof(D), typeof(C)}(D, C, f, g)
 end
 
 function Base.inv(M::MapFromFunc)
   if isdefined(M, :g)
-     return MapFromFunc(M.g, M.f, codomain(M), domain(M))
+     return MapFromFunc(codomain(M), domain(M), M.g, M.f)
   else
-     return MapFromFunc(x->preimage(M, x), codomain(M), domain(M))
+     return MapFromFunc(codomain(M), domain(M), x->preimage(M, x))
   end
 end
 

--- a/src/Map/NfRelOrd.jl
+++ b/src/Map/NfRelOrd.jl
@@ -401,7 +401,7 @@ mutable struct NfRelOrdToRelFinFieldMor{S, T} <: Map{S, RelFinField{T}, HeckeMap
 
       FE = RelFinField(h, :v)
       FEabs, FEabstoFE = Hecke.absolute_field(FE, cached = false)
-      FKxtoFKabsz = MapFromFunc(f -> FKabsz(FKtoFKabs.(collect(coefficients(f)))), FKx, FKabsz)
+      FKxtoFKabsz = MapFromFunc(FKx, FKabsz, f -> FKabsz(FKtoFKabs.(collect(coefficients(f)))))
       FE2, mE2 = field_extension(hh)
       FE2toFEabs = hom(FE2, FEabs, gen(FEabs))
       mE = compose(FKxtoFKabsz,compose(mE2, compose(FE2toFEabs, FEabstoFE)))
@@ -449,7 +449,7 @@ mutable struct NfRelOrdToRelFinFieldMor{S, T} <: Map{S, RelFinField{T}, HeckeMap
 
       FE = RelFinField(h, :v)
       FEabs, FEabstoFE = Hecke.absolute_field(FE, cached = false)
-      FKxtoFKabsz = MapFromFunc(f -> FKabsz(FKtoFKabs.(collect(coefficients(f)))), FKx, FKabsz)
+      FKxtoFKabsz = MapFromFunc(FKx, FKabsz, f -> FKabsz(FKtoFKabs.(collect(coefficients(f)))))
       FE2, mE2 = field_extension(hh)
       FE2toFEabs = hom(FE2, FEabs, gen(FEabs))
       mE = compose(FKxtoFKabsz,compose(mE2, compose(FE2toFEabs, FEabstoFE)))

--- a/src/Misc/FiniteField.jl
+++ b/src/Misc/FiniteField.jl
@@ -209,7 +209,7 @@ function find_morphism(k::fqPolyRepField, K::fqPolyRepField)
    if degree(k) > 1
     phi = Nemo.find_morphism(k, K) #avoids embed - which stores the info
   else
-    phi = MapFromFunc(x->K((coeff(x, 0))), y->k((coeff(y, 0))), k, K)
+    phi = MapFromFunc(k, K, x->K((coeff(x, 0))), y->k((coeff(y, 0))))
   end
   return phi
 end

--- a/src/Misc/Integer.jl
+++ b/src/Misc/Integer.jl
@@ -559,7 +559,7 @@ function unit_group(::ZZRing)
   log = function (z::ZZRingElem)
     return z == -1 ? G[1] : G[0]
   end
-  return G, MapFromFunc(exp, log, G, FlintZZ)
+  return G, MapFromFunc(G, FlintZZ, exp, log)
 end
 
 @doc raw"""
@@ -575,7 +575,7 @@ function unit_group(R::AbstractAlgebra.Integers{T}) where {T}
   log = function (z::T)
     return z == -1 ? G[1] : G[0]
   end
-  return G, MapFromFunc(exp, log, G, R)
+  return G, MapFromFunc(G, R, exp, log)
 end
 
 #Nemo.fpField = zzModRingElem?
@@ -815,13 +815,13 @@ end
 
 function quo(::ZZRing, a::ZZRingElem)
   R = residue_ring(FlintZZ, a)
-  f = MapFromFunc(x -> R(x), y -> lift(y), FlintZZ, R)
+  f = MapFromFunc(FlintZZ, R, x -> R(x), y->lift(y))
   return R, f
 end
 
 function quo(::ZZRing, a::Integer)
   R = residue_ring(FlintZZ, a)
-  f = MapFromFunc(x -> R(x), y -> lift(y), FlintZZ, R)
+  f = MapFromFunc(FlintZZ, R, x -> R(x), y->lift(y))
   return R, f
 end
 

--- a/src/Misc/Series.jl
+++ b/src/Misc/Series.jl
@@ -224,7 +224,7 @@ end
 
 function Hecke.residue_field(S::SeriesRing{T}) where {T <: Nemo.RingElem} #darn zzModRingElem/gfp
   k = base_ring(S)
-  return k, MapFromFunc(x -> coeff(x, 0), y -> set_precision(S(y), 1), S, k)
+  return k, MapFromFunc(S, k, x -> coeff(x, 0), y -> set_precision(S(y), 1))
 end
 
 function rational_reconstruction(a::SeriesElem; parent::PolyRing = polynomial_ring(base_ring(a), cached = false)[1])

--- a/src/Misc/nmod_poly.jl
+++ b/src/Misc/nmod_poly.jl
@@ -1207,7 +1207,7 @@ end
 
 function quo(R::fqPolyRepPolyRing, f::fqPolyRepPolyRingElem)
   Q = residue_ring(R, f)
-  mQ = MapFromFunc(x -> Q(x), y -> lift(y), R, Q)
+  mQ = MapFromFunc(R, Q, x -> Q(x), y -> lift(y))
   return Q, mQ
 end
 

--- a/src/ModAlgAss/GAPMeatAxe.jl
+++ b/src/ModAlgAss/GAPMeatAxe.jl
@@ -48,7 +48,7 @@ function _ring_iso_oscar_gap(F::T) where T <: Union{Nemo.fpField, Nemo.FpField}
    f(x::Union{Nemo.fpFieldElem, Nemo.FpFieldElem}) = GAP.Obj(lift(x))*e
    finv(x) = F(ZZRingElem(GAP.Globals.IntFFE(x)))
 
-   return MapFromFunc(f, finv, F, G)
+   return MapFromFunc(F, G, f, finv)
 end
 
 function _ring_iso_oscar_gap(F::T) where T <: Union{Nemo.fqPolyRepField, Nemo.FqPolyRepField}
@@ -62,7 +62,7 @@ function _ring_iso_oscar_gap(F::T) where T <: Union{Nemo.fqPolyRepField, Nemo.Fq
    if d == 1
       f1(x::Union{Nemo.fqPolyRepFieldElem, Nemo.FqPolyRepFieldElem}) = GAP.Obj(coeff(x, 0))*e
       finv1(x) = F(ZZRingElem(GAP.Globals.IntFFE(x)))
-      return MapFromFunc(f1, finv1, F, Fp_gap)
+      return MapFromFunc(F, Fp_gap, f1, finv1)
    end
 
    # non-prime fields: convert the defining polynomial to GAP...
@@ -114,7 +114,7 @@ function _ring_iso_oscar_gap(F::T) where T <: Union{Nemo.fqPolyRepField, Nemo.Fq
       return sum([ v_int[i]*Basis_F[i] for i = 1:d ])
    end
 
-   return MapFromFunc(f, finv, F, G)
+   return MapFromFunc(F, G, f, finv)
 end
 
 function __to_gap(h, x::Vector)

--- a/src/NumField/NfAbs/NfAbs.jl
+++ b/src/NumField/NfAbs/NfAbs.jl
@@ -35,7 +35,7 @@ is_simple(::AnticNumberField) = true
 function number_field(S::Generic.ResidueRing{QQPolyRingElem}; cached::Bool = true, check::Bool = true)
   Qx = parent(modulus(S))
   K, a = number_field(modulus(S), "_a", cached = cached, check = check)
-  mp = MapFromFunc(y -> S(Qx(y)), x -> K(lift(x)), K, S)
+  mp = MapFromFunc(K, S, y -> S(Qx(y)), x -> K(lift(x)))
   return K, mp
 end
 
@@ -958,7 +958,7 @@ function collect_all_chains(a::NumField, filter::Function = x->true)
   s === nothing && return s
   all_chain = Dict{UInt, Array{Any}}(objectid(domain(f)) => [f] for f = s if filter(f))
   if isa(base_field(a), NumField)
-    all_chain[objectid(base_field(a))] = [MapFromFunc(x->a(x), base_field(a), a)]
+    all_chain[objectid(base_field(a))] = [MapFromFunc(base_field(a), a, x->a(x))]
   end
   new_k = Any[domain(f) for f = s]
   while length(new_k) > 0
@@ -979,7 +979,7 @@ function collect_all_chains(a::NumField, filter::Function = x->true)
           b = base_field(domain(f))
           ob = objectid(b)
           if !haskey(all_chain, ob)
-            g = MapFromFunc(x->domain(f)(x), b, domain(f))
+            g = MapFromFunc(b, domain(f), x->domain(f)(x))
             all_chain[ob] = vcat([g], all_chain[objectid(domain(f))])
             push!(new_k, b)
           end
@@ -997,7 +997,7 @@ function find_one_chain(t::NumField, a::NumField)
   ot = objectid(t)
   all_chain = Dict{UInt, Array{Any}}(objectid(domain(f)) => [f] for f = s)
   if isa(base_field(a), NumField)
-    all_chain[objectid(base_field(a))] = [MapFromFunc(x->a(x), base_field(a), a)]
+    all_chain[objectid(base_field(a))] = [MapFromFunc(base_field(a), a, x->a(x))]
   end
   new_k = Any[domain(f) for f = s]
   if haskey(all_chain, ot)
@@ -1024,7 +1024,7 @@ function find_one_chain(t::NumField, a::NumField)
         b = base_field(domain(f))
         ob = objectid(b)
         if !haskey(all_chain, ob)
-          g = MapFromFunc(x->domain(f)(x), b, domain(f))
+          g = MapFromFunc(b, domain(f), x->domain(f)(x))
           all_chain[ob] = vcat([g], all_chain[objectid(domain(f))])
           push!(new_k, b)
         end

--- a/src/NumField/NfAbs/NonSimple.jl
+++ b/src/NumField/NfAbs/NonSimple.jl
@@ -866,7 +866,7 @@ function simple_extension(K::NfAbsNS; cached::Bool = true, check = true, simplif
   end
   h = hom(Ka, K, pe, inverse = emb)
   embed(h)
-  embed(MapFromFunc(x->preimage(h, x), K, Ka))
+  embed(MapFromFunc(K, Ka, x->preimage(h, x)))
   return Ka, h
 end
 

--- a/src/NumField/NfAbs/PolyFact.jl
+++ b/src/NumField/NfAbs/PolyFact.jl
@@ -644,7 +644,7 @@ function van_hoeij(f::PolyElem{nf_elem}, P::NfOrdIdl; prec_scale = 1)
     have = vcat(0:up_to-1, from:N-2)  #N-1 is always 1
 
     if degree(P) == 1
-      mD = MapFromFunc(x->coeff(mC(x),0), y->K(lift(y)), K, base_ring(vH.H.f))
+      mD = MapFromFunc(K, base_ring(vH.H.f), x->coeff(mC(x),0), y->K(lift(y)))
       @vtime :PolyFactor 1 C = cld_data(vH.H, up_to, from, mD, vH.pM[1], den*leading_coefficient(f))
     else
       @vtime :PolyFactor 1 C = cld_data(vH.H, up_to, from, mC, vH.pM[1], den*leading_coefficient(f))

--- a/src/NumField/NfRel/absolute_field.jl
+++ b/src/NumField/NfRel/absolute_field.jl
@@ -129,7 +129,7 @@ function absolute_simple_field(K::NfRel{nf_elem}; cached::Bool = false, simplify
   Ka, a, b, c = _absolute_field(K, cached = cached)
   h1 = hom(Ka, K, c, inverse = (a, b))
   embed(h1)
-  embed(MapFromFunc(x->preimage(h1, x), K, Ka))
+  embed(MapFromFunc(K, Ka, x->preimage(h1, x)))
   return Ka, h1
 end
 
@@ -212,7 +212,7 @@ function collapse_top_layer(K::NfRel{T}; cached::Bool = false, do_embedding::Boo
   h1 = hom(Ka, K, c, inverse = (a, b), check = false)
   h2 = hom(base_field(K), Ka, a, check = false)
   embed(h1)
-  embed(MapFromFunc(x->preimage(h1, x), K, Ka))
+  embed(MapFromFunc(K, Ka, x->preimage(h1, x)))
   embed(h2)
   return Ka, h1, h2
 end

--- a/src/NumField/Selmer.jl
+++ b/src/NumField/Selmer.jl
@@ -192,7 +192,7 @@ function pselmer_group_fac_elem(p::Int, S::Vector{<:NfOrdIdl}; check::Bool = tru
     return Sel(map(lift, vec(collect(sol))))
   end
 
-  return Sel, MapFromFunc(toK, toSel, Sel, codomain(mU)) 
+  return Sel, MapFromFunc(Sel, codomain(mU), toK, toSel) 
 end
 
 @doc raw"""
@@ -203,7 +203,7 @@ ie. returned explicitly wrt the basis of the number field.
 """    
 function pselmer_group(p::Int, S::Vector{NfOrdIdl}; check::Bool = true, algo::Symbol = :raw)
   G, mp = pselmer_group_fac_elem(p, S, check = check, algo = algo)
-  return G, MapFromFunc(x->evaluate(mp(x)), y->preimage(mp, FacElem([y], ZZRingElem[1])), G, number_field(order(S[1])))
+  return G, MapFromFunc(G, number_field(order(S[1])), x->evaluate(mp(x)), y->preimage(mp, FacElem([y], ZZRingElem[1])))
 end
 
 @doc raw"""
@@ -257,7 +257,7 @@ function pselmer_group_fac_elem(p::Int, S::Vector{ZZRingElem}; algo::Symbol = :r
   function toG(a::Integer)
     return toF(FacElem(QQ, QQFieldElem[a], ZZRingElem[1]), parent = R)
   end
-  return G, MapFromFunc(toQ, toG, G, R)
+  return G, MapFromFunc(G, R, toQ, toG)
 end
 
 function pselmer_group_fac_elem(p::Int, S::Vector{<:Integer}; algo::Symbol = :raw, check::Bool = true)
@@ -301,7 +301,7 @@ end
 
 function pselmer_group(p::Int, S::Vector{ZZRingElem}; check::Bool = true, algo::Symbol = :raw)
   G, mp = pselmer_group_fac_elem(p, S, check = check, algo = algo)
-  return G, MapFromFunc(x->evaluate(mp(x)), y->preimage(mp, FacElem(QQ, QQFieldElem[y], ZZRingElem[1], parent = codomain(mp))), G, QQ)
+  return G, MapFromFunc(G, QQ, x->evaluate(mp(x)), y->preimage(mp, FacElem(QQ, QQFieldElem[y], ZZRingElem[1], parent = codomain(mp))))
 end
 function pselmer_group(p::Int, S::Vector{<:Integer}; check::Bool = true, algo::Symbol = :raw)
   return pselmer_group(p, map(ZZRingElem, S), check = check, algo = algo)

--- a/src/QuadForm/Quad/GenusRep.jl
+++ b/src/QuadForm/Quad/GenusRep.jl
@@ -1458,7 +1458,7 @@ function non_square(F::FinField)
 end
 
 function inv(f::Hecke.LocMultGrpModSquMap)
-  return MapFromFunc(x -> preimage(f, x), codomain(f), domain(f))
+  return MapFromFunc(codomain(f), domain(f), x -> preimage(f, x))
 end
 
 ################################################################################

--- a/src/QuadForm/Quad/ZGenus.jl
+++ b/src/QuadForm/Quad/ZGenus.jl
@@ -1869,7 +1869,7 @@ Return the product $\prod_p \QQ_p* / (\QQ_p*)^2$ where `p in primes`.
 function local_multiplicative_group_modulo_squares(primes::Vector{ZZRingElem})
   K, _ = Hecke.rationals_as_number_field()
   # f : QQ -> K
-  f = MapFromFunc(x -> K(x), x -> coeff(x, 0), QQ, K)
+  f = MapFromFunc(QQ, K, x -> K(x), x -> coeff(x, 0))
   OK = maximal_order(K)
   primes_as_ideals = [prime_decomposition(OK, p)[1][1] for p in primes]
   stuff = [Hecke.local_multiplicative_group_modulo_squares(P) for P in primes_as_ideals]
@@ -1900,7 +1900,7 @@ function local_multiplicative_group_modulo_squares(primes::Vector{ZZRingElem})
     @assert backwardmap(z) == x
     return z
   end
-  diagonal_morphism = inv(MapFromFunc(forwardmap, backwardmap, A, QQ))
+  diagonal_morphism = inv(MapFromFunc(A, QQ, forwardmap, backwardmap))
   projd = Any[(primes[i],proj[i]*maps[i]*inv(f)) for i in 1:length(primes)]
   injd = Any[(primes[i],f*inv(maps[i])*inj[i]) for i in 1:length(primes)]
   return A, Dict(projd), Dict(injd), diagonal_morphism
@@ -1951,7 +1951,7 @@ Further Delta is in bijection with the proper spinor genera of `G`.
   B,b = sub(A,gens_local_automorphs)
   C,c = sub(B, [preimage(b,i) for i in gens_automorph])
   Delta, proj = cokernel(c, false)
-  binv = MapFromFunc(x -> preimage(b, x), b, A, B)
+  binv = MapFromFunc(A, B, x -> preimage(b, x), b)
   f1 = compose(diagonal_map, binv)
   f2 = compose(f1, proj)
   f3 = Dict([(p,compose(compose(inj[p], binv), proj)) for p in keys(inj)])

--- a/src/RCF/autos.jl
+++ b/src/RCF/autos.jl
@@ -29,9 +29,9 @@ function automorphism_group(C::ClassField)
     end
     push!(zz, t)
   end
-  f = MapFromFunc(x->prod(z[i]^x[i] for i=1:length(z)),
-                  y->A([findfirst(isequal(y(gen(K, i))), zz[i])-1 for i=1:length(z)]),
-                  A, G)
+  f = MapFromFunc(A, G,
+                  x->prod(z[i]^x[i] for i=1:length(z)),
+                  y->A([findfirst(isequal(y(gen(K, i))), zz[i])-1 for i=1:length(z)]))
   set_attribute!(C, :RelAuto => f)                
   return A, f                      
 end

--- a/src/RCF/conductor.jl
+++ b/src/RCF/conductor.jl
@@ -942,7 +942,7 @@ function norm_group_map(R::ClassField{S, T}, r::Vector{<:ClassField}, map = fals
     return [hom(domain(fR), domain(x.quotientmap), GrpAbFinGenElem[]) for x = r]
   end
 
-  lp, sR = find_gens(MapFromFunc(x->preimage(fR, x), IdealSet(base_ring(R)), domain(fR)),
+  lp, sR = find_gens(MapFromFunc(IdealSet(base_ring(R)), domain(fR), x->preimage(fR, x)),
                              PrimesSet(100, -1), minimum(mR))
 
   if map == false

--- a/src/RCF/rcf.jl
+++ b/src/RCF/rcf.jl
@@ -1000,9 +1000,9 @@ function _rcf_descent(CF::ClassField_pp)
     @vprintln :ClassField 2 "finding Artin map..."
     #TODO can only use non-indx primes, easy primes...
     cp = lcm([minimum(defining_modulus(CF)[1]), index(Zk), index(ZK)])
-    #@vtime :ClassField 2 lp, f1 = find_gens(MapFromFunc(canFrob, IdealSet(Zk), AutA),
+    #@vtime :ClassField 2 lp, f1 = find_gens(MapFromFunc(IdealSet(Zk), AutA, canFrob),
     #                  PrimesSet(200, -1), cp)
-    lp, f1 = find_gens_descent(MapFromFunc(canFrob, IdealSet(Zk), AutA), CF, cp)
+    lp, f1 = find_gens_descent(MapFromFunc(IdealSet(Zk), AutA, canFrob), CF, cp)
     imgs = GrpAbFinGenElem[image(CF.quotientmap, preimage(CF.rayclassgroupmap, p1)) for p1 = lp]
     h = hom(f1, imgs)
     @hassert :ClassField 1 is_surjective(h)

--- a/test/Map/MapFromFunc.jl
+++ b/test/Map/MapFromFunc.jl
@@ -1,5 +1,5 @@
 @testset "Test inverse of MapFromFunc" begin
-  f = MapFromFunc(x -> x+1, x -> x-1, ZZ, ZZ)
+  f = MapFromFunc(ZZ, ZZ, x -> x+1, x -> x-1)
   x = ZZ(1)
   y = f(x)
   @test preimage(f, y) == x


### PR DESCRIPTION
Resolves https://github.com/oscar-system/Oscar.jl/issues/1104.

Unfortunately, one cannot add deprecations, as the constructor has no type annotations at all (cf. https://github.com/thofma/Hecke.jl/blob/master/src/Map/MapType.jl#L225). Thus, this PR is breaking.

The changes needed in Oscar are proposed in https://github.com/oscar-system/Oscar.jl/pull/2475.