### PR TITLE
Remove unnecessary tests

### DIFF
--- a/test/QuadForm/Quad/Spaces.jl
+++ b/test/QuadForm/Quad/Spaces.jl
@@ -29,6 +29,8 @@
   Qx, x = polynomial_ring(FlintQQ, "x")
   K1, a1 = number_field(x^2 - 2, "a1")
   K2, a2 = number_field(x^3 - 2, "a2")
+  
+  K1t, t = polynomial_ring(K1, "t")
   L, b = number_field(t^2 + a1)
 
   for K in [k, K1, K2, L]

--- a/test/QuadForm/Quad/Spaces.jl
+++ b/test/QuadForm/Quad/Spaces.jl
@@ -29,16 +29,6 @@
   Qx, x = polynomial_ring(FlintQQ, "x")
   K1, a1 = number_field(x^2 - 2, "a1")
   K2, a2 = number_field(x^3 - 2, "a2")
-
-  K1t, t = polynomial_ring(K1, "t")
-  F = GF(3)
-
-  Hecke.change_base_ring(::QQField, ::Hecke.fpMatrix) = error("asd")
-  @test_throws ErrorException quadratic_space(FlintQQ, F[1 2; 2 1])
-
-  Hecke.change_base_ring(::QQField, x::Hecke.fpMatrix) = x
-  @test_throws ErrorException quadratic_space(FlintQQ, F[1 2; 2 1])
-
   L, b = number_field(t^2 + a1)
 
   for K in [k, K1, K2, L]


### PR DESCRIPTION
I don't see what purposes these tests are meant to serve. Also they lead to a warning ("WARNING: Method definition change_base_ring ... overwritten ..."), and potentially change the behavior of later tests.

Resolves #1235

@thofma added this in PR #139.