### PR TITLE
Let `AbsAlgAss` no longer be a `Ring`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,7 +28,7 @@ GAPExt = "GAP"
 PolymakeExt = "Polymake"
 
 [compat]
-AbstractAlgebra = "^0.31.0"
+AbstractAlgebra = "^0.32.0"
 GAP = "0.9.6"
 Nemo = "^0.35.1"
 Polymake = "0.10, 0.11"

--- a/src/AlgAss/AlgMat.jl
+++ b/src/AlgAss/AlgMat.jl
@@ -256,12 +256,12 @@ end
 
 # Constructs Mat_n(S) as an R-algebra
 @doc raw"""
-    matrix_algebra(R::Ring, S::Ring, n::Int) -> AlgMat
+    matrix_algebra(R::Ring, S::NCRing, n::Int) -> AlgMat
 
 Returns $\mathrm{Mat}_n(S)$ as an $R$-algebra.
 It is assumed that $S$ is an $R$-algebra.
 """
-function matrix_algebra(R::Ring, S::Ring, n::Int)
+function matrix_algebra(R::Ring, S::NCRing, n::Int)
   A = AlgMat{elem_type(R), dense_matrix_type(elem_type(S))}(R, S)
   n2 = n^2
   A.dim = n2*dim(S)
@@ -369,7 +369,7 @@ function matrix_algebra(R::Ring, gens::Vector{<:MatElem}; isbasis::Bool = false)
 end
 
 @doc raw"""
-    matrix_algebra(R::Ring, S::Ring, gens::Vector{<: MatElem};
+    matrix_algebra(R::Ring, S::NCRing, gens::Vector{<: MatElem};
                    isbasis::Bool = false)
       -> AlgMat
 
@@ -380,7 +380,7 @@ If `isbasis` is `true`, it is assumed that the given matrices are an $R$-basis
 of this algebra, i. e. that the spanned $R$-module is closed under
 multiplication.
 """
-function matrix_algebra(R::AbstractAlgebra.NCRing, S::AbstractAlgebra.NCRing, gens::Vector{<:MatElem}; isbasis::Bool = false)
+function matrix_algebra(R::Ring, S::NCRing, gens::Vector{<:MatElem}; isbasis::Bool = false)
   @assert length(gens) > 0
   A = AlgMat{elem_type(R), dense_matrix_type(elem_type(S))}(R, S)
   A.degree = nrows(gens[1])

--- a/src/AlgAss/Types.jl
+++ b/src/AlgAss/Types.jl
@@ -279,7 +279,7 @@ end
 # T == elem_type(base_ring), S == dense_matrix_type(coefficient_ring)
 @attributes mutable struct AlgMat{T, S} <: AbsAlgAss{T}
   base_ring::Ring
-  coefficient_ring::Ring
+  coefficient_ring::NCRing
   one::S
   basis
   basis_matrix # matrix over the base_ring
@@ -312,7 +312,7 @@ end
     return A
   end
 
-  function AlgMat{T, S}(R1::Ring, R2::Ring) where {T, S}
+  function AlgMat{T, S}(R1::Ring, R2::NCRing) where {T, S}
     A = new{T, S}()
     A.base_ring = R1
     A.coefficient_ring = R2

--- a/src/AlgAss/Types.jl
+++ b/src/AlgAss/Types.jl
@@ -1,8 +1,8 @@
 export AlgAss, AlgAssElem, AlgGrp, AlgGrpElem, AlgMat, AlgMatElem
 
-abstract type AbsAlgAss{T} <: Ring end
+abstract type AbsAlgAss{T} <: NCRing end
 
-abstract type AbsAlgAssElem{T} <: RingElem end
+abstract type AbsAlgAssElem{T} <: NCRingElem end
 
 ################################################################################
 #

--- a/src/AlgAss/Types.jl
+++ b/src/AlgAss/Types.jl
@@ -346,13 +346,3 @@ mutable struct AlgMatElem{T, S, Mat} <: AbsAlgAssElem{T}
     return z
   end
 end
-
-################################################################################
-#
-#  Polynomial ring hack
-#
-################################################################################
-
-function AbstractAlgebra.polynomial_ring(A::AbsAlgAss, s::Symbol; cached::Bool = true)
-  return invoke(Generic.polynomial_ring, Tuple{AbstractAlgebra.NCRing, Symbol}, A, s; cached = cached)
-end

--- a/src/AlgAssAbsOrd/Ideal.jl
+++ b/src/AlgAssAbsOrd/Ideal.jl
@@ -1837,7 +1837,7 @@ end
 RandomExtensions.maketype(P::AlgAssAbsOrdIdl, ::Int) = elem_type(algebra(P))
 
 function rand(rng::AbstractRNG,
-              sp::SamplerTrivial{<:Make2{<:RingElem,<:AlgAssAbsOrdIdl,Int}})
+              sp::SamplerTrivial{<:Make2{<:NCRingElem,<:AlgAssAbsOrdIdl,Int}})
   a, B = sp[][1:end]
   r = rand(rng, -B:B, dim(algebra(a)))
   b = basis(a, copy = false)

--- a/src/AlgAssAbsOrd/Order.jl
+++ b/src/AlgAssAbsOrd/Order.jl
@@ -428,7 +428,7 @@ end
 RandomExtensions.maketype(O::AlgAssAbsOrd, R::AbstractUnitRange) = elem_type(O)
 
 function rand(rng::AbstractRNG,
-              sp::SamplerTrivial{<:Make2{<:RingElem,<:AlgAssAbsOrd,<:AbstractUnitRange}})
+              sp::SamplerTrivial{<:Make2{<:NCRingElem,<:AlgAssAbsOrd,<:AbstractUnitRange}})
   O, R = sp[][1:2]
   O(map(ZZRingElem, rand(rng, R, degree(O))))
 

--- a/src/AlgAssAbsOrd/Types.jl
+++ b/src/AlgAssAbsOrd/Types.jl
@@ -5,7 +5,7 @@
 ################################################################################
 
 # Orders in algebras over the rationals
-@attributes mutable struct AlgAssAbsOrd{S, T} <: Ring
+@attributes mutable struct AlgAssAbsOrd{S, T} <: NCRing
   algebra::S                       # Algebra containing the order
   dim::Int
   basis#::Vector{AlgAssAbsOrdElem{S, T}}
@@ -79,7 +79,7 @@ end
 
 const AlgAssAbsOrdID = Dict{Tuple{AbsAlgAss, FakeFmpqMat}, AlgAssAbsOrd}()
 
-@attributes mutable struct AlgAssAbsOrdElem{S, T} <: RingElem
+@attributes mutable struct AlgAssAbsOrdElem{S, T} <: NCRingElem
   elem_in_algebra::T
   coordinates::Vector{ZZRingElem}
   has_coord::Bool # needed for mul!

--- a/src/AlgAssRelOrd/Types.jl
+++ b/src/AlgAssRelOrd/Types.jl
@@ -6,7 +6,7 @@
 
 # S is the element type of the base field of the algebra, T the fractional ideal
 # type of this field
-mutable struct AlgAssRelOrd{S, T, U} <: Ring
+mutable struct AlgAssRelOrd{S, T, U} <: NCRing
   algebra::U
   dim::Int
   pseudo_basis#::Vector{Tuple{AbsAlgAssElem{S}, T}}
@@ -58,7 +58,7 @@ end
 #
 ################################################################################
 
-mutable struct AlgAssRelOrdElem{S, T, U} <: RingElem
+mutable struct AlgAssRelOrdElem{S, T, U} <: NCRingElem
   parent::AlgAssRelOrd{S, T, U}
   elem_in_algebra::AbsAlgAssElem{S}
   coordinates::Vector{S}


### PR DESCRIPTION
Fixes https://github.com/thofma/Hecke.jl/issues/1139.

Let's see if anything breaks. If not, I see no reason not to change this.
However, I would classify this a breaking change.