### PR TITLE
Fix printing of SRow in compound structures

### DIFF
--- a/src/Sparse/Row.jl
+++ b/src/Sparse/Row.jl
@@ -131,7 +131,7 @@ end
 ################################################################################
 
 function show(io::IO, A::SRow{T}) where T
-  print(io, "Sparse row with positions $(A.pos) and values $(A.values)\n")
+  print(io, "Sparse row with positions $(A.pos) and values $(A.values)")
 end
 
 ################################################################################


### PR DESCRIPTION
before:
```julia
julia> (sparse_row(QQ), sparse_row(QQ))
(Sparse row with positions Int64[] and values QQFieldElem[]
, Sparse row with positions Int64[] and values QQFieldElem[]
)

julia> [sparse_row(QQ), sparse_row(QQ)]
2-element Vector{SRow{QQFieldElem, Vector{QQFieldElem}}}:
 Sparse row with positions Int64[] and values QQFieldElem[]

 Sparse row with positions Int64[] and values QQFieldElem[]


```

after:
```julia
julia> (sparse_row(QQ), sparse_row(QQ))
(Sparse row with positions Int64[] and values QQFieldElem[], Sparse row with positions Int64[] and values QQFieldElem[])

julia> [sparse_row(QQ), sparse_row(QQ)]
2-element Vector{SRow{QQFieldElem, Vector{QQFieldElem}}}:
 Sparse row with positions Int64[] and values QQFieldElem[]
 Sparse row with positions Int64[] and values QQFieldElem[]

```