### PR TITLE
chore: bump version to 0.25.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Hecke"
 uuid = "3e1990a7-5d81-5526-99ce-9ba3ff248f21"
-version = "0.25.0-DEV"
+version = "0.25.0"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"


### PR DESCRIPTION
See https://github.com/thofma/Hecke.jl/commit/1398592225585c5666cb215f3cdb7f136e6a934e#commitcomment-137856547
@thofma can you just merge this without CI (and then tag again)?