### PR TITLE
Fix `kronecker_product` for sparse matrices with zero row

### DIFF
--- a/src/Sparse/Matrix.jl
+++ b/src/Sparse/Matrix.jl
@@ -1481,16 +1481,21 @@ function kronecker_product(A::SMat{T}, B::SMat{T}) where {T}
     for rB = B.rows
       p = Int[]
       v = T[]
-      o = (rA.pos[1]-1)*ncols(B)
-      for (pp, vv) = rA
-        for (qq, ww) = rB
-          push!(p, qq+o)
-          push!(v, vv*ww)
+      if !iszero(rA)
+        o = (rA.pos[1]-1)*ncols(B)
+        for (pp, vv) = rA
+          for (qq, ww) = rB
+            push!(p, qq+o)
+            push!(v, vv*ww)
+          end
+          o += ncols(B)
         end
-        o += ncols(B)
       end
       push!(C, sparse_row(base_ring(A), p, v))
     end
   end
+  @assert nrows(C) == nrows(A)*nrows(B)
+  @assert ncols(C) <= ncols(A)*ncols(B)
+  C.c = ncols(A)*ncols(B)
   return C
 end

--- a/test/Sparse/Matrix.jl
+++ b/test/Sparse/Matrix.jl
@@ -315,6 +315,12 @@ using Hecke.SparseArrays
   E = SparseArrays.sparse(D)
   @test Matrix(E) == ZZRingElem[1 5 3; 0 -10 0; 0 1 0]
   @test Array(E) == ZZRingElem[1 5 3; 0 -10 0; 0 1 0]
+
+  # kronecker_product
+  D1 = sparse_matrix(FlintZZ, [12 403 -23; 0 0 122; -1 2 99])
+  D2 = sparse_matrix(FlintZZ, [81 0 2; 31 0 -5])
+  E = @inferred kronecker_product(D1, D2)
+  @test E == sparse_matrix(kronecker_product(matrix(D1), matrix(D2)))
 end
 
 @testset "Oscar #2128" begin
@@ -327,4 +333,9 @@ end
   S0 = sparse_matrix(ZZ,[1 0; 0 1])
   S1 = sparse_matrix(ZZ,[-1 0; 0 -1])
   @test S0 + S1 == sparse_matrix(ZZ, 2, 2)
+end
+
+@testset "Hecke #1227" begin
+  A = sparse_matrix(FlintZZ, [2 0; 0 0])
+  @test kronecker_product(A, A) == sparse_matrix(FlintZZ, [4 0 0 0; 0 0 0 0; 0 0 0 0; 0 0 0 0])
 end


### PR DESCRIPTION
The following example fails:
```julia
A = sparse_matrix(FlintZZ, [2 0; 0 0])
kronecker_product(A, A)
```
I would expect it to instead return the sparse matrix `[4 0 0 0; 0 0 0 0; 0 0 0 0; 0 0 0 0]`.