### PR TITLE
Remove instance dispatches for `{elem,parent}_type`

### DIFF
--- a/src/AlgAss/AlgMat.jl
+++ b/src/AlgAss/AlgMat.jl
@@ -18,8 +18,6 @@ basis(A::AlgMat) = A.basis
 
 has_one(A::AlgMat) = true
 
-elem_type(A::AlgMat{T, S}) where { T, S } = AlgMatElem{T, AlgMat{T, S}, S}
-
 elem_type(::Type{AlgMat{T, S}}) where { T, S } = AlgMatElem{T, AlgMat{T, S}, S}
 
 order_type(::AlgMat{QQFieldElem, S}) where { S } = AlgAssAbsOrd{AlgMat{QQFieldElem, S}, elem_type(AlgMat{QQFieldElem, S})}

--- a/src/AlgAss/AlgQuat.jl
+++ b/src/AlgAss/AlgQuat.jl
@@ -53,8 +53,6 @@ standard_form(A::AlgQuat) = A.std
 
 has_one(A::AlgQuat) = true
 
-elem_type(A::AlgQuat{T}) where {T} = AlgAssElem{T, AlgQuat{T}}
-
 elem_type(::Type{AlgQuat{T}}) where {T} = AlgAssElem{T, AlgQuat{T}}
 
 is_commutative(A::AlgQuat) = false

--- a/src/AlgAssAbsOrd/Elem.jl
+++ b/src/AlgAssAbsOrd/Elem.jl
@@ -2,8 +2,6 @@ export elem_in_algebra
 
 parent_type(::Type{AlgAssAbsOrdElem{S, T}}) where {S, T} = AlgAssAbsOrd{S, T}
 
-parent_type(::AlgAssAbsOrdElem{S, T}) where {S, T} = AlgAssAbsOrd{S, T}
-
 @inline parent(x::AlgAssAbsOrdElem) = x.parent
 
 Base.hash(x::AlgAssAbsOrdElem, h::UInt) = hash(elem_in_algebra(x, copy = false), h)

--- a/src/AlgAssAbsOrd/Ideal.jl
+++ b/src/AlgAssAbsOrd/Ideal.jl
@@ -1447,8 +1447,6 @@ FracIdealSet(O::AlgAssAbsOrd) = IdealSet(O)
 
 elem_type(::Type{AlgAssAbsOrdIdlSet{S, T}}) where {S, T} = AlgAssAbsOrdIdl{S, T}
 
-elem_type(::AlgAssAbsOrdIdlSet{S, T}) where {S, T} = AlgAssAbsOrdIdl{S, T}
-
 parent_type(::Type{AlgAssAbsOrdIdl{S, T}}) where {S, T} = AlgAssAbsOrdIdlSet{S, T}
 
 function Base.one(S::AlgAssAbsOrdIdlSet)

--- a/src/AlgAssAbsOrd/Order.jl
+++ b/src/AlgAssAbsOrd/Order.jl
@@ -3,8 +3,6 @@ export algebra, integral_group_ring
 add_assertion_scope(:AlgAssOrd)
 add_verbosity_scope(:AlgAssOrd)
 
-elem_type(::AlgAssAbsOrd{S, T}) where {S, T} = AlgAssAbsOrdElem{S, T}
-
 elem_type(::Type{AlgAssAbsOrd{S, T}}) where {S, T} = AlgAssAbsOrdElem{S, T}
 
 ideal_type(::AlgAssAbsOrd{S, T}) where {S, T} = AlgAssAbsOrdIdl{S, T}

--- a/src/AlgAssAbsOrd/Order.jl
+++ b/src/AlgAssAbsOrd/Order.jl
@@ -1,4 +1,4 @@
-export algebra, integral_group_ring
+export algebra, ideal_type, integral_group_ring
 
 add_assertion_scope(:AlgAssOrd)
 add_verbosity_scope(:AlgAssOrd)

--- a/src/AlgAssRelOrd/Elem.jl
+++ b/src/AlgAssRelOrd/Elem.jl
@@ -4,8 +4,6 @@ export trred
 
 parent_type(::Type{AlgAssRelOrdElem{S, T, U}}) where {S, T, U} = AlgAssRelOrd{S, T, U}
 
-parent_type(::AlgAssRelOrdElem{S, T, U}) where {S, T, U} = AlgAssRelOrd{S, T, U}
-
 @doc raw"""
     parent(x::AlgAssRelOrdElem) -> AlgAssRelOrd
 

--- a/src/AlgAssRelOrd/Order.jl
+++ b/src/AlgAssRelOrd/Order.jl
@@ -1,7 +1,5 @@
 export is_commutative, trred_matrix, any_order, pmaximal_overorder, phereditary_overorder, is_maximal
 
-elem_type(::AlgAssRelOrd{S, T, U}) where {S, T, U} = AlgAssRelOrdElem{S, T, U}
-
 elem_type(::Type{AlgAssRelOrd{S, T, U}}) where {S, T, U} = AlgAssRelOrdElem{S, T, U}
 
 ideal_type(::AlgAssRelOrd{S, T, U}) where {S, T, U} = AlgAssRelOrdIdl{S, T, U}

--- a/src/AlgAssRelOrd/Order.jl
+++ b/src/AlgAssRelOrd/Order.jl
@@ -1,4 +1,4 @@
-export is_commutative, trred_matrix, any_order, pmaximal_overorder, phereditary_overorder, is_maximal
+export is_commutative, trred_matrix, any_order, pmaximal_overorder, phereditary_overorder, is_maximal, ideal_type
 
 elem_type(::Type{AlgAssRelOrd{S, T, U}}) where {S, T, U} = AlgAssRelOrdElem{S, T, U}
 

--- a/src/EllCrv/EllCrv.jl
+++ b/src/EllCrv/EllCrv.jl
@@ -775,10 +775,6 @@ end
 #
 ################################################################################
 
-function elem_type(E::EllCrv{T}) where T
-  return EllCrvPt{T}
-end
-
 function elem_type(::Type{EllCrv{T}}) where T
   return EllCrvPt{T}
 end

--- a/src/FunField/HessQR.jl
+++ b/src/FunField/HessQR.jl
@@ -143,7 +143,6 @@ function Hecke.denominator(a::Generic.RationalFunctionFieldElem, S::HessQR)
   return integral_split(a, S)[2]
 end
 
-Nemo.elem_type(::HessQR) = HessQRElem
 Nemo.elem_type(::Type{HessQR}) = HessQRElem
 Nemo.parent_type(::HessQRElem) = HessQR
 Nemo.parent_type(::Type{HessQRElem}) = HessQR

--- a/src/FunField/HessQR.jl
+++ b/src/FunField/HessQR.jl
@@ -144,7 +144,6 @@ function Hecke.denominator(a::Generic.RationalFunctionFieldElem, S::HessQR)
 end
 
 Nemo.elem_type(::Type{HessQR}) = HessQRElem
-Nemo.parent_type(::HessQRElem) = HessQR
 Nemo.parent_type(::Type{HessQRElem}) = HessQR
 Nemo.is_domain_type(::Type{HessQRElem}) = true
 

--- a/src/GenOrd/GenOrd.jl
+++ b/src/GenOrd/GenOrd.jl
@@ -46,8 +46,6 @@ function elem_type(::Type{GenOrd{S, T}}) where {S, T}
   return GenOrdElem{elem_type(S), elem_type(T)}
 end
 
-elem_type(::O) where {O <: GenOrd} = elem_type(O)
-
 function parent_type(::Type{GenOrdElem{S, T}}) where {S, T}
   return GenOrd{parent_type(S), parent_type(T)}
 end

--- a/src/GenOrd/GenOrd.jl
+++ b/src/GenOrd/GenOrd.jl
@@ -50,8 +50,6 @@ function parent_type(::Type{GenOrdElem{S, T}}) where {S, T}
   return GenOrd{parent_type(S), parent_type(T)}
 end
 
-parent_type(::OE) where {OE <: GenOrdElem} = parent_type(OE)
-
 # prepare for algebras, which are not domains
 is_domain_type(::Type{GenOrdElem{S, T}}) where {S, T} = is_domain_type(S)
 

--- a/src/Grp/GenGrp.jl
+++ b/src/Grp/GenGrp.jl
@@ -181,8 +181,6 @@ end
 
 elem_type(::Type{GrpGen}) = GrpGenElem
 
-elem_type(::GrpGen) = GrpGenElem
-
 Base.hash(G::GrpGenElem, h::UInt) = Base.hash(G.i, h)
 
 Base.hash(G::GrpGen, h::UInt) = UInt(0)

--- a/src/GrpAb/GrpAbFinGen.jl
+++ b/src/GrpAb/GrpAbFinGen.jl
@@ -48,8 +48,6 @@ import Base.+, Nemo.snf, Nemo.parent, Base.rand, Nemo.is_snf
 #
 ################################################################################
 
-elem_type(G::GrpAbFinGen) = GrpAbFinGenElem
-
 elem_type(::Type{GrpAbFinGen}) = GrpAbFinGenElem
 
 parent_type(::Type{GrpAbFinGenElem}) = GrpAbFinGen
@@ -882,7 +880,6 @@ function show(io::IO, P::TupleParent{T}) where {T}
 end
 
 elem_type(::Type{TupleParent{T}}) where {T} = T
-elem_type(::TupleParent{T}) where {T} = T
 
 parent(t::Tuple) = TupleParent(t)
 

--- a/src/HeckeTypes.jl
+++ b/src/HeckeTypes.jl
@@ -1993,8 +1993,6 @@ end
 
 elem_type(::Type{NfRel{T}}) where {T} = NfRelElem{T}
 
-elem_type(::NfRel{T}) where {T} = NfRelElem{T}
-
 parent_type(::Type{NfRelElem{T}}) where {T} = NfRel{T}
 
 

--- a/src/HypellCrv/HypellCrv.jl
+++ b/src/HypellCrv/HypellCrv.jl
@@ -460,10 +460,6 @@ end
 #
 ################################################################################
 
-function elem_type(C::HypellCrv{T}) where T
-  return HypellCrvPt{T}
-end
-
 function elem_type(::Type{HypellCrv{T}}) where T
   return HypellCrvPt{T}
 end

--- a/src/LocalField/Elem.jl
+++ b/src/LocalField/Elem.jl
@@ -87,7 +87,6 @@ end
 
 parent(a::LocalFieldElem) = a.parent
 
-parent_type(a::LocalFieldElem{S, T}) where {S <: FieldElem, T <: LocalFieldParameter} = LocalField{S, T}
 parent_type(::Type{LocalFieldElem{S, T}}) where {S <: FieldElem, T <: LocalFieldParameter} = LocalField{S, T}
 
 ################################################################################

--- a/src/LocalField/LocalField.jl
+++ b/src/LocalField/LocalField.jl
@@ -42,9 +42,6 @@ base_field_type(::Type{LocalField{S, T}}) where {S <: FieldElem, T <: LocalField
 
 elem_type(::Type{LocalField{S, T}}) where {S <: FieldElem, T <: LocalFieldParameter} = LocalFieldElem{S, T}
 
-dense_matrix_type(K::LocalField{S, T}) where {S <: FieldElem, T <: LocalFieldParameter} =  Generic.MatSpaceElem{LocalFieldElem{S, T}}
-dense_matrix_type(::Type{LocalField{S, T}}) where {S <: FieldElem, T <: LocalFieldParameter} =  Generic.MatSpaceElem{LocalFieldElem{S, T}}
-
 dense_poly_type(K::LocalField{S, T}) where {S <: FieldElem, T <: LocalFieldParameter} = Generic.Poly{LocalFieldElem{S, T}}
 dense_poly_type(::Type{LocalField{S, T}}) where {S <: FieldElem, T <: LocalFieldParameter} = Generic.Poly{LocalFieldElem{S, T}}
 

--- a/src/LocalField/LocalField.jl
+++ b/src/LocalField/LocalField.jl
@@ -40,7 +40,6 @@ prime(K::LocalField) = prime(base_field(K))
 base_field_type(K::LocalField{S, T}) where {S <: FieldElem, T <: LocalFieldParameter} = parent_type(S)
 base_field_type(::Type{LocalField{S, T}}) where {S <: FieldElem, T <: LocalFieldParameter} = parent_type(S)
 
-elem_type(K::LocalField{S, T}) where {S <: FieldElem, T <: LocalFieldParameter} = LocalFieldElem{S, T}
 elem_type(::Type{LocalField{S, T}}) where {S <: FieldElem, T <: LocalFieldParameter} = LocalFieldElem{S, T}
 
 dense_matrix_type(K::LocalField{S, T}) where {S <: FieldElem, T <: LocalFieldParameter} =  Generic.MatSpaceElem{LocalFieldElem{S, T}}

--- a/src/Map/NumField.jl
+++ b/src/Map/NumField.jl
@@ -199,13 +199,9 @@ base_field_type(::Type{NfRel{T}}) where {T} = parent_type(T)
 
 elem_type(::Type{NfRelNS{T}}) where {T} = NfRelNSElem{T}
 
-elem_type(::NfRelNS{T}) where {T} = NfRelNSElem{T}
-
 parent_type(::Type{NfRelNSElem{T}}) where {T} = NfRelNS{T}
 
 elem_type(::Type{NfAbsNS}) = NfAbsNSElem
-
-elem_type(::NfAbsNS) = NfAbsNSElem
 
 parent_type(::Type{NfAbsNSElem}) = NfAbsNS
 

--- a/src/Map/NumberField.jl
+++ b/src/Map/NumberField.jl
@@ -8,10 +8,6 @@ function elem_type(::Type{NfMorSet{T}}) where {T}
   return morphism_type(T, T)
 end
 
-function elem_type(::NfMorSet{T}) where {T}
-  return elem_type(NfMorSet{T})
-end
-
 function show(io::IO, S::NfMorSet{T}) where {T}
   print(io, "Set of automorphisms of ", S.field)
 end

--- a/src/Misc/RelFiniteField.jl
+++ b/src/Misc/RelFiniteField.jl
@@ -154,7 +154,6 @@ end
 
 elem_type(::Type{RelFinField{T}}) where T = RelFinFieldElem{RelFinField{T}, dense_poly_type(T)}
 
-parent_type(::RelFinFieldElem{S, T}) where {S, T} = S
 parent_type(::Type{RelFinFieldElem{S, T}}) where {S, T}  = S
 
 gen(F::RelFinField) = F(gen(parent(defining_polynomial(F))))

--- a/src/Misc/RelFiniteField.jl
+++ b/src/Misc/RelFiniteField.jl
@@ -152,8 +152,7 @@ function zero!(x::RelFinFieldElem)
   return x
 end
 
-elem_type(F::RelFinField{T}) where T = RelFinFieldElem{RelFinField{T}, dense_poly_type(T)}
-elem_type(::Type{RelFinField{T}}) where T  = RelFinFieldElem{RelFinField{T}, dense_poly_type(T)}
+elem_type(::Type{RelFinField{T}}) where T = RelFinFieldElem{RelFinField{T}, dense_poly_type(T)}
 
 parent_type(::RelFinFieldElem{S, T}) where {S, T} = S
 parent_type(::Type{RelFinFieldElem{S, T}}) where {S, T}  = S

--- a/src/NumField/Embedded.jl
+++ b/src/NumField/Embedded.jl
@@ -57,8 +57,6 @@ elem_type(::Type{EmbeddedField{S, E}}) where {S, E} = EmbeddedElem{elem_type(S)}
 
 parent_type(::Type{EmbeddedElem{T}}) where {T} = EmbeddedField{parent_type(T), embedding_type(parent_type(T))}
 
-parent_type(x::EmbeddedElem{T}) where {T} = parent_type(EmbeddedElem{T})
-
 data(x::EmbeddedElem) = x.element
 
 function embedded_field(K::SimpleNumField, i::NumFieldEmb)

--- a/src/NumField/Embedded.jl
+++ b/src/NumField/Embedded.jl
@@ -55,8 +55,6 @@ parent(x::EmbeddedElem{T}) where {T} = x.parent::parent_type(x)
 
 elem_type(::Type{EmbeddedField{S, E}}) where {S, E} = EmbeddedElem{elem_type(S)}
 
-elem_type(K::EmbeddedField{S, E}) where {S, E} = elem_type(EmbeddedField{S, E})
-
 parent_type(::Type{EmbeddedElem{T}}) where {T} = EmbeddedField{parent_type(T), embedding_type(parent_type(T))}
 
 parent_type(x::EmbeddedElem{T}) where {T} = parent_type(EmbeddedElem{T})

--- a/src/NumFieldOrd/NfOrd/FracIdeal.jl
+++ b/src/NumFieldOrd/NfOrd/FracIdeal.jl
@@ -202,8 +202,6 @@ end
 
 elem_type(::Type{NfAbsOrdFracIdlSet{S, T}}) where {S, T} = NfAbsOrdFracIdl{S, T}
 
-elem_type(::NfAbsOrdFracIdlSet{S, T}) where {S, T} = NfAbsOrdFracIdl{S, T}
-
 parent_type(::Type{NfAbsOrdFracIdl{S, T}}) where {S, T} = NfAbsOrdFracIdlSet{S, T}
 
 ==(a::NfAbsOrdFracIdlSet, b::NfAbsOrdFracIdlSet) = order(a) === order(b)

--- a/src/NumFieldOrd/NfOrd/Ideal/Ideal.jl
+++ b/src/NumFieldOrd/NfOrd/Ideal/Ideal.jl
@@ -99,8 +99,6 @@ end
 
 elem_type(::Type{NfOrdIdlSet}) = NfOrdIdl
 
-elem_type(::NfOrdIdlSet) = NfOrdIdl
-
 parent_type(::Type{NfOrdIdl}) = NfOrdIdlSet
 
 ################################################################################

--- a/src/NumFieldOrd/NfOrd/NfOrd.jl
+++ b/src/NumFieldOrd/NfOrd/NfOrd.jl
@@ -37,7 +37,7 @@ export ==, +, basis, basis_matrix, basis_mat_inv, contains_equation_order,
        is_equation_order, is_index_divisor, lll, lll_basis, nf,
        minkowski_matrix, norm_change_const, Order, parent, different,
        signature, trace_matrix, codifferent, ramified_primes,
-       reduced_discriminant
+       reduced_discriminant, ideal_type
 
 ################################################################################
 #

--- a/src/NumFieldOrd/NfOrd/NfOrd.jl
+++ b/src/NumFieldOrd/NfOrd/NfOrd.jl
@@ -47,8 +47,6 @@ export ==, +, basis, basis_matrix, basis_mat_inv, contains_equation_order,
 
 Nemo.parent_type(::Type{NfAbsOrdElem{S, T}}) where {S, T} = NfAbsOrd{S, T}
 
-Nemo.elem_type(::NfAbsOrd{S, T}) where {S, T} = NfAbsOrdElem{S, T}
-
 Nemo.elem_type(::Type{NfAbsOrd{S, T}}) where {S, T} = NfAbsOrdElem{S, T}
 
 ideal_type(::NfAbsOrd{S, T}) where {S, T} = NfAbsOrdIdl{S, T}

--- a/src/NumFieldOrd/NfOrd/ResidueRing.jl
+++ b/src/NumFieldOrd/NfOrd/ResidueRing.jl
@@ -55,11 +55,6 @@ function elem_type(::Type{AbsOrdQuoRing{S, T}}) where {S, T}
   return AbsOrdQuoRingElem{S, T, U}
 end
 
-function elem_type(::AbsOrdQuoRing{S, T}) where {S, T}
-  U = elem_type(S)
-  return AbsOrdQuoRingElem{S, T, U}
-end
-
 base_ring(Q::AbsOrdQuoRing) = Q.base_ring
 
 ideal(Q::AbsOrdQuoRing) = Q.ideal

--- a/src/NumFieldOrd/NfRelOrd/NfRelOrd.jl
+++ b/src/NumFieldOrd/NfRelOrd/NfRelOrd.jl
@@ -22,8 +22,6 @@ parent(O::NfRelOrd) = O.parent
 
 base_ring(O::NfRelOrd) = order(pseudo_basis(O, copy = false)[1][2])
 
-elem_type(::NfRelOrd{T, S, U}) where {T, S, U} = NfRelOrdElem{T, U}
-
 elem_type(::Type{NfRelOrd{T, S, U}}) where {T, S, U} = NfRelOrdElem{T, U}
 
 ideal_type(::NfRelOrd{T, S, U}) where {T, S, U} = NfRelOrdIdl{T, S, U}

--- a/src/NumFieldOrd/NfRelOrd/OrdElem.jl
+++ b/src/NumFieldOrd/NfRelOrd/OrdElem.jl
@@ -1,4 +1,3 @@
-parent_type(::NfRelOrdElem{T, U}) where {T, U} = NfRelOrd{T, fractional_ideal_type(order_type(parent_type(T))), U}
 parent_type(::Type{NfRelOrdElem{T, U}}) where {T, U} = NfRelOrd{T, fractional_ideal_type(order_type(parent_type(T))), U}
 
 ################################################################################

--- a/src/NumFieldOrd/NfRelOrd/ResidueRing.jl
+++ b/src/NumFieldOrd/NfRelOrd/ResidueRing.jl
@@ -9,11 +9,6 @@ function elem_type(::Type{RelOrdQuoRing{T1, T2, T3}}) where { T1, T2, T3 }
   return RelOrdQuoRingElem{T1, T2, T3, S}
 end
 
-function elem_type(::RelOrdQuoRing{T1, T2, T3}) where { T1, T2, T3 }
-  S = elem_type(T1)
-  return RelOrdQuoRingElem{T1, T2, T3, S}
-end
-
 base_ring(Q::RelOrdQuoRing) = Q.base_ring
 
 ideal(Q::RelOrdQuoRing) = Q.ideal


### PR DESCRIPTION
As they already exist via https://github.com/Nemocas/AbstractAlgebra.jl/blob/9dd22199b5262f23ad071b877f5d4fb5ce9ad436/src/fundamental_interface.jl#L53 and are only inconsistently used throughout Hecke.

Furthermore, export `ideal_type`, so Oscar can use the same function for its methods.