### PR TITLE
Remove rational_function_field wrapper

### DIFF
--- a/src/GenOrd/Auxiliary.jl
+++ b/src/GenOrd/Auxiliary.jl
@@ -283,7 +283,3 @@ function Hecke.lcm(a::Vector{<:RingElem})
   end
   return reduce(lcm, a)
 end
-
-function rational_function_field(k::Field, s::VarName = :t)
-  return RationalFunctionField(k, s)
-end


### PR DESCRIPTION
... for RationalFunctionField. It was neither used nor exported.

Soon we will have the real thing, see https://github.com/Nemocas/AbstractAlgebra.jl/pull/1463