### PR TITLE
Fixes is_commutative for 1-dim matrix algebras

### DIFF
--- a/src/AlgAss/AlgMat.jl
+++ b/src/AlgAss/AlgMat.jl
@@ -57,6 +57,14 @@ function is_commutative(A::AlgMat)
     return A.is_commutative == 1
   end
   dcr = dim_of_coefficient_ring(A)
+  if degree(A) == 1
+    if is_commutative(base_ring(A))
+      A.is_commutative = 1
+      return true
+    end
+    A.is_commutative = 2
+    return false
+  end
   if dim(A) == degree(A)^2*dcr
     A.is_commutative = 2
     return false


### PR DESCRIPTION
Previously, full matrix algebras were assumed to be not commutative. This PR changes this for degree-one matrix algebras.

As I found no tests for this function, I did not write any myself.