### PR TITLE
fix: make `is_principal` working again

### DIFF
--- a/src/AlgAssAbsOrd/PicardGroup.jl
+++ b/src/AlgAssAbsOrd/PicardGroup.jl
@@ -478,10 +478,21 @@ function _principal_generator_fac_elem(a::AlgAssAbsOrdIdl)
 end
 
 function _is_principal_with_data_etale(a::AlgAssAbsOrdIdl)
-  if is_maximal(order(a))
-    return _is_principal_maximal(a)
+  # all the internal functions assume that the ideal is an ideal of the order
+  O = order(a)
+  d = denominator(a, O)
+  b = d * a
+  if is_maximal(O)
+    fl, z = _is_principal_maximal(b)
+  else
+    fl, z =  _is_principal_non_maximal(b)
   end
-  return _is_principal_non_maximal(a)
+  if !fl
+    return fl, elem_in_algebra(z)
+  else
+    # d * a = z * O
+    return fl, 1//d * elem_in_algebra(z)
+  end
 end
 
 function is_principal_fac_elem(a::AlgAssAbsOrdIdl)
@@ -496,6 +507,7 @@ end
 
 function _is_principal_maximal_fac_elem(a::AlgAssAbsOrdIdl)
   O = order(a)
+  @assert is_one(denominator(a, O))
   A = algebra(O)
   fields_and_maps = as_number_fields(A)
 

--- a/src/ModAlgAss/Lattices/Morphisms.jl
+++ b/src/ModAlgAss/Lattices/Morphisms.jl
@@ -26,7 +26,6 @@ function endomorphism_ring(f::EndAlgMap, L::ModAlgAssLat)
     end
     return O
   end
-  @show "endomorphism_ring computation: $(objectid(L))"
 
   Bm = basis_matrix(L)
   Bminv = basis_matrix_inverse(L)

--- a/src/NumFieldOrd/NfOrd/PicardGroup.jl
+++ b/src/NumFieldOrd/NfOrd/PicardGroup.jl
@@ -350,6 +350,9 @@ function _is_principal_non_maximal(I::Union{ AbsNumFieldOrderIdeal, AlgAssAbsOrd
   # (O_K/F)^\times/(O/F)^\times and hence an element of (O/F)^\times, so of O.
   # But I*O_K = c*O_K, as b is a unit of O_K, so I = c*O.
   O = order(I)
+  if I isa AlgAssAbsOrdIdl
+    @assert is_one(denominator(I, O))
+  end
   if !is_invertible(I)[1]
     return false, O()
   end

--- a/test/ModAlgAss/Lattices/Lattices.jl
+++ b/test/ModAlgAss/Lattices/Lattices.jl
@@ -1,0 +1,10 @@
+begin
+  Qx, x = QQ["x"];
+  K, a = number_field(x^4 - x^3 + x^2 - x + 1, "a");
+  V, f = galois_module(K); OK = ring_of_integers(K); M = f(OK);
+  fl, c = is_free_with_basis(M); # the elements of c are a basis; @show fl
+  for i in 1:5
+    @test fl
+    @test lattice(V, integral_group_ring(algebra(V)), c) == M
+  end
+end


### PR DESCRIPTION
The "ideal" type AlgAssAbsOrdIdl can be fractional.
