### PR TITLE
Fix alignment in printing of maps for restriction of scalars

### DIFF
--- a/src/QuadForm/Misc.jl
+++ b/src/QuadForm/Misc.jl
@@ -12,7 +12,7 @@ function Base.show(io::IO, ::MIME"text/plain", f::VecSpaceRes)
   io = pretty(io)
   println(io, "Map of change of scalars")
   println(io, Indent(), "from vector space of dimension ", n, " over ", Lowercase(), QQ)
-  print(io, "to vector space of dimension ", m, " over ", Lowercase())
+  print(io, "to   vector space of dimension ", m, " over ", Lowercase())
   print(io, f.field)
   print(io, Dedent())
 end
@@ -29,7 +29,7 @@ function Base.show(io::IO, ::MIME"text/plain", f::AbstractSpaceRes)
   io = pretty(io)
   println(io, "Map of change of scalars")
   println(io, Indent(), "from ", Lowercase(), domain(f))
-  print(io, "to ", Lowercase(), codomain(f))
+  print(io, "to   ", Lowercase(), codomain(f))
   print(io, Dedent())
 end
 


### PR DESCRIPTION
This might break a doctest in Oscar (for `hermitian_structure(::ZZLatWithIsom)`)