### PR TITLE
Disable several `AlgAss` checks by default

### DIFF
--- a/src/AlgAss/AlgAss.jl
+++ b/src/AlgAss/AlgAss.jl
@@ -169,7 +169,7 @@ function AlgAss(R::Ring, mult_table::Array{T, 3}; check::Bool = true) where {T}
   return A
 end
 
-function AlgAss(R::Ring, d::Int, arr::Vector{T}) where {T}
+function AlgAss(R::Ring, d::Int, arr::Vector{T}; check::Bool = true) where {T}
   if d == 0
     return _zero_algebra(R)
   end
@@ -207,7 +207,7 @@ function AlgAss(f::PolyElem)
   end
   one = map(R, zeros(Int, n))
   one[1] = R(1)
-  A = AlgAss(R, mult_table, one)
+  A = AlgAss(R, mult_table, one; check = get_assertion_level(:AlgAss)>0)
   A.is_commutative = 1
   return A
 end
@@ -444,7 +444,7 @@ function AlgAss(I::Union{ NfAbsOrdIdl, AlgAssAbsOrdIdl }, J::Union{NfAbsOrdIdl, 
     end
   end
 
-  A = AlgAss(Fp, mult_table)
+  A = AlgAss(Fp, mult_table; check = get_assertion_level(:AlgAss)>0)
   if is_commutative(O)
     A.is_commutative = 1
   end
@@ -592,9 +592,9 @@ function AlgAss(O::Union{ NfRelOrd{T, S}, AlgAssRelOrd{T, S} }, I::Union{ NfRelO
   if isone(new_basisO[basis_elts[1]][1])
     one = zeros(Fp, length(basis_elts))
     one[1] = Fp(1)
-    A = AlgAss(Fp, mult_table, one)
+    A = AlgAss(Fp, mult_table, one; check = get_assertion_level(:AlgAss)>0)
   else
-    A = AlgAss(Fp, mult_table)
+    A = AlgAss(Fp, mult_table; check = get_assertion_level(:AlgAss)>0)
   end
   if is_commutative(O)
     A.is_commutative = 1
@@ -747,9 +747,9 @@ function AlgAss(I::Union{ NfRelOrdIdl{T, S}, AlgAssRelOrdIdl{T, S} }, J::Union{ 
   if isone(new_basisI[basis_elts[1]][1])
     one = zeros(Fp, length(basis_elts))
     one[1] = Fp(1)
-    A = AlgAss(Fp, mult_table, one)
+    A = AlgAss(Fp, mult_table, one; check = get_assertion_level(:AlgAss)>0)
   else
-    A = AlgAss(Fp, mult_table)
+    A = AlgAss(Fp, mult_table; check = get_assertion_level(:AlgAss)>0)
   end
   if is_commutative(O)
     A.is_commutative = 1
@@ -823,7 +823,7 @@ function AlgAss(A::Generic.MatAlgebra{T}) where { T <: FieldElem }
   for i = 1:n
     oneA[i + (i - 1)*n] = oneK
   end
-  A = AlgAss(K, mult_table, oneA)
+  A = AlgAss(K, mult_table, oneA; check = get_assertion_level(:AlgAss)>0)
   A.is_commutative = ( n == 1 ? 1 : 2 )
   return A
 end
@@ -1024,7 +1024,7 @@ function subalgebra(A::AlgAss{T}, basis::Vector{AlgAssElem{T, AlgAss{T}}}; is_co
     elem_to_mat_row!(M, i, basis[i])
   end
   mt = _build_subalgebra_mult_table!(A, M, is_commutative = is_commutative)
-  B = AlgAss(base_ring(A), mt)
+  B = AlgAss(base_ring(A), mt; check = get_assertion_level(:AlgAss)>0)
   return B, hom(B, A, sub(M, 1:length(basis), 1:dim(A)))
 end
 
@@ -1413,7 +1413,7 @@ function direct_product(a::AlgAss{T}, _algebras::AlgAss{T}...; task::Symbol = :s
     end
     offset += dd
   end
-  A = AlgAss(base_ring(algebras[1]), mt)
+  A = AlgAss(base_ring(algebras[1]), mt; check = get_assertion_level(:AlgAss)>0)
   if task == :none
     return A
   end
@@ -1506,7 +1506,7 @@ function quaternion_algebra2(K::Field, a::T, b::T) where { T <: FieldElem }
   M[4, 3, 2] = b
   M[4, 4, 1] = -a*b
 
-  return AlgAss(K, M, [ one(K), zero(K), zero(K), zero(K) ])
+  return AlgAss(K, M, [ one(K), zero(K), zero(K), zero(K) ]; check = get_assertion_level(:AlgAss)>0)
 end
 
 quaternion_algebra2(K::Field, a::Int, b::Int) = quaternion_algebra2(K, K(a), K(b))
@@ -1531,7 +1531,7 @@ function opposite_algebra(A::AlgAss)
   end
   o = one(A).coeffs
 
-  B = AlgAss(K, z, o)
+  B = AlgAss(K, z, o; check = get_assertion_level(:AlgAss)>0)
   return B, hom(A, B, identity_matrix(K, d), identity_matrix(K, d))
 end
 

--- a/src/AlgAss/AlgAss.jl
+++ b/src/AlgAss/AlgAss.jl
@@ -145,7 +145,7 @@ function AlgAss(R::Ring, mult_table::Array{T, 3}, one::Vector{T}; check::Bool = 
   A = AlgAss{T}(R, mult_table, one)
   if check
     @req check_associativity(A) "Multiplication table does not define associative operation"
-    @req check_distributivity(A) "Multiplication table does not define associative operation"
+    @req check_distributivity(A) "Multiplication table does not define distributive operation"
   end
   return A
 end
@@ -164,7 +164,7 @@ function AlgAss(R::Ring, mult_table::Array{T, 3}; check::Bool = true) where {T}
   end
   if check
     @req check_associativity(A) "Multiplication table does not define associative operation"
-    @req check_distributivity(A) "Multiplication table does not define associative operation"
+    @req check_distributivity(A) "Multiplication table does not define distributive operation"
   end
   return A
 end

--- a/src/AlgAss/AlgAss.jl
+++ b/src/AlgAss/AlgAss.jl
@@ -1,5 +1,7 @@
 export is_split, multiplication_table, restrict_scalars, center
 
+add_assertion_scope(:AlgAss)
+
 ################################################################################
 #
 #  Basic field access
@@ -313,9 +315,9 @@ function AlgAss(O::Union{NfAbsOrd, AlgAssAbsOrd}, I::Union{NfAbsOrdIdl, AlgAssAb
   if isone(BO[1])
     one = zeros(Fp, r)
     one[1] = Fp(1)
-    A = AlgAss(Fp, mult_table, one)
+    A = AlgAss(Fp, mult_table, one; check = get_assertion_level(:AlgAss)>0)
   else
-    A = AlgAss(Fp, mult_table)
+    A = AlgAss(Fp, mult_table; check = get_assertion_level(:AlgAss)>0)
   end
   if is_commutative(O)
     A.is_commutative = 1
@@ -975,9 +977,9 @@ function subalgebra(A::AlgAss{T}, e::AlgAssElem{T, AlgAss{T}}, idempotent::Bool 
     fl, vv = solve(LL, e.coeffs)
     @assert fl
     #@assert v == vv[1:r]
-    eA = AlgAss(R, mult_table, vv[1:r])
+    eA = AlgAss(R, mult_table, vv[1:r]; check = get_assertion_level(:AlgAss)>0)
   else
-    eA = AlgAss(R, mult_table)
+    eA = AlgAss(R, mult_table; check = get_assertion_level(:AlgAss)>0)
   end
 
   if A.is_commutative == 1

--- a/src/AlgAss/AlgGrp.jl
+++ b/src/AlgAss/AlgGrp.jl
@@ -228,7 +228,7 @@ function AlgAss(A::AlgGrp{T, S, R}) where {T, S, R}
       end
     end
   end
-  B = AlgAss(K, mult, one(A).coeffs, check = false)
+  B = AlgAss(K, mult, one(A).coeffs; check = get_assertion_level(:AlgAss)>0)
   B.is_commutative = A.is_commutative
   B.is_simple = A.is_simple
   B.issemisimple = A.issemisimple

--- a/src/AlgAss/AlgMat.jl
+++ b/src/AlgAss/AlgMat.jl
@@ -245,7 +245,7 @@ function matrix_algebra(R::Ring, n::Int)
     for j = 1:n
       M = zero_matrix(R, n, n)
       M[j, i] = one(R)
-      B[ni + j] = A(M, check = false)
+      B[ni + j] = A(M; check = get_assertion_level(:AlgAss)>1)
     end
   end
   A.basis = B
@@ -276,7 +276,7 @@ function matrix_algebra(R::Ring, S::Ring, n::Int)
       for j = 1:n
         M = zero_matrix(S, n, n)
         M[j, i] = S[k]
-        B[ni + j] = A(M, check = false)
+        B[ni + j] = A(M; check = get_assertion_level(:AlgAss)>1)
       end
     end
   end
@@ -304,12 +304,12 @@ function matrix_algebra(R::Ring, gens::Vector{<:MatElem}; isbasis::Bool = false)
     A.dim = length(gens)
     bas = Vector{elem_type(A)}(undef, dim(A))
     for i = 1:dim(A)
-      bas[i] = A(gens[i]; check = false)
+      bas[i] = A(gens[i]; check = get_assertion_level(:AlgAss)>1)
     end
     A.basis = bas
     return A
   end
-  A.gens = map(x -> A(x, check = false), gens)
+  A.gens = map(x -> A(x,; check = get_assertion_level(:AlgAss)>1), gens)
 
   d = degree(A)
   d2 = degree(A)^2

--- a/src/AlgAss/AlgMat.jl
+++ b/src/AlgAss/AlgMat.jl
@@ -243,7 +243,7 @@ function matrix_algebra(R::Ring, n::Int)
     for j = 1:n
       M = zero_matrix(R, n, n)
       M[j, i] = one(R)
-      B[ni + j] = A(M; check = get_assertion_level(:AlgAss)>1)
+      B[ni + j] = A(M, check = false)
     end
   end
   A.basis = B
@@ -274,7 +274,7 @@ function matrix_algebra(R::Ring, S::Ring, n::Int)
       for j = 1:n
         M = zero_matrix(S, n, n)
         M[j, i] = S[k]
-        B[ni + j] = A(M; check = get_assertion_level(:AlgAss)>1)
+        B[ni + j] = A(M, check = false)
       end
     end
   end
@@ -302,12 +302,12 @@ function matrix_algebra(R::Ring, gens::Vector{<:MatElem}; isbasis::Bool = false)
     A.dim = length(gens)
     bas = Vector{elem_type(A)}(undef, dim(A))
     for i = 1:dim(A)
-      bas[i] = A(gens[i]; check = get_assertion_level(:AlgAss)>1)
+      bas[i] = A(gens[i]; check = false)
     end
     A.basis = bas
     return A
   end
-  A.gens = map(x -> A(x,; check = get_assertion_level(:AlgAss)>1), gens)
+  A.gens = map(x -> A(x, check = false), gens)
 
   d = degree(A)
   d2 = degree(A)^2

--- a/src/AlgAss/AlgMat.jl
+++ b/src/AlgAss/AlgMat.jl
@@ -1,7 +1,5 @@
 export matrix_algebra
 
-add_assertion_scope(:AlgMat)
-
 ################################################################################
 #
 #  Basic field access

--- a/src/AlgAss/AlgMat.jl
+++ b/src/AlgAss/AlgMat.jl
@@ -1,5 +1,7 @@
 export matrix_algebra
 
+add_assertion_scope(:AlgMat)
+
 ################################################################################
 #
 #  Basic field access
@@ -596,7 +598,7 @@ end
 
 function AlgAss(A::AlgMat{T, S}) where {T, S}
   K = base_ring(A)
-  B = AlgAss(K, multiplication_table(A), coefficients(one(A)), check = false)
+  B = AlgAss(K, multiplication_table(A), coefficients(one(A)), check = get_assertion_level(:AlgAss)>0)
   B.is_simple = A.is_simple
   B.issemisimple = A.issemisimple
   AtoB = hom(A, B, identity_matrix(K, dim(A)), identity_matrix(K, dim(A)))

--- a/src/AlgAss/AlgMatElem.jl
+++ b/src/AlgAss/AlgMatElem.jl
@@ -105,7 +105,7 @@ end
 
 function *(a::T, b::T) where {T <: AlgMatElem}
   parent(a) != parent(b) && error("Parents don't match.")
-  return parent(a)(matrix(a, copy = false)*matrix(b, copy = false), check = false)
+  return parent(a)(matrix(a, copy = false)*matrix(b, copy = false), check = get_assertion_level(:AlgMat)>0)
 end
 
 ################################################################################

--- a/src/AlgAss/AlgMatElem.jl
+++ b/src/AlgAss/AlgMatElem.jl
@@ -105,7 +105,7 @@ end
 
 function *(a::T, b::T) where {T <: AlgMatElem}
   parent(a) != parent(b) && error("Parents don't match.")
-  return parent(a)(matrix(a, copy = false)*matrix(b, copy = false), check = get_assertion_level(:AlgMat)>0)
+  return parent(a)(matrix(a, copy = false)*matrix(b, copy = false), check = get_assertion_level(:AlgAss)>1)
 end
 
 ################################################################################

--- a/src/AlgAss/AlgQuat.jl
+++ b/src/AlgAss/AlgQuat.jl
@@ -387,7 +387,7 @@ function _change_basis(A::AlgAss, bas)
     end
   end
 
-  B = AlgAss(K, mt)
+  B = AlgAss(K, mt; check = get_assertion_level(:AlgAss)>0)
   h = hom(B, A, M, invM)
   return B, h
 end
@@ -515,6 +515,6 @@ end
 
 function AlgAss(A::AlgQuat)
   K = base_ring(A)
-  B = AlgAss(K, A.mult_table)
+  B = AlgAss(K, A.mult_table; check = get_assertion_level(:AlgAss)>0)
   return B, hom(A, B, identity_matrix(K, 4), identity_matrix(K, 4))
 end

--- a/src/AlgAss/ChangeRing.jl
+++ b/src/AlgAss/ChangeRing.jl
@@ -179,7 +179,7 @@ function _restrict_scalars(A::AbsAlgAss{T}, prime_field) where { T }
     end
   end
 
-  B = AlgAss(F, mult_table, y)
+  B = AlgAss(F, mult_table, y; check = get_assertion_level(:AlgAss)>0)
   B.is_commutative = is_commutative(A)
 
   return B, AlgAssResMor(B, A, f, absbasis)

--- a/src/AlgAss/ChangeRing.jl
+++ b/src/AlgAss/ChangeRing.jl
@@ -360,7 +360,7 @@ function __as_algebra_over_center(A, K, L, CtoA, CtoL)
   end
 
 
-  B = AlgAss(L, mult_table, y)
+  B = AlgAss(L, mult_table, y; check = get_assertion_level(:AlgAss)>0)
   B.is_commutative = A.is_commutative
 
   BtoA = AlgAssExtMor(B, A, CtoL, basisCinA, basisCinL, iMM, elem_type(A)[A[i] for i in AoverC])

--- a/src/AlgAss/Ideal.jl
+++ b/src/AlgAss/Ideal.jl
@@ -483,7 +483,7 @@ function quo(A::S, a::AbsAlgAssIdl{S, T, U}) where { S, T, U }
     end
   end
 
-  B = AlgAss(K, mult_table)
+  B = AlgAss(K, mult_table; check = get_assertion_level(:AlgAss)>0)
   AtoB = hom(A, B, NN, N)
   return B, AtoB
 end
@@ -531,7 +531,7 @@ function quo(a::AbsAlgAssIdl{S, T, U}, b::AbsAlgAssIdl{S, T, U}) where { S, T, U
   mult_table = _build_subalgebra_mult_table!(A, M)
   # M is now in rref
 
-  B = AlgAss(K, mult_table)
+  B = AlgAss(K, mult_table; check = get_assertion_level(:AlgAss)>0)
   MM = sub(M, 1:dim(B), 1:dim(A))
 
   AtoB = AbsAlgAssMor{typeof(A), typeof(B), typeof(MM)}(A, B)

--- a/src/AlgAssAbsOrd/PIP.jl
+++ b/src/AlgAssAbsOrd/PIP.jl
@@ -1459,7 +1459,7 @@ function _my_direct_product(algebras)
     push!(maps, BtoA)
     push!(pre_maps, AtoB)
   end
-  A = AlgAss(K, mt)
+  A = AlgAss(K, mt; check = get_assertion_level(:AlgAss)>0)
   A.decomposition = [ (algebras[i], hom(algebras[i], A, maps[i], pre_maps[i])) for i in 1:length(algebras) ]
   return A
 end

--- a/src/AlgAssAbsOrd/Quotient.jl
+++ b/src/AlgAssAbsOrd/Quotient.jl
@@ -27,7 +27,7 @@ function quotient_order(O::AlgAssAbsOrd, I::AlgAssAbsOrdIdl)
       mt[i, j, :] = (coordinates(bij) * V)[k:end]
     end
   end
-  quoAlg = AlgAss(QQ, mt)
+  quoAlg = AlgAss(QQ, mt; check = get_assertion_level(:AlgAss)>0)
   ord = Order(quoAlg, basis(quoAlg))
   #
   bminvO = QQMatrix(basis_mat_inv(O))

--- a/src/GenOrd/Ideal.jl
+++ b/src/GenOrd/Ideal.jl
@@ -792,9 +792,9 @@ function Hecke.AlgAss(O::GenOrd, I::GenOrdIdl, p::RingElem)
   if isone(BO[1])
     one = zeros(FQ, r)
     one[1] = FQ(1)
-    A = AlgAss(FQ, mult_table, one)
+    A = AlgAss(FQ, mult_table, one; check = get_assertion_level(:AlgAss)>0)
   else
-    A = AlgAss(FQ, mult_table)
+    A = AlgAss(FQ, mult_table; check = get_assertion_level(:AlgAss)>0)
   end
   if is_commutative(O)
     A.is_commutative = 1

--- a/src/QuadForm/Quad/GenusRep.jl
+++ b/src/QuadForm/Quad/GenusRep.jl
@@ -2045,7 +2045,7 @@ function _genus_representatives_binary_quadratic_indefinite(_L::QuadLat)
     end
   end
 
-  A = AlgAss(K, mult_tb)
+  A = AlgAss(K, mult_tb; check = get_assertion_level(:AlgAss)>0)
   B = basis(A)
   sigma(a) = A([a.coeffs[2], a.coeffs[1]])
   inv2 = inv(A(2))


### PR DESCRIPTION
More speedup when creating new `AlgAss` with computed multiplication tables, that mathematically have to be correct and where checking often needs a lot more time than everything else.

As I just fixed a bug in [47a74b6](https://github.com/thofma/Hecke.jl/pull/1132/commits/47a74b635b3a5b4dfc0d00df1ffe48b9d236bb77), where I did my maths wrong, optionally reenabling those and some previously disabled tests seems sensible to me.