### PR TITLE
Speed up `multiplication_table(::AlgMat)`

### DIFF
--- a/src/AlgAss/AlgMat.jl
+++ b/src/AlgAss/AlgMat.jl
@@ -516,7 +516,7 @@ end
   return inv(U), pivots
 end
 
-function _matrix_in_algebra(M::S, A::AlgMat{T, S})::Vector{Q} where {T, Q, S<:MatElem{Q}}
+function _matrix_in_algebra(M::S, A::AlgMat{T, S}) where {T, S<:MatElem}
   @assert size(M) == (degree(A), degree(A))
   U, pivots = basis_matrix_transform(A) # U*basis_matrix(A)[:, pivots] == I
 
@@ -524,8 +524,8 @@ function _matrix_in_algebra(M::S, A::AlgMat{T, S})::Vector{Q} where {T, Q, S<:Ma
     ind = CartesianIndices(axes(M))
     t = [M[I] for I in ind[pivots]] # = M[ind[pivots]] if it were supported
   else
-    ind = CartesianIndices((axes(M)..., dim_of_coefficient_ring(A)))
-    t = [coefficients(M[I[2], I[3]])[I[1]] for I in ind[pivots]]
+    ind = CartesianIndices((dim_of_coefficient_ring(A), axes(M)...))
+    t = [coefficients(M[I[2], I[3]]; copy=false)[I[1]] for I in ind[pivots]]
   end
   return U*t
 end

--- a/src/AlgAss/AlgMat.jl
+++ b/src/AlgAss/AlgMat.jl
@@ -517,6 +517,7 @@ function _matrix_in_algebra(M::S, A::AlgMat{T, S}) where {T, S<:MatElem}
   # U * basis_matrix(A)[:, pivots] == R[:, pivots] == I, thus
   # U = inv(basis_matrix(A)[:, pivots]). So, for t = M[pivots],
   # summing (t*U)[i]*basis(A)[i] gives back M, for all M in the basis and hence for all M.
+  # Note: Unless `isbasis=true` was given in the constructor, basis(A) is already in rref, and U == I.
 
   if coefficient_ring(A) == base_ring(A)
     ind = CartesianIndices(axes(M))

--- a/src/AlgAss/AlgMat.jl
+++ b/src/AlgAss/AlgMat.jl
@@ -511,14 +511,12 @@ end
 #
 ################################################################################
 
-@attr function basis_matrix_transform(A::AlgMat)
-  _, U, pivots = basis_matrix_rref(A)
-  return inv(U), pivots
-end
-
 function _matrix_in_algebra(M::S, A::AlgMat{T, S}) where {T, S<:MatElem}
   @assert size(M) == (degree(A), degree(A))
-  U, pivots = basis_matrix_transform(A) # U*basis_matrix(A)[:, pivots] == I
+  _, U, pivots = basis_matrix_rref(A)
+  # U * basis_matrix(A)[:, pivots] == R[:, pivots] == I, thus
+  # U = inv(basis_matrix(A)[:, pivots]). So, for t = M[pivots],
+  # summing (t*U)[i]*basis(A)[i] gives back M, for all M in the basis and hence for all M.
 
   if coefficient_ring(A) == base_ring(A)
     ind = CartesianIndices(axes(M))
@@ -527,7 +525,7 @@ function _matrix_in_algebra(M::S, A::AlgMat{T, S}) where {T, S<:MatElem}
     ind = CartesianIndices((dim_of_coefficient_ring(A), axes(M)...))
     t = [coefficients(M[I[2], I[3]]; copy=false)[I[1]] for I in ind[pivots]]
   end
-  return U*t
+  return t*U
 end
 
 function _check_matrix_in_algebra(M::S, A::AlgMat{T, S}, short::Type{Val{U}} = Val{false}) where {S, T, U}

--- a/src/AlgAss/AlgMatElem.jl
+++ b/src/AlgAss/AlgMatElem.jl
@@ -20,16 +20,10 @@ end
 ################################################################################
 
 function assure_has_coeffs(a::AlgMatElem)
-  if a.has_coeffs
-    return nothing
+  if !a.has_coeffs
+    a.coeffs = _matrix_in_algebra(matrix(a), parent(a))
+    a.has_coeffs = true
   end
-
-  A = parent(a)
-  Ma = matrix(a)
-  b, c = _check_matrix_in_algebra(Ma, A)
-  @assert b "The element is not in the algebra."
-  a.coeffs = c
-  a.has_coeffs = true
   return nothing
 end
 
@@ -235,7 +229,7 @@ end
 
 function (A::AlgMat{T, S})(M::S; check::Bool = true) where {T, S}
   @assert base_ring(M) === coefficient_ring(A)
-  if check 
+  if check
     b, c = _check_matrix_in_algebra(M, A)
     @req b "Matrix not an element of the matrix algebra"
     z = AlgMatElem{T, typeof(A), S}(A, deepcopy(M))

--- a/test/AlgAss/AlgMat.jl
+++ b/test/AlgAss/AlgMat.jl
@@ -16,8 +16,9 @@
   end
 
   @testset "multiplication table" begin
-    M = matrix_algebra(QQ, [matrix(QQ,[4;;])]; isbasis=true)
-    @test multiplication_table(M) == [4;;;]
+    M = matrix_algebra(QQ, [matrix(QQ, 1, 1, [4])]; isbasis=true)
+    @test Hecke._matrix_in_algebra(matrix(QQ, 1, 1, [1]), M) == [QQ(1, 4)]
+    @test multiplication_table(M) == fill(QQ(4), 1, 1, 1)
   end
 
   @testset "Radical" begin

--- a/test/AlgAss/AlgMat.jl
+++ b/test/AlgAss/AlgMat.jl
@@ -15,6 +15,11 @@
     @test dim(A) == 4
   end
 
+  @testset "multiplication table" begin
+    M = matrix_algebra(QQ, [matrix(QQ,[4;;])]; isbasis=true)
+    @test multiplication_table(M) == [4;;;]
+  end
+
   @testset "Radical" begin
 
     mats = [[0 0 0 0 0 0 0 0 0 0;


### PR DESCRIPTION
This mostly improves the case of matrix algebras with small dimension `d=dim(A)` compared to the dimension `D=degree(A)^2*dim_of_coefficient_ring(A)` of the full matrix algebra.

This improves `coefficients(B[i]*B[j])` by exploiting, that we know `B[i]*B[j]` to be representable as linear combination of the $d$ entries of `B`. The old code in `_check_matrix_in_algebra` does a $D×D$ basis transform of our element `B[i]*B[j]`, checking, that it is then really spanned by the first $d$ unit vectors. The new `_matrix_in_algebra`  just transforms the $d$ pivot columns without a check.

This gave slight speedup in the full matrix algebra case (if one disables the late #1130 special handling) and tenfold and more, when $D÷d$ gets larger.

Probably, the `_check_matrix_in_algebra` code could also benefit from some of the changes I incorporated in the new variant.