### PR TITLE
Remove code dependent on old Nemo versions

### DIFF
--- a/src/LinearAlgebra/Howell.jl
+++ b/src/LinearAlgebra/Howell.jl
@@ -9,116 +9,58 @@ end
 #
 ###############################################################################
 
-if Nemo.version() > v"0.15.1"
-  function howell_form(A::Generic.Mat{Nemo.ZZModRingElem})
-    local B::ZZMatrix
-    if nrows(A) < ncols(A)
-      B = vcat(lift(A), zero_matrix(FlintZZ, ncols(A)-nrows(A), ncols(A)))
-    else
-      B = lift(A)
-    end
-    R = base_ring(A)
-    ccall((:fmpz_mat_howell_form_mod, libflint), Nothing,
-                (Ref{ZZMatrix}, Ref{ZZRingElem}), B, modulus(R))
-    return change_base_ring(B, R)
+function howell_form(A::Generic.Mat{Nemo.ZZModRingElem})
+  local B::ZZMatrix
+  if nrows(A) < ncols(A)
+    B = vcat(lift(A), zero_matrix(FlintZZ, ncols(A)-nrows(A), ncols(A)))
+  else
+    B = lift(A)
   end
+  R = base_ring(A)
+  ccall((:fmpz_mat_howell_form_mod, libflint), Nothing,
+              (Ref{ZZMatrix}, Ref{ZZRingElem}), B, modulus(R))
+  return change_base_ring(B, R)
+end
+
+#
+#  for the in-place function, the number of rows must be at least equal to the number of columns
+#
+function howell_form!(A::Generic.Mat{Nemo.ZZModRingElem})
+
+  R = base_ring(A)
+  A1 = lift(A)
+  ccall((:fmpz_mat_howell_form_mod, libflint), Nothing,
+                (Ref{ZZMatrix}, Ref{ZZRingElem}), A1, modulus(R))
+  for i in 1:nrows(A)
+    for j in 1:ncols(A)
+      A[i, j] = A1[i, j]
+    end
+  end
+  return A
+end
+
+function triangularize!(A::Generic.Mat{Nemo.ZZModRingElem})
+  R=base_ring(A)
+  n=R.modulus
 
   #
-  #  for the in-place function, the number of rows must be at least equal to the number of columns
+  #  Get an upper triangular matrix
   #
-  function howell_form!(A::Generic.Mat{Nemo.ZZModRingElem})
 
-    R = base_ring(A)
-    A1 = lift(A)
-    ccall((:fmpz_mat_howell_form_mod, libflint), Nothing,
-                  (Ref{ZZMatrix}, Ref{ZZRingElem}), A1, modulus(R))
-    for i in 1:nrows(A)
-      for j in 1:ncols(A)
-        A[i, j] = A1[i, j]
-      end
-    end
-    return A
-  end
-
-  function triangularize!(A::Generic.Mat{Nemo.ZZModRingElem})
-    R=base_ring(A)
-    n=R.modulus
-
-    #
-    #  Get an upper triangular matrix
-    #
-
-    for j=1:ncols(A)
-      for i=j+1:ncols(A)
-        g,s,t,u,v = _xxgcd(A[j,j].data,A[i,j].data,n)
-        for k in 1:ncols(A)
-          t1 = s* A[j,k] + t* A[i,k]
-          t2 = u* A[j,k] + v* A[i,k]
-          A[j,k] = t1
-          A[i,k] = t2
-        end
-      end
-    end
-  end
-
-  function triangularize(A::Generic.Mat{Nemo.ZZModRingElem})
-    B= triangularize!(deepcopy(A))
-    return B
-  end
-else
-  function howell_form(A::Generic.Mat{Nemo.Generic.ResidueRingElem{Nemo.ZZRingElem}})
-    local B::ZZMatrix
-    if nrows(A) < ncols(A)
-      B = vcat(lift(A), zero_matrix(FlintZZ, ncols(A)-nrows(A), ncols(A)))
-    else
-      B = lift(A)
-    end
-    R = base_ring(A)
-    ccall((:fmpz_mat_howell_form_mod, libflint), Nothing,
-          (Ref{ZZMatrix}, Ref{ZZRingElem}), B, modulus(R))
-    return change_base_ring(B, R)
-  end
-
-  #
-  #  for the in-place function, the number of rows must be at least equal to the number of columns
-  #
-  function howell_form!(A::Generic.Mat{Nemo.Generic.ResidueRingElem{Nemo.ZZRingElem}})
-
-    R = base_ring(A)
-    A1 = lift(A)
-    ccall((:fmpz_mat_howell_form_mod, libflint), Nothing,
-          (Ref{ZZMatrix}, Ref{ZZRingElem}), A1, modulus(R))
-    for i in 1:nrows(A)
-      for j in 1:ncols(A)
-        A[i, j] = A1[i, j]
-      end
-    end
-    return A
-  end
-
-  function triangularize!(A::Generic.Mat{Nemo.Generic.ResidueRingElem{Nemo.ZZRingElem}})
-    R=base_ring(A)
-    n=R.modulus
-
-    #
-    #  Get an upper triangular matrix
-    #
-
-    for j=1:ncols(A)
-      for i=j+1:ncols(A)
-        g,s,t,u,v = _xxgcd(A[j,j].data,A[i,j].data,n)
-        for k in 1:ncols(A)
-          t1 = s* A[j,k] + t* A[i,k]
-          t2 = u* A[j,k] + v* A[i,k]
-          A[j,k] = t1
-          A[i,k] = t2
-        end
+  for j=1:ncols(A)
+    for i=j+1:ncols(A)
+      g,s,t,u,v = _xxgcd(A[j,j].data,A[i,j].data,n)
+      for k in 1:ncols(A)
+        t1 = s* A[j,k] + t* A[i,k]
+        t2 = u* A[j,k] + v* A[i,k]
+        A[j,k] = t1
+        A[i,k] = t2
       end
     end
   end
+end
 
-  function triangularize(A::Generic.Mat{Nemo.Generic.ResidueRingElem{Nemo.ZZRingElem}})
-    B= triangularize!(deepcopy(A))
-    return B
-  end
+function triangularize(A::Generic.Mat{Nemo.ZZModRingElem})
+  B= triangularize!(deepcopy(A))
+  return B
 end

--- a/src/Map/FqPolyRing.jl
+++ b/src/Map/FqPolyRing.jl
@@ -156,10 +156,8 @@ mutable struct FqPolyRingToFqMor{S, T, PolyType, MatType} <: Map{S, T, HeckeMap,
   end
 end
 
-if Nemo.version() > v"0.28.0"
-  function FqPolyRingToFqMor(h::FqPolyRepPolyRingElem)
-    return FqPolyRingToFqMor{FqPolyRepPolyRing, FqPolyRepField, FqPolyRepPolyRingElem, FpMatrix}(h)
-  end
+function FqPolyRingToFqMor(h::FqPolyRepPolyRingElem)
+  return FqPolyRingToFqMor{FqPolyRepPolyRing, FqPolyRepField, FqPolyRepPolyRingElem, FpMatrix}(h)
 end
 
 function FqPolyRingToFqMor(h::fqPolyRepPolyRingElem)

--- a/src/Misc/Integer.jl
+++ b/src/Misc/Integer.jl
@@ -228,16 +228,6 @@ function modord(a::Integer, m::Integer)
 end
 
 
-if Nemo.version() <= v"0.15.1"
-  function isodd(a::ZZRingElem)
-    ccall((:fmpz_is_odd, libflint), Int, (Ref{ZZRingElem},), a) == 1
-  end
-
-  function iseven(a::ZZRingElem)
-    ccall((:fmpz_is_even, libflint), Int, (Ref{ZZRingElem},), a) == 1
-  end
-end
-
 function neg!(a::ZZRingElem)
   ccall((:fmpz_neg, libflint), Nothing, (Ref{ZZRingElem}, Ref{ZZRingElem}), a, a)
   return a

--- a/src/Misc/Matrix.jl
+++ b/src/Misc/Matrix.jl
@@ -647,17 +647,14 @@ function lift_nonsymmetric(a::fpMatrix)
   return z
 end
 
-
-if Nemo.version() > v"0.15.1"
-  function lift(a::Generic.Mat{Nemo.ZZModRingElem})
-    z = zero_matrix(FlintZZ, nrows(a), ncols(a))
-    for i in 1:nrows(a)
-      for j in 1:ncols(a)
-        z[i, j] = lift(a[i, j])
-      end
+function lift(a::Generic.Mat{Nemo.ZZModRingElem})
+  z = zero_matrix(FlintZZ, nrows(a), ncols(a))
+  for i in 1:nrows(a)
+    for j in 1:ncols(a)
+      z[i, j] = lift(a[i, j])
     end
-    return z
   end
+  return z
 end
 
 function lift_unsigned(a::zzModMatrix)

--- a/src/Misc/Poly.jl
+++ b/src/Misc/Poly.jl
@@ -45,18 +45,16 @@ function (::ZZRing)(a::Nemo.zzModRingElem)
   return ZZRingElem(a.data)
 end
 
-if Nemo.version() > v"0.15.1"
-  function ZZRingElem(a::Nemo.ZZModRingElem)
-    return a.data
-  end
+function ZZRingElem(a::Nemo.ZZModRingElem)
+  return a.data
+end
 
-  function lift(::ZZRing, a::Nemo.ZZModRingElem)
-    return a.data
-  end
+function lift(::ZZRing, a::Nemo.ZZModRingElem)
+  return a.data
+end
 
-  function (::ZZRing)(a::Nemo.ZZModRingElem)
-    return a.data
-  end
+function (::ZZRing)(a::Nemo.ZZModRingElem)
+  return a.data
 end
 
 function div(f::PolyElem, g::PolyElem)

--- a/src/Misc/UnitsModM.jl
+++ b/src/Misc/UnitsModM.jl
@@ -20,15 +20,13 @@ function is_primitive_root(x::Generic.ResidueRingElem{ZZRingElem}, M::ZZRingElem
   return true
 end
 
-if Nemo.version() > v"0.15.1"
-  function is_primitive_root(x::Nemo.ZZModRingElem, M::ZZRingElem, fM::Fac{ZZRingElem})
-    for (p, l) in fM
-      if x^divexact(M, p) == 1
-        return false
-      end
+function is_primitive_root(x::Nemo.ZZModRingElem, M::ZZRingElem, fM::Fac{ZZRingElem})
+  for (p, l) in fM
+    if x^divexact(M, p) == 1
+      return false
     end
-    return true
   end
+  return true
 end
 
 #=

--- a/src/NumFieldOrd/NfOrd/StrongEchelonForm.jl
+++ b/src/NumFieldOrd/NfOrd/StrongEchelonForm.jl
@@ -351,13 +351,11 @@ function can_make_small(Q::Generic.ResidueRing{ZZRingElem})
   end
 end
 
-if Nemo.version() > v"0.15.1"
-  function can_make_small(Q::Nemo.ZZModRing)
-    if nbits(modulus(Q)) < Sys.WORD_SIZE - 1
-      return true
-    else
-      return false
-    end
+function can_make_small(Q::Nemo.ZZModRing)
+  if nbits(modulus(Q)) < Sys.WORD_SIZE - 1
+    return true
+  else
+    return false
   end
 end
 
@@ -368,13 +366,11 @@ function make_small(Q::Generic.ResidueRing{ZZRingElem})
   return R, f, g
 end
 
-if Nemo.version() > v"0.15.1"
-  function make_small(Q::Nemo.ZZModRing)
-    R = residue_ring(FlintZZ, Int(modulus(Q)), cached = false)
-    f = (x -> R(data(x))::zzModRingElem)
-    g = (x -> Q(x.data)::Nemo.ZZModRingElem)
-    return R, f, g
-  end
+function make_small(Q::Nemo.ZZModRing)
+  R = residue_ring(FlintZZ, Int(modulus(Q)), cached = false)
+  f = (x -> R(data(x))::zzModRingElem)
+  g = (x -> Q(x.data)::Nemo.ZZModRingElem)
+  return R, f, g
 end
 
 


### PR DESCRIPTION
Nemo's compat is fixed to at least 0.34. Thus all of these checks for old Nemo versions can be safely removed.