### PR TITLE
remove unneeded broken line in class group proof

### DIFF
--- a/src/NumFieldOrd/NfOrd/Clgp/Proof.jl
+++ b/src/NumFieldOrd/NfOrd/Clgp/Proof.jl
@@ -147,7 +147,6 @@ function class_group_proof(clg::ClassGrpCtx, lb::ZZRingElem, ub::ZZRingElem; ext
         end
         f, r = is_smooth!(clg.FB.fb_int, numerator(n))
         if f
-          M = SMat{Int}()
           fl = _factor!(clg.FB, a, false, n)[1]
           if fl
             break


### PR DESCRIPTION
This line was failing for me when I tried to compute class groups with GRH=false