### PR TITLE
Miscellaneous matrix methods

### DIFF
--- a/src/Misc/Matrix.jl
+++ b/src/Misc/Matrix.jl
@@ -1902,6 +1902,19 @@ Return `rank(H), p` such that `p[j]` states whether the `j`th column is a pivot 
 The input `H` must be in row echelon form.
 
 See also: `rank_of_ref`, `pivot_cols_of_ref`, `non_pivot_cols_of_ref`.
+
+# Examples
+```jldoctest
+julia> pivots_of_ref(QQ[1 1; 0 1])
+(2, Bool[1, 1])
+
+julia> pivots_of_ref(QQ[1 1; 0 0])
+(1, Bool[1, 0])
+
+julia> pivots_of_ref(QQ[0 2 2 2 2; 0 0 3 3 3; 0 0 0 4 4])
+(3, Bool[0, 1, 1, 1, 0])
+
+```
 """
 function pivots_of_ref(H::MatrixElem) :: Tuple{Int, BitVector}
   p = falses(ncols(H))
@@ -1919,6 +1932,19 @@ end
 Rank of a row echelon matrix.
 
 See also: `pivots_of_ref`, `pivot_cols_of_ref`, `non_pivot_cols_of_ref`.
+
+# Examples
+```jldoctest
+julia> rank_of_ref(QQ[1 1; 0 1])
+2
+
+julia> pivots_of_ref(QQ[1 1; 0 0])
+1
+
+julia> pivots_of_ref(QQ[0 2 2 2 2; 0 0 3 3 3; 0 0 0 4 4])
+3
+
+```
 """
 function rank_of_ref(H::MatrixElem)
   i = 1
@@ -1935,6 +1961,25 @@ end
 Vector of the indices of pivot columns of a row echelon matrix in increasing order.
 
 See also: `pivots_of_ref`, `rank_of_ref`, `non_pivot_cols_of_ref`.
+
+# Examples
+```jldoctest
+julia> pivot_cols_of_ref(QQ[1 1; 0 1])
+2-element Vector{Int64}:
+ 1
+ 2
+
+julia> pivot_cols_of_ref(QQ[1 1; 0 0])
+1-element Vector{Int64}:
+ 1
+
+julia> pivot_cols_of_ref(QQ[0 2 2 2 2; 0 0 3 3 3; 0 0 0 4 4])
+3-element Vector{Int64}:
+ 2
+ 3
+ 4
+
+```
 """
 pivot_cols_of_ref(H::MatrixElem) = findall(pivots_of_ref(H)[2])
 
@@ -1944,6 +1989,22 @@ pivot_cols_of_ref(H::MatrixElem) = findall(pivots_of_ref(H)[2])
 Vector of the indices of non-pivot columns of a row echelon matrix in increasing order.
 
 See also: `pivots_of_ref`, `rank_of_ref`, `pivot_cols_of_ref`
+
+# Examples
+```jldoctest
+julia> non_pivot_cols_of_ref(QQ[1 1; 0 1])
+Int64[]
+
+julia> non_pivot_cols_of_ref(QQ[1 1; 0 0])
+1-element Vector{Int64}:
+ 2
+
+julia> non_pivot_cols_of_ref(QQ[0 2 2 2 2; 0 0 3 3 3; 0 0 0 4 4])
+2-element Vector{Int64}:
+ 1
+ 5
+
+```
 """
 non_pivot_cols_of_ref(H::MatrixElem) = findall(!, pivots_of_ref(H)[2])
 

--- a/src/Misc/Matrix.jl
+++ b/src/Misc/Matrix.jl
@@ -1938,10 +1938,10 @@ See also: `pivots_of_ref`, `pivot_cols_of_ref`, `non_pivot_cols_of_ref`.
 julia> Hecke.rank_of_ref(QQ[1 1; 0 1])
 2
 
-julia> Hecke.pivots_of_ref(QQ[1 1; 0 0])
+julia> Hecke.rank_of_ref(QQ[1 1; 0 0])
 1
 
-julia> Hecke.pivots_of_ref(QQ[0 2 2 2 2; 0 0 3 3 3; 0 0 0 4 4])
+julia> Hecke.rank_of_ref(QQ[0 2 2 2 2; 0 0 3 3 3; 0 0 0 4 4])
 3
 
 ```

--- a/src/Misc/Matrix.jl
+++ b/src/Misc/Matrix.jl
@@ -1899,7 +1899,7 @@ end
     pivots_of_ref(H::MatrixElem) -> Tuple{Int, BitVector}
 
 Return `rank(H), p` such that `p[j]` states whether the `j`th column is a pivot column.
-The input `H` must be in row echolon form.
+The input `H` must be in row echelon form.
 
 See also: `rank_of_ref`, `pivot_cols_of_ref`, `non_pivot_cols_of_ref`.
 """
@@ -1916,7 +1916,7 @@ end
 """
     rank_of_ref(H::MatrixElem) -> Int
 
-Rank of a row echolon matrix.
+Rank of a row echelon matrix.
 
 See also: `pivots_of_ref`, `pivot_cols_of_ref`, `non_pivot_cols_of_ref`.
 """
@@ -1932,7 +1932,7 @@ end
 """
     pivot_cols_of_ref(H::MatrixElem) -> Vector{Int}
 
-Vector of the indices of pivot columns of a row echolon matrix in increasing order.
+Vector of the indices of pivot columns of a row echelon matrix in increasing order.
 
 See also: `pivots_of_ref`, `rank_of_ref`, `non_pivot_cols_of_ref`.
 """
@@ -1941,7 +1941,7 @@ pivot_cols_of_ref(H::MatrixElem) = findall(pivots_of_ref(H)[2])
 """
     non_pivot_cols_of_ref(H::MatrixElem) -> Vector{Int}
 
-Vector of the indices of non-pivot columns of a row echolon matrix in increasing order.
+Vector of the indices of non-pivot columns of a row echelon matrix in increasing order.
 
 See also: `pivots_of_ref`, `rank_of_ref`, `pivot_cols_of_ref`
 """

--- a/src/Misc/Matrix.jl
+++ b/src/Misc/Matrix.jl
@@ -1905,13 +1905,13 @@ See also: `rank_of_ref`, `pivot_cols_of_ref`, `non_pivot_cols_of_ref`.
 
 # Examples
 ```jldoctest
-julia> pivots_of_ref(QQ[1 1; 0 1])
+julia> Hecke.pivots_of_ref(QQ[1 1; 0 1])
 (2, Bool[1, 1])
 
-julia> pivots_of_ref(QQ[1 1; 0 0])
+julia> Hecke.pivots_of_ref(QQ[1 1; 0 0])
 (1, Bool[1, 0])
 
-julia> pivots_of_ref(QQ[0 2 2 2 2; 0 0 3 3 3; 0 0 0 4 4])
+julia> Hecke.pivots_of_ref(QQ[0 2 2 2 2; 0 0 3 3 3; 0 0 0 4 4])
 (3, Bool[0, 1, 1, 1, 0])
 
 ```
@@ -1935,13 +1935,13 @@ See also: `pivots_of_ref`, `pivot_cols_of_ref`, `non_pivot_cols_of_ref`.
 
 # Examples
 ```jldoctest
-julia> rank_of_ref(QQ[1 1; 0 1])
+julia> Hecke.rank_of_ref(QQ[1 1; 0 1])
 2
 
-julia> pivots_of_ref(QQ[1 1; 0 0])
+julia> Hecke.pivots_of_ref(QQ[1 1; 0 0])
 1
 
-julia> pivots_of_ref(QQ[0 2 2 2 2; 0 0 3 3 3; 0 0 0 4 4])
+julia> Hecke.pivots_of_ref(QQ[0 2 2 2 2; 0 0 3 3 3; 0 0 0 4 4])
 3
 
 ```
@@ -1964,16 +1964,16 @@ See also: `pivots_of_ref`, `rank_of_ref`, `non_pivot_cols_of_ref`.
 
 # Examples
 ```jldoctest
-julia> pivot_cols_of_ref(QQ[1 1; 0 1])
+julia> Hecke.pivot_cols_of_ref(QQ[1 1; 0 1])
 2-element Vector{Int64}:
  1
  2
 
-julia> pivot_cols_of_ref(QQ[1 1; 0 0])
+julia> Hecke.pivot_cols_of_ref(QQ[1 1; 0 0])
 1-element Vector{Int64}:
  1
 
-julia> pivot_cols_of_ref(QQ[0 2 2 2 2; 0 0 3 3 3; 0 0 0 4 4])
+julia> Hecke.pivot_cols_of_ref(QQ[0 2 2 2 2; 0 0 3 3 3; 0 0 0 4 4])
 3-element Vector{Int64}:
  2
  3
@@ -1992,14 +1992,14 @@ See also: `pivots_of_ref`, `rank_of_ref`, `pivot_cols_of_ref`
 
 # Examples
 ```jldoctest
-julia> non_pivot_cols_of_ref(QQ[1 1; 0 1])
+julia> Hecke.non_pivot_cols_of_ref(QQ[1 1; 0 1])
 Int64[]
 
-julia> non_pivot_cols_of_ref(QQ[1 1; 0 0])
+julia> Hecke.non_pivot_cols_of_ref(QQ[1 1; 0 0])
 1-element Vector{Int64}:
  2
 
-julia> non_pivot_cols_of_ref(QQ[0 2 2 2 2; 0 0 3 3 3; 0 0 0 4 4])
+julia> Hecke.non_pivot_cols_of_ref(QQ[0 2 2 2 2; 0 0 3 3 3; 0 0 0 4 4])
 2-element Vector{Int64}:
  1
  5


### PR DESCRIPTION
The call to `hnf(A)` gives a row echelon form, but no information about rank or pivots. These fast methods provide that information. (Without verifying the echelon form.)

Also fix the `transpose!` method, I have lately introduced.