### PR TITLE
add `dot(x, A, y)` for sparse matrices

### DIFF
--- a/docs/src/sparse/intro.md
+++ b/docs/src/sparse/intro.md
@@ -211,6 +211,12 @@ Various products:
 *(::SRow{T}, ::SMat{T}) where {T}
 ```
 
+```@docs
+dot(::SRow{T}, ::SMat{T}, ::SRow{T}) where T
+dot(::MatrixElem{T}, ::SMat{T}, ::MatrixElem{T}) where T
+dot(::AbstractVector{T}, ::SMat{T}, ::AbstractVector{T}) where T
+```
+
 Other:
 ```@docs
 sparse(::SMat)

--- a/src/Sparse/Matrix.jl
+++ b/src/Sparse/Matrix.jl
@@ -725,6 +725,70 @@ end
 
 ################################################################################
 #
+#  Dot product
+#
+################################################################################
+
+function dot(x::SRow{T}, A::SMat{T}, y::SRow{T}) where T
+  v = T(0)
+
+  px = 1
+  py = 1
+  for i in 1:length(A.rows), j in 1:length(A[i].pos)
+    while px <= length(x.pos) && x.pos[px] < A[i].pos[j]
+      px += 1
+    end
+    if px > length(x.pos)
+      break
+    end
+
+    while py <= length(y.pos) && y.pos[py] < A[i].pos[j]
+      py += 1
+    end
+    if py > length(y.pos)
+      break
+    end
+
+    if x.pos[px] == A[i].pos[j] == y.pos[py]
+      v += x.values[px] * A[i].values[j] * y.values[py]
+    end
+  end
+
+  return v
+end
+
+function dot(x::AbstractVector{T}, A::SMat{T}, y::AbstractVector{T}) where T
+  @assert length(x) == length(y)
+
+  v = T(0)
+  for i in 1:length(A.rows), j in 1:length(A[i].pos)
+    if A[i].pos[j] > length(x) || A[i].pos[j] > length(y)
+      error("incompatible matrix dimensions")
+    end
+    v += x[A[i].pos[j]] * A[i].values[j] * y[A[i].pos[j]]
+  end
+
+  return v
+end
+
+# support dot product for vector matrices
+function dot(x::MatrixElem{T}, A::SMat{T}, y::MatrixElem{T}) where T
+  @assert length(x) == length(y)
+  len = length(x)
+
+  v = T(0)
+  for i in 1:length(A.rows), j in 1:length(A[i].pos)
+    if A[i].pos[j] > len || A[i].pos[j] > len
+      error("incompatible matrix dimensions")
+    end
+    v += x[A[i].pos[j]] * A[i].values[j] * y[A[i].pos[j]] # this will throw if x or y is not a vector
+  end
+
+  return v
+end
+
+################################################################################
+#
 #  Submatrix
 #
 ################################################################################

--- a/src/Sparse/Matrix.jl
+++ b/src/Sparse/Matrix.jl
@@ -735,7 +735,7 @@ end
 Return the generalized dot product `dot(x, A*y)`.
 """
 function dot(x::SRow{T}, A::SMat{T}, y::SRow{T}) where T
-  v = T(0)
+  v = zero(T)
   px = 1
   for i in 1:length(A.rows)
     while px <= length(x.pos) && x.pos[px] < i
@@ -747,7 +747,7 @@ function dot(x::SRow{T}, A::SMat{T}, y::SRow{T}) where T
       continue
     end
 
-    s = T(0)
+    s = zero(T)
     py = 1
     for j in 1:length(A[i].pos)
       while py <= length(y.pos) && y.pos[py] < A[i].pos[j]
@@ -776,7 +776,7 @@ Return the generalized dot product `dot(x, A*y)`.
 function dot(x::AbstractVector{T}, A::SMat{T}, y::AbstractVector{T}) where T
   @req length(x) == length(A.rows) == length(y) "incompatible matrix dimensions"
 
-  v = T(0)
+  v = zero(T)
   for i in 1:length(A.rows)
     s = T(0)
     for j in 1:length(A[i].pos)
@@ -800,9 +800,9 @@ function dot(x::MatrixElem{T}, A::SMat{T}, y::MatrixElem{T}) where T
   @req length(x) == length(A.rows) == length(y) "incompatible matrix dimensions"
   len = length(x)
 
-  v = T(0)
+  v = zero(T)
   for i in 1:length(A.rows)
-    s = T(0)
+    s = zero(T)
     for j in 1:length(A[i].pos)
       if A[i].pos[j] > len
         error("incompatible matrix dimensions")

--- a/src/Sparse/Matrix.jl
+++ b/src/Sparse/Matrix.jl
@@ -774,15 +774,12 @@ end
 Return the generalized dot product `dot(x, A*y)`.
 """
 function dot(x::AbstractVector{T}, A::SMat{T}, y::AbstractVector{T}) where T
-  @req length(x) == length(A.rows) == length(y) "incompatible matrix dimensions"
+  @req length(x) == nrows(A) && ncols(A) <= length(y) "incompatible matrix dimensions"
 
   v = zero(T)
   for i in 1:length(A.rows)
     s = T(0)
     for j in 1:length(A[i].pos)
-      if A[i].pos[j] > length(y)
-        error("incompatible matrix dimensions")
-      end
       s += A[i].values[j] * y[A[i].pos[j]]
     end
     v += x[i] * s
@@ -797,16 +794,12 @@ end
 Return the generalized dot product `dot(x, A*y)`.
 """
 function dot(x::MatrixElem{T}, A::SMat{T}, y::MatrixElem{T}) where T
-  @req length(x) == length(A.rows) == length(y) "incompatible matrix dimensions"
-  len = length(x)
+  @req length(x) == nrows(A) && ncols(A) <= length(y) "incompatible matrix dimensions"
 
   v = zero(T)
   for i in 1:length(A.rows)
     s = zero(T)
     for j in 1:length(A[i].pos)
-      if A[i].pos[j] > len
-        error("incompatible matrix dimensions")
-      end
       s += A[i].values[j] * y[A[i].pos[j]]
     end
     v += x[i] * s

--- a/test/Sparse/Matrix.jl
+++ b/test/Sparse/Matrix.jl
@@ -207,6 +207,34 @@ using Hecke.SparseArrays
   E = @inferred D * R(3)
   @test E == sparse_matrix(R, [3 0 0; 0 0 3; 0 0 0])
 
+  # Dot product
+
+  D = sparse_matrix(ZZ, [4 -2; -2 2])
+  E = sparse_matrix(ZZ, [3 0 0; 0 0 3; 0 3 0])
+
+  @test dot(sparse_row(ZZ, [1], [1]), D, sparse_row(ZZ, [1], [1])) == 4
+  @test dot(sparse_row(ZZ, [1, 2], [1, 1]), D, sparse_row(ZZ, [1, 2], [1, 2])) == 2
+  @test dot(sparse_row(ZZ, [1], [1]), D, sparse_row(ZZ, [2], [1])) == -2
+
+  @test dot(sparse_row(ZZ, [1, 4], [1, 2]), D, sparse_row(ZZ, [2], [1])) == -2
+  @test dot(sparse_row(ZZ, [1, 4], [1, 2]), E, sparse_row(ZZ, [2], [1])) == 0
+  @test dot(sparse_row(ZZ, [1, 3], [1, 2]), E, sparse_row(ZZ, [2], [1])) == 6
+
+  @test dot(ZZRingElem[1, 0], D, ZZRingElem[1, 0]) == 4
+  @test dot(ZZRingElem[1, 1], D, ZZRingElem[1, 2]) == 2
+  @test dot(ZZRingElem[1, 0], D, ZZRingElem[0, 1]) == -2
+
+  @test dot(ZZ[1 0], D, ZZ[1 0]) == 4
+  @test dot(ZZ[1; 1], D, ZZ[1 2]) == 2
+  @test dot(ZZ[1 0], D, ZZ[0; 1]) == -2
+
+  @test_throws ArgumentError dot(ZZRingElem[1], D, ZZRingElem[0, 1])
+  @test_throws ArgumentError dot(ZZRingElem[1, 0, 0], D, ZZRingElem[0, 1])
+  @test_throws ArgumentError dot(ZZRingElem[1, 0], D, ZZRingElem[0, 1, 0])
+
+  @test_throws ArgumentError dot(ZZ[1 0 0], D, ZZ[1 0])
+  @test_throws ArgumentError dot(ZZ[1 0; 0 0], D, ZZ[1 0 0 0])
+
   # Submatrix
 
   D = sparse_matrix(FlintZZ, [1 5 3; 0 0 0; 0 1 0])

--- a/test/Sparse/Matrix.jl
+++ b/test/Sparse/Matrix.jl
@@ -210,7 +210,7 @@ using Hecke.SparseArrays
   # Dot product
 
   D = sparse_matrix(ZZ, [4 -2; -2 2])
-  E = sparse_matrix(ZZ, [3 0 0; 0 0 3; 0 3 0])
+  E = sparse_matrix(ZZ, [3 0 0; 0 3 0])
 
   @test dot(sparse_row(ZZ, [1], [1]), D, sparse_row(ZZ, [1], [1])) == 4
   @test dot(sparse_row(ZZ, [1, 2], [1, 1]), D, sparse_row(ZZ, [1, 2], [1, 2])) == 2
@@ -218,21 +218,26 @@ using Hecke.SparseArrays
 
   @test dot(sparse_row(ZZ, [1, 4], [1, 2]), D, sparse_row(ZZ, [2], [1])) == -2
   @test dot(sparse_row(ZZ, [1, 4], [1, 2]), E, sparse_row(ZZ, [2], [1])) == 0
-  @test dot(sparse_row(ZZ, [1, 3], [1, 2]), E, sparse_row(ZZ, [2], [1])) == 6
+  @test dot(sparse_row(ZZ, [1, 2], [1, 2]), E, sparse_row(ZZ, [2], [1])) == 6
 
   @test dot(ZZRingElem[1, 0], D, ZZRingElem[1, 0]) == 4
   @test dot(ZZRingElem[1, 1], D, ZZRingElem[1, 2]) == 2
   @test dot(ZZRingElem[1, 0], D, ZZRingElem[0, 1]) == -2
+  @test dot(ZZRingElem[1, 0], E, ZZRingElem[0, 1, 2]) == 0
+  @test dot(ZZRingElem[0, 1], E, ZZRingElem[0, 1, 2]) == 3
 
   @test dot(ZZ[1 0], D, ZZ[1 0]) == 4
   @test dot(ZZ[1; 1], D, ZZ[1 2]) == 2
   @test dot(ZZ[1 0], D, ZZ[0; 1]) == -2
+  @test dot(ZZ[1 0], E, ZZ[0 1 2]) == 0
+  @test dot(ZZ[0 1], E, ZZ[0 1 2]) == 3
 
   @test_throws ArgumentError dot(ZZRingElem[1], D, ZZRingElem[0, 1])
-  @test_throws ArgumentError dot(ZZRingElem[1, 0, 0], D, ZZRingElem[0, 1])
-  @test_throws ArgumentError dot(ZZRingElem[1, 0], D, ZZRingElem[0, 1, 0])
+  @test_throws ArgumentError dot(ZZRingElem[1, 0], D, ZZRingElem[0])
+  @test_throws ArgumentError dot(ZZRingElem[1, 0, 2], E, ZZRingElem[0, 1])
 
   @test_throws ArgumentError dot(ZZ[1 0 0], D, ZZ[1 0])
+  @test_throws ArgumentError dot(ZZ[0 1 2], E, ZZ[0 1])
   @test_throws ArgumentError dot(ZZ[1 0; 0 0], D, ZZ[1 0 0 0])
 
   # Submatrix


### PR DESCRIPTION
This PR adds the following dispatches
```julia
dot(x::SRow{T}, A::SMat{T}, y::SRow{T}) where T
dot(x::MatrixElem{T}, A::SMat{T}, y::MatrixElem{T}) where T
dot(x::AbstractVector{T}, A::SMat{T}, y::AbstractVector{T}) where T
```

If you have any suggestions for improvements, let me know.