### PR TITLE
Fix `is_isotropic`

### DIFF
--- a/src/QuadForm/Quad/Spaces.jl
+++ b/src/QuadForm/Quad/Spaces.jl
@@ -818,6 +818,7 @@ is_isotropic(V::QuadSpace{QQField,QQMatrix}, p::Int) = is_isotropic(V, ZZ(p))
 is_isotropic(V::QuadSpace{QQField,QQMatrix}, p::PosInf) = _isisotropic(diagonal(V), p)
 
 function is_isotropic(V::QuadSpace, p)
+  @req is_prime(p) "p must be prime"
   @hassert :Lattice 1 base_ring(V) == nf(order(p))
   d = det(V)
   n = rank(V)
@@ -829,7 +830,7 @@ function is_isotropic(V::QuadSpace, p)
   elseif n == 2
     return is_local_square(-d, p)
   elseif n == 3
-    return hasse_invariant(V, p) == hilbert_symbol(K(-1), K(-1), p)
+    return hasse_invariant(V, p) == hilbert_symbol(K(-1), -d, p)
   elseif n == 4
     return !is_local_square(d, p) || (hasse_invariant(V, p) == hilbert_symbol(K(-1), K(-1), p))
   else

--- a/test/QuadForm/Quad/Spaces.jl
+++ b/test/QuadForm/Quad/Spaces.jl
@@ -510,3 +510,17 @@ end
   end
   S, inj, proj = @inferred biproduct(V, V, V)
 end
+
+@testset "fix is_isotropic" begin
+  # Example Chapter 4, 1. (i) from Cassels
+  V = quadratic_space(QQ, diagonal_matrix(QQ, [5,-1,-3]))
+  # So by Cassels, Lemma 2.5, V is isotropic at all primes except 3 and 5
+  @test hilbert_symbol(QQ(-1), QQ(-15), ZZ(3)) != hasse_invariant(V, 3)
+  # What was previously implemented was then wrong because of the following
+  # inequality
+  @test hilbert_symbol(QQ(-1), QQ(-1), ZZ(3)) != hilbert_symbol(QQ(-1), QQ(-15), ZZ(3))
+  @test !is_isotropic(V, 3)
+  @test hilbert_symbol(QQ(-1), QQ(-15), ZZ(5)) != hasse_invariant(V, 5)
+  @test !is_isotropic(V, 5)
+  @test_throws ArgumentError is_isotropic(V, 4)
+end


### PR DESCRIPTION
Typo in the code of `is_isotropic` for quadratic spaces. I have fixed and put an example from Cassels for which the previous implementation could return a wrong output (I have checked it by hand, following Cassels propositions)