### PR TITLE
Use `associative_algebra` as frontend to `AlgAss` and disable checks when calling `AlgAss` directly

### DIFF
--- a/src/AlgAss/AlgAss.jl
+++ b/src/AlgAss/AlgAss.jl
@@ -1,4 +1,4 @@
-export is_split, multiplication_table, restrict_scalars, center
+export associative_algebra, is_split, multiplication_table, restrict_scalars, center
 
 add_assertion_scope(:AlgAss)
 
@@ -196,7 +196,12 @@ function AlgAss(R::Ring, d::Int, arr::Vector{T}) where {T}
   return AlgAss(R, mult_table)
 end
 
-# Constructs the algebra R[X]/f
+raw"""
+    associative_algebra(f::PolyElem)
+
+Associative algebra $R[x]/f$.
+"""
+associative_algebra(f::PolyElem) = AlgAss(f)
 function AlgAss(f::PolyElem)
   R = base_ring(parent(f))
   n = degree(f)

--- a/src/AlgAss/AlgAss.jl
+++ b/src/AlgAss/AlgAss.jl
@@ -1,5 +1,7 @@
 export is_split, multiplication_table, restrict_scalars, center
 
+add_assertion_scope(:AlgAss)
+
 ################################################################################
 #
 #  Basic field access
@@ -136,19 +138,29 @@ function _zero_algebra(R::Ring)
   return A
 end
 
-function AlgAss(R::Ring, mult_table::Array{T, 3}, one::Vector{T}; check::Bool = true) where {T}
+raw"""
+    associative_algebra(R::Ring, mult_table::Array{T, 3}[, one::Vector{T}]; check::Bool = true) where T
+
+    Associative Algebra over `R` with generators $e_1,\dots,e_d$ where `size(mult_table) == (d, d, d)` and $e_ie_j$ = `sum(mult_table[i,j,k]*e[k] for k in 1:d)`.
+    Unless `check = false`, this includes (time consuming) associativity and distributivity checks.
+    If `one` is given, record the element with the according coefficient vector as one element of the algebra.
+"""
+associative_algebra(R::Ring, mult_table::Array{<:Any, 3}; check::Bool = true) = AlgAss(R, mult_table; check)
+associative_algebra(R::Ring, mult_table::Array{T, 3}, one::Vector{T}; check::Bool = true) where T = AlgAss(R, mult_table, one; check)
+
+function AlgAss(R::Ring, mult_table::Array{T, 3}, one::Vector{T}; check::Bool = get_assertion_level(:AlgAss)>0) where {T}
   if size(mult_table, 1) == 0
     return _zero_algebra(R)
   end
   A = AlgAss{T}(R, mult_table, one)
   if check
     @req check_associativity(A) "Multiplication table does not define associative operation"
-    @req check_distributivity(A) "Multiplication table does not define associative operation"
+    @req check_distributivity(A) "Multiplication table does not define distributive operation"
   end
   return A
 end
 
-function AlgAss(R::Ring, mult_table::Array{T, 3}; check::Bool = true) where {T}
+function AlgAss(R::Ring, mult_table::Array{T, 3}; check::Bool = get_assertion_level(:AlgAss)>0) where {T}
   if size(mult_table, 1) == 0
     return _zero_algebra(R)
   end
@@ -162,11 +174,12 @@ function AlgAss(R::Ring, mult_table::Array{T, 3}; check::Bool = true) where {T}
   end
   if check
     @req check_associativity(A) "Multiplication table does not define associative operation"
-    @req check_distributivity(A) "Multiplication table does not define associative operation"
+    @req check_distributivity(A) "Multiplication table does not define distributive operation"
   end
   return A
 end
 
+# Does anyone actually use this?
 function AlgAss(R::Ring, d::Int, arr::Vector{T}) where {T}
   if d == 0
     return _zero_algebra(R)

--- a/src/AlgAss/AlgMat.jl
+++ b/src/AlgAss/AlgMat.jl
@@ -596,7 +596,7 @@ end
 
 function AlgAss(A::AlgMat{T, S}) where {T, S}
   K = base_ring(A)
-  B = AlgAss(K, multiplication_table(A), coefficients(one(A)), check = false)
+  B = AlgAss(K, multiplication_table(A), coefficients(one(A)))
   B.is_simple = A.is_simple
   B.issemisimple = A.issemisimple
   AtoB = hom(A, B, identity_matrix(K, dim(A)), identity_matrix(K, dim(A)))

--- a/src/AlgAss/AlgMatElem.jl
+++ b/src/AlgAss/AlgMatElem.jl
@@ -105,7 +105,7 @@ end
 
 function *(a::T, b::T) where {T <: AlgMatElem}
   parent(a) != parent(b) && error("Parents don't match.")
-  return parent(a)(matrix(a, copy = false)*matrix(b, copy = false), check = false)
+  return parent(a)(matrix(a, copy = false)*matrix(b, copy = false); check = get_assertion_level(:AlgAss)>1)
 end
 
 ################################################################################

--- a/test/AlgAss/AlgAss.jl
+++ b/test/AlgAss/AlgAss.jl
@@ -48,7 +48,7 @@ end
 
   # creation
 
-  @test_throws ArgumentError AlgAss(QQ, map(QQ, reshape([1 2 1 2; 1 2 1 2], 2, 2, 2)))
+  @test_throws ArgumentError associative_algebra(QQ, map(QQ, reshape([1 2 1 2; 1 2 1 2], 2, 2, 2)))
 
   @testset "Change of ring" begin
 
@@ -106,7 +106,7 @@ end
     # Extend from F_p^m to F_p^n
     Fqx, x = Fq["x"]
     f = x^2 + 5x + 2
-    A = AlgAss(f)
+    A = associative_algebra(f)
     B, BtoA = Hecke._as_algebra_over_center(A)
     @test characteristic(base_ring(B)) == characteristic(Fq)
     @test absolute_degree(base_ring(B)) == degree(f)*degree(Fq)
@@ -124,7 +124,7 @@ end
     mt[2, 1, 2] = Fp(1)
     mt[2, 2, 1] = Fp(1)
     mt[2, 2, 2] = Fp(1)
-    A = AlgAss(Fp, mt)
+    A = associative_algebra(Fp, mt)
     B, BtoA = Hecke._as_algebra_over_center(A)
     @test characteristic(base_ring(B)) == characteristic(Fp)
     @test degree(base_ring(B)) == dim(A)
@@ -220,7 +220,7 @@ end
 
     K, a = number_field(x^2 - 2, "a")
     HH = Hecke.quaternion_algebra2(2, 3)
-    A = AlgAss(K, map(K, HH.mult_table))
+    A = associative_algebra(K, map(K, HH.mult_table))
     Ps = real_places(K)
     @test is_split(A, Ps[1])
     @test is_split(A, Ps[2])


### PR DESCRIPTION
Concept for an alternative to #1133.