### PR TITLE
Fix `kronecker_product(::SMat, ::SMat)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Hecke"
 uuid = "3e1990a7-5d81-5526-99ce-9ba3ff248f21"
-version = "0.22.4"
+version = "0.22.5"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"

--- a/src/Sparse/Matrix.jl
+++ b/src/Sparse/Matrix.jl
@@ -1484,13 +1484,12 @@ function kronecker_product(A::SMat{T}, B::SMat{T}) where {T}
       p = Int[]
       v = T[]
       if !iszero(rA)
-        o = (rA.pos[1]-1)*ncols(B)
         for (pp, vv) = rA
+          o = (pp-1)*ncols(B)
           for (qq, ww) = rB
-            push!(p, qq+o)
+            push!(p, o+qq)
             push!(v, vv*ww)
           end
-          o += ncols(B)
         end
       end
       push!(C, sparse_row(base_ring(A), p, v))

--- a/test/Sparse/Matrix.jl
+++ b/test/Sparse/Matrix.jl
@@ -342,3 +342,10 @@ end
   A = sparse_matrix(FlintZZ, [2 0; 0 0])
   @test kronecker_product(A, A) == sparse_matrix(FlintZZ, [4 0 0 0; 0 0 0 0; 0 0 0 0; 0 0 0 0])
 end
+
+@testset "Hecke #1261" begin
+  D1 = sparse_matrix(FlintZZ, [3 0 4 0; 0 3 0 4; 0 0 2 0; 0 0 0 2])
+  D2 = identity_matrix(SMat, FlintZZ, 2)
+  E = kronecker_product(D1, D2)
+  @test E == sparse_matrix(kronecker_product(matrix(D1), matrix(D2)))
+end


### PR DESCRIPTION
Another nasty bug in that function. I added the example that confused me as a test.

I am looking forward to a fast merge and release of this so that I can use it in https://github.com/oscar-system/Oscar.jl/pull/2936.