### PR TITLE
Remove wildly general `check_parent`

### DIFF
--- a/src/GenOrd/Ideal.jl
+++ b/src/GenOrd/Ideal.jl
@@ -251,8 +251,7 @@ end
 
 
 function Base.:(+)(a::GenOrdIdl, b::GenOrdIdl)
-  check_parent(a, b)
-  O = order(a)
+  @req order(a) === order(b) "Ideals must have same order"
 
   if iszero(a)
     return b

--- a/src/NumField/NfRel/NfRel.jl
+++ b/src/NumField/NfRel/NfRel.jl
@@ -443,10 +443,6 @@ function add!(c::NfRelElem{T}, a::NfRelElem{T}, b::NfRelElem{T}) where {T}
   return c
 end
 
-function check_parent(a, b)
-  return a==b
-end
-
 ################################################################################
 #
 #  Hash function


### PR DESCRIPTION
This removes the code mentioned in https://github.com/thofma/Hecke.jl/issues/1145 to see where it is currently used aka what fails without it.

Resolves #1145.