### PR TITLE
Tb/fix error inconsistency

### DIFF
--- a/src/NumFieldOrd/NumFieldOrdElem.jl
+++ b/src/NumFieldOrd/NumFieldOrdElem.jl
@@ -88,14 +88,14 @@ end
 ###############################################################################
 
 function *(x::T, y::T) where T <: NumFieldOrdElem
-  !check_parent(x, y) && error("Wrong parents")
+  @req check_parent(x, y) "Wrong parents"
   z = parent(x)()
   z.elem_in_nf = x.elem_in_nf*y.elem_in_nf
   return z
 end
 
 function +(x::T, y::T) where T <: NumFieldOrdElem
-  !check_parent(x, y) && error("Wrong parents")
+  @req check_parent(x, y) "Wrong parents"
   z = parent(x)()
   z.elem_in_nf = x.elem_in_nf + y.elem_in_nf
   if x.has_coord && y.has_coord
@@ -107,7 +107,7 @@ function +(x::T, y::T) where T <: NumFieldOrdElem
 end
 
 function -(x::T, y::T) where T <: NumFieldOrdElem
-  !check_parent(x, y) && error("Wrong parents")
+  @req check_parent(x, y) "Wrong parents"
   z = parent(x)()
   z.elem_in_nf = x.elem_in_nf - y.elem_in_nf
   if x.has_coord && y.has_coord
@@ -118,12 +118,10 @@ function -(x::T, y::T) where T <: NumFieldOrdElem
 end
 
 function divexact(x::T, y::T; check::Bool = true) where T <: NumFieldOrdElem
-  !check_parent(x, y) && error("Wrong parents")
+  @req check_parent(x, y) "Wrong parents"
   a = divexact(x.elem_in_nf, y.elem_in_nf)
-  if check
-    if !in(a, parent(x))
-      error("Quotient not an element of the order")
-    end
+  if check && !(in(a, parent(x)))
+    throw(ArgumentError("Quotient not an element of the order."))
   end
   z = parent(x)()
   z.elem_in_nf = a

--- a/src/NumFieldOrd/NumFieldOrdElem.jl
+++ b/src/NumFieldOrd/NumFieldOrdElem.jl
@@ -176,10 +176,8 @@ for T in [Integer, ZZRingElem]
 
     function divexact(a::NumFieldOrdElem, b::$T; check::Bool = true)
       t = divexact(a.elem_in_nf, b)
-      if check
-        if !in(t, parent(a))
-          error("Quotient not an element of the order.")
-        end
+      if check && !(in(t, parent(a)))
+        throw(ArgumentError("Quotient not an element of the order."))
       end
       c  = parent(a)(t)
       return c

--- a/test/NfOrd/Elem.jl
+++ b/test/NfOrd/Elem.jl
@@ -139,7 +139,7 @@
     c = @inferred divexact(O1(a1^2), O1(a1); check=false)
     @test c == O1(a1)
 
-    @test_throws ErrorException divexact(O1(1), O1(2))
+    @test_throws ArgumentError divexact(O1(1), O1(2))
 
     b = O1(2)
     c = @inferred b//b
@@ -196,7 +196,7 @@
     c = @inferred divexact(b, ZZRingElem(2); check=false)
     @test c == O1(a1)
 
-    @test_throws ErrorException divexact(b, O1(4*a1))
+    @test_throws ArgumentError divexact(b, O1(4*a1))
   end
 
   @testset "Exponentiation" begin


### PR DESCRIPTION
The divexact method for ZZ throws an ArgumentError for inexact divisions. These commits change the divexact methods for orders, so that they throw the same Error. The same was also done for the various binary operators as they use exactly the same code for input sanitation.