### PR TITLE
Ignore complex embeddings for Schur index

### DIFF
--- a/src/AlgAss/Ramification.jl
+++ b/src/AlgAss/Ramification.jl
@@ -136,15 +136,14 @@ function schur_index(A::AbsAlgAss{nf_elem}, P::InfPlc)
   @req iscentral(A) "Algebra must be central"
   @req issimple(A) "Algebra must be simple"
 
-  if dim(A) % 4 != 0
-    return 1
-  end
+  dim(A) % 4 == 0 && is_real(P) || return 1
 
-  x = trace_signature(A, P)
+  x, = trace_signature(A, P)
   n = root(dim(A), 2)
-  if x[1] == divexact(n * (n + 1),2)
+  if x == n * (n+1) / 2
     return 1
   else
+    @assert x == n * (n-1) / 2
     return 2
   end
 end

--- a/test/AlgAss/Ramification.jl
+++ b/test/AlgAss/Ramification.jl
@@ -118,4 +118,21 @@
 
   A = matrix_algebra(QQ, 2)
   @test schur_index(A) == 1
+
+  @testset "ignore complex embeddings" begin
+    # The schur index of QQ[i]^{2×2} is 1
+    # Test this for various ways of writing QQ[i]^{2×2}
+
+    X = zero_matrix(QQ, 4, 4)
+    Y = zero_matrix(QQ, 4, 4)
+    IM = QQ[0 -1;1 0]
+    X[1:2,1:2] = Y[1:2,3:4] = Y[3:4,1:2] = IM
+    QQIM2x2 = matrix_algebra(QQ, [X, Y])
+    QQIM2x2overQQi = Hecke._as_algebra_over_center(QQIM2x2)
+
+    QQi, i = cyclotomic_field(4, :i)
+    QQi2x2 = matrix_algebra(QQi, 2)
+    QQi2x2i = AlgAss(QQi, i * multiplication_table(QQi2x2))
+    @test schur_index(QQIM2x2overQQi) == schur_index(QQi2x2i) == schur_index(QQi2x2) == 1
+  end
 end

--- a/test/AlgAss/Ramification.jl
+++ b/test/AlgAss/Ramification.jl
@@ -123,16 +123,21 @@
     # The schur index of QQ[i]^{2×2} is 1
     # Test this for various ways of writing QQ[i]^{2×2}
 
+    QQi, i = cyclotomic_field(4, :i)
+    QQi2x2 = matrix_algebra(QQi, 2)
+    QQi2x2i = AlgAss(QQi, i .* multiplication_table(QQi2x2))
+
+    @test schur_index(QQi2x2) == 1 # harmless
+    @test schur_index(QQi2x2i) == 1
+
+    # A usecase where QQi2x2i can pop up
     X = zero_matrix(QQ, 4, 4)
     Y = zero_matrix(QQ, 4, 4)
     IM = QQ[0 -1;1 0]
     X[1:2,1:2] = Y[1:2,3:4] = Y[3:4,1:2] = IM
     QQIM2x2 = matrix_algebra(QQ, [X, Y])
-    QQIM2x2overQQi = Hecke._as_algebra_over_center(QQIM2x2)
+    QQIM2x2overQQi = Hecke._as_algebra_over_center(AlgAss(QQIM2x2)[1])[1]
 
-    QQi, i = cyclotomic_field(4, :i)
-    QQi2x2 = matrix_algebra(QQi, 2)
-    QQi2x2i = AlgAss(QQi, i * multiplication_table(QQi2x2))
-    @test schur_index(QQIM2x2overQQi) == schur_index(QQi2x2i) == schur_index(QQi2x2) == 1
+    @test schur_index(QQIM2x2overQQi) == 1
   end
 end


### PR DESCRIPTION
As described by Nebe and Steel on the third page of https://doi.org/10.1016/j.jalgebra.2009.04.026, the complex embeddings do not contribute to the Schur index, as $ℂ⊗A≅ℂ^{s×s}$ is always a full matrix algebra over ℂ. Only the infinite completions with real embeddings contribute, as there $ℝ⊗A$ can be isomorphic to $ℍ^{s/2×s/2}$ giving a Schur index of 2, or isomorphic to $ℝ^{s×s}$ giving trivial Schur index 1.

See the tests for an example of the full matrix algebra over $K=ℚ[i]$ but with the basis matrices multiplied with the some unit $α$. This should not change the Schur index, but with the current implementation this multiplication changes the Schur index from 1 to either 1, 2, or an error stemming from getting the “positive” roots of a polynomial like $y^4-1$.