### PR TITLE
Add some tweaks for type stability etc.

### DIFF
--- a/src/Map/MapType.jl
+++ b/src/Map/MapType.jl
@@ -187,14 +187,14 @@ function image(f::MapFromFunc, x)
   @req parent(x) === domain(f) "Element not in the domain"
   y = f.f(x)
   @req parent(y) === codomain(f) "Image not in the codomain"
-  return y
+  return y::elem_type(codomain(f))
 end
 
 function preimage(f::MapFromFunc, y)
   @req parent(y) === codomain(f) "Element not in the codomain"
   x = f.g(y)
   @req parent(x) === domain(f) "Preimage not in the domain"
-  return x
+  return x::elem_type(domain(f))
 end
 
 function Base.show(io::IO, M::MapFromFunc)

--- a/src/Map/NfRelOrd.jl
+++ b/src/Map/NfRelOrd.jl
@@ -72,7 +72,7 @@ function NfRelOrdToFqMor(O::NfRelOrd{T, S, U}, P::NfRelOrdIdl{T, S, U}) where {T
     ccall((:fq_default_poly_set, libflint), Nothing, (Ref{FqPolyRingElem}, Ref{FqPolyRingElem}, Ref{FqField}), hh, h, F)
     z.poly_of_the_field = hh
     d = degree(hh)
-    FF, mFF = Nemo._residue_field(hh; absolute = true)
+    FF, mFF2 = Nemo._residue_field(hh; absolute = true)
 
     function _image(x::NfRelOrdElem)
       f = parent(nf(O).pol)(elem_in_nf(x))
@@ -81,11 +81,11 @@ function NfRelOrdToFqMor(O::NfRelOrd{T, S, U}, P::NfRelOrdIdl{T, S, U}) where {T
       else
         ff = Fx([ mmF(coeff(f, i)) for i = 0:degree(f) ])
       end
-      return mFF(ff)
+      return mFF2(ff)
     end
 
     function _preimage(x::FqFieldElem)
-      f = preimage(mFF, x)
+      f = preimage(mFF2, x)
       immF = pseudo_inv(mmF)
       #xp = Nemo._as_poly(x)
       y = nf(O)([ immF(coeff(f, i)) for i = 0:(d - 1) ])
@@ -173,7 +173,7 @@ mutable struct NfRelOrdToFqFieldRelMor{S} <: Map{S, FqField, HeckeMap, NfRelOrdT
   poly_of_the_field
   P
   map_subfield::Union{NfOrdToFqFieldMor, NfRelOrdToFqFieldRelMor}
-  
+
     function NfRelOrdToFqFieldRelMor{S}(O::S, P, mapsub) where {S}
     z = new{S}()
     z.P = P
@@ -194,7 +194,7 @@ mutable struct NfRelOrdToFqFieldRelMor{S} <: Map{S, FqField, HeckeMap, NfRelOrdT
       hh = FKx()
       ccall((:fq_default_poly_set, libflint), Nothing, (Ref{FqPolyRingElem}, Ref{FqPolyRingElem}, Ref{FqField}), hh, h, FK)
       z.poly_of_the_field = hh
-      
+
       FE, mE = Nemo._residue_field(hh)
 #
 #      FE = RelFinField(hh, :v)

--- a/src/QuadForm/Herm/LocallyIsometricSublattice.jl
+++ b/src/QuadForm/Herm/LocallyIsometricSublattice.jl
@@ -203,7 +203,7 @@ function _locally_isometric_sublattice_odd_ramified(M, L, p, P, absolute_map)
         end
         _Y0 = vcat(B[1:r-1], mtype[B[n - 1] + s * B[n]])
       else
-        SS = Int[ i for i in 1:n if !(i in NN)]
+        SS = setdiff(1:n, NN)
         if det(c, 1) == 1
           Y0 = Int[]
         else
@@ -222,7 +222,7 @@ function _locally_isometric_sublattice_odd_ramified(M, L, p, P, absolute_map)
             v = B[n - 1]
             B[n - 1] = B[n - 1] + E(s) * B[n]
             B[n] = B[n] - s * _G[n, n]//_G[n - 1, n - 1] * v
-            NN = Int[i for i in NN if i < n - 1]
+            filter!(i -> i < n - 1, NN)
             SS = Int[n - 1, n]
           end
           push!(Y0, SS[1])

--- a/src/QuadForm/Lattices.jl
+++ b/src/QuadForm/Lattices.jl
@@ -1321,9 +1321,9 @@ function hermitian_structure_with_transfer_data(_L::ZZLat, f::QQMatrix; check::B
   @req !is_finite(n) || n > 2 "Isometry must have infinite order or order bigger than 2"
 
   if check
-    G = gram_matrix(ambient_space(L))
+    gram = gram_matrix(ambient_space(L))
     @req is_irreducible(minpoly(f)) "The minimal polynomial of f must be irreducible"
-    @req f*G*transpose(f) == G "f does not define an isometry of the space of L"
+    @req f*gram*transpose(f) == gram "f does not define an isometry of the space of L"
     @req divides(rank(L), n2)[1] "The degree of the minimal polynomial of f must divide the rank of L"
   end
 


### PR DESCRIPTION
Several changes deal with JET warnings about "captured variables"
resulting in disabled optimizations resp. type unstable code.
E.g. `mFF` was assigned different values in two places which then
are referenced inside closures.

Likewise, `NN` was used in lambdas, which we now avoid.
