### PR TITLE
Adjust to Nemo changes: 0 is not squarefree any more

### DIFF
--- a/test/Misc/Poly.jl
+++ b/test/Misc/Poly.jl
@@ -103,7 +103,7 @@ end
   Qx, x = QQ["x"]
   @test @inferred is_squarefree(x)
   @test @inferred is_squarefree(2*x^0)
-  @test @inferred is_squarefree(0*x^0)
+  @test @inferred !is_squarefree(0*x^0)
   @test @inferred !is_squarefree(2*x^2)
   @test @inferred is_squarefree(x * (x + 1))
   @test @inferred !is_squarefree(x * (x + 1)^2)
@@ -111,7 +111,7 @@ end
   Zx, x = ZZ["x"]
   @test @inferred is_squarefree(x)
   @test @inferred is_squarefree(2*x^0)
-  @test @inferred is_squarefree(0*x^0)
+  @test @inferred !is_squarefree(0*x^0)
   @test @inferred !is_squarefree(2*x^2)
   @test @inferred is_squarefree(x * (x + 1))
   @test @inferred !is_squarefree(x * (x + 1)^2)
@@ -120,7 +120,7 @@ end
   Fx, x = F["x"]
   @test @inferred is_squarefree(x)
   @test @inferred is_squarefree(2*x^0)
-  @test @inferred is_squarefree(0*x^0)
+  @test @inferred !is_squarefree(0*x^0)
   @test @inferred !is_squarefree(2*x^2)
   @test @inferred is_squarefree(x^3 - a)
   @test @inferred is_squarefree(2*x)


### PR DESCRIPTION
In https://github.com/Nemocas/Nemo.jl/pull/1596 `is_squarefree` was set to return `false` for 0. The Hecke tests wanted `true`.
(Which makes me wonder whether these tests should be in Nemo.)