### PR TITLE
deprecate `field_of_fractions(O::GenOrd)`

### DIFF
--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -115,6 +115,9 @@
 
 @deprecate any_root(f::Hecke.AbstractAlgebra.Generic.Poly, F::Hecke.RelFinField) any_root(F, f)
 
+# Deprecated during 0.22.*
+
+@deprecate field_of_fractions(O::GenOrd) function_field(O::GenOrd)
 
 # Things that moved to Nemo
 

--- a/src/FunField/Divisor.jl
+++ b/src/FunField/Divisor.jl
@@ -171,18 +171,15 @@ function ideals(D)
 end
 
 @doc raw"""
-    field_of_fractions(O::GenOrd) -> FunctionField
     function_field(O::GenOrd) -> FunctionField
 
 Return the function field of O.
 """
-function field_of_fractions(O::GenOrd)
-  return O.F
-end
-
 function function_field(O::GenOrd)
   return O.F
 end
+
+@deprecate field_of_fractions function_field
 
 @doc raw"""
     constant_field(K::FunctionField) -> Field

--- a/src/FunField/Divisor.jl
+++ b/src/FunField/Divisor.jl
@@ -179,8 +179,6 @@ function function_field(O::GenOrd)
   return O.F
 end
 
-@deprecate field_of_fractions(O::GenOrd) function_field(O::GenOrd)
-
 @doc raw"""
     constant_field(K::FunctionField) -> Field
     

--- a/src/FunField/Divisor.jl
+++ b/src/FunField/Divisor.jl
@@ -179,7 +179,7 @@ function function_field(O::GenOrd)
   return O.F
 end
 
-@deprecate field_of_fractions function_field
+@deprecate field_of_fractions(O::GenOrd) function_field(O::GenOrd)
 
 @doc raw"""
     constant_field(K::FunctionField) -> Field


### PR DESCRIPTION
A quick search shows that `field_of_fractions` isn't used anywhere, but causes confusion with `fraction_field` used in OSCAR and co.
I am not sure if simply removing or offering `fraction_field` as an alias of `function_field` is better. For now I think it is best to deprecate `field_of_fractions`.