### PR TITLE
Random lines in `LineEnumCtx`

### DIFF
--- a/src/QuadForm/LineOrbits.jl
+++ b/src/QuadForm/LineOrbits.jl
@@ -54,7 +54,7 @@ function Base.show(io::IO, P::LineEnumCtx)
   end
 end
 
-Base.length(P::LineEnumCtx) = BigInt(P.length)
+Base.length(P::LineEnumCtx) = Int(P.length)
 
 Base.eltype(::Type{LineEnumCtx{T, S}}) where {T, S} = Vector{S}
 

--- a/src/QuadForm/LineOrbits.jl
+++ b/src/QuadForm/LineOrbits.jl
@@ -16,7 +16,7 @@ function LineEnumCtx(K::T, n::Int) where {T}
   depth = n + 1
   dim = n
   q = order(K)
-  length = divexact(ZZ(q)^n - 1, q - 1)
+  length = divexact(BigInt(q)^n - 1, q - 1)
   return LineEnumCtx{T, elem_type(T)}(K, a, dim, depth, v, length)
 end
 
@@ -29,7 +29,7 @@ function LineEnumCtx(K::T, n::Int) where {T <: Union{fpField, FpField}}
   depth = n + 1
   dim = n
   q = order(K)
-  length = divexact(ZZ(q)^n - 1, q - 1)
+  length = divexact(BigInt(q)^n - 1, q - 1)
   return LineEnumCtx{T, elem_type(T)}(K, a, dim, depth, v, length)
 end
 
@@ -54,7 +54,7 @@ function Base.show(io::IO, P::LineEnumCtx)
   end
 end
 
-Base.length(P::LineEnumCtx) = Int(P.length)
+Base.length(P::LineEnumCtx) = P.length
 
 Base.eltype(::Type{LineEnumCtx{T, S}}) where {T, S} = Vector{S}
 

--- a/src/QuadForm/Types.jl
+++ b/src/QuadForm/Types.jl
@@ -444,7 +444,7 @@ mutable struct LineEnumCtx{T, S}
   dim::Int
   depth::Int
   v::Vector{S}
-  length::BigInt
+  length::IntegerUnion
 end
 
 ###############################################################################

--- a/src/QuadForm/Types.jl
+++ b/src/QuadForm/Types.jl
@@ -444,7 +444,7 @@ mutable struct LineEnumCtx{T, S}
   dim::Int
   depth::Int
   v::Vector{S}
-  length::IntegerUnion
+  length::BigInt
 end
 
 ###############################################################################

--- a/test/QuadForm.jl
+++ b/test/QuadForm.jl
@@ -15,4 +15,5 @@
   include("QuadForm/indefiniteLLL.jl")
   include("QuadForm/IO.jl")
   include("QuadForm/Database.jl")
+  include("QuadForm/LineOrbits.jl")
 end

--- a/test/QuadForm/LineOrbits.jl
+++ b/test/QuadForm/LineOrbits.jl
@@ -2,13 +2,10 @@
   P = Hecke.enumerate_lines(GF(5), 20)
   io = IOBuffer()
   show(io, MIME"text/plain"(), P)
-  @test length(String(take!(io))) == 98
   show(IOContext(io, :supercompact => true), P)
-  @test length(String(take!(io))) == 25
   show(io, P)
-  @test length(String(take!(io))) == 33
   for i in 1:100
     v = rand(P)
-    @test is_zero(v) || gcd(v) == 1
+    @test gcd(v) == 1
   end
 end

--- a/test/QuadForm/LineOrbits.jl
+++ b/test/QuadForm/LineOrbits.jl
@@ -6,6 +6,6 @@
   show(io, P)
   for i in 1:100
     v = rand(P)
-    @test gcd(v) == 1
+    @test !iszero(v) && isone(v[findfirst(!iszero, v)])
   end
 end

--- a/test/QuadForm/LineOrbits.jl
+++ b/test/QuadForm/LineOrbits.jl
@@ -1,0 +1,14 @@
+@testset "Random lines" begin
+  P = Hecke.enumerate_lines(GF(5), 20)
+  io = IOBuffer()
+  show(io, MIME"text/plain"(), P)
+  @test length(String(take!(io))) == 98
+  show(IOContext(io, :supercompact => true), P)
+  @test length(String(take!(io))) == 25
+  show(io, P)
+  @test length(String(take!(io))) == 33
+  for i in 1:100
+    v = rand(P)
+    @test is_zero(v) || gcd(v) == 1
+  end
+end


### PR DESCRIPTION
To prepare random Kneser's neighbour method, allow to have access to random lines from the `LineEnumCtx`. It might not be the most optimized way but at least it works.