### PR TITLE
Adapt to name printing changes in AA

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,7 +28,7 @@ GAPExt = "GAP"
 PolymakeExt = "Polymake"
 
 [compat]
-AbstractAlgebra = "^0.37.0"
+AbstractAlgebra = "^0.37.5"
 Dates = "1.6"
 Distributed = "1.6"
 GAP = "0.9.6, 0.10"

--- a/src/GrpAb/ChainComplex.jl
+++ b/src/GrpAb/ChainComplex.jl
@@ -325,24 +325,7 @@ map_type(C::ComplexOfMorphisms) = valtype(C.maps)
 
 Hecke.base_ring(::FinGenAbGroup) = ZZ
 
-function get_name(M, na::String)
-  name = get_attribute(M, :name)
-  if name !== nothing
-    return name
-  end
-  name = AbstractAlgebra.find_name(M)
-  if name !== nothing
-    return String(name)
-  end
-  return na
-end
-
 function pres_show(io::IO, C::ComplexOfMorphisms)
-  Cn = get_attribute(C, :name)
-  if Cn === nothing
-    Cn = "F"
-  end
-
   name_mod = String[]
   rank_mod = Int[]
 
@@ -350,15 +333,26 @@ function pres_show(io::IO, C::ComplexOfMorphisms)
   arr = ("<--", "--")
 
   R = Nemo.base_ring(C[first(rng)])
-  R_name = get_name(R, "$R")
+  R_name = get_name(R)
+  if isnothing(R_name)
+    R_name = "$R"
+  end
 
   for i=reverse(rng)
     M = C[i]
     if i == -1 #the object that is presented
-      push!(name_mod, get_name(M, "M"))
+      M_name = get_name(M)
+      if isnothing(M_name)
+        M_name = "M"
+      end
+      push!(name_mod, M_name)
       push!(rank_mod, 0)
     else
-      push!(name_mod, get_name(M, "$R_name^$(rank(M))"))
+      M_name = get_name(M)
+      if isnothing(M_name)
+        M_name = "$R_name^$(rank(M))"
+      end
+      push!(name_mod, name)
       push!(rank_mod, rank(M))
     end
   end
@@ -397,11 +391,6 @@ end
 
 
 function free_show(io::IO, C::ComplexOfMorphisms)
-  Cn = get_attribute(C, :name)
-  if Cn === nothing
-    Cn = "F"
-  end
-
   name_mod = String[]
   rank_mod = Int[]
 
@@ -410,18 +399,18 @@ function free_show(io::IO, C::ComplexOfMorphisms)
   arr = ("<--", "--")
 
   R = Nemo.base_ring(C[first(rng)])
-  R_name = get_attribute(R, :name)
+  R_name = get_name(R)
   if R_name === nothing
     R_name = "$R"
   end
 
   for i=reverse(rng)
     M = C[i]
-    if get_attribute(M, :name) !== nothing
-      push!(name_mod, get_attribute(M, :name))
-    else
-      push!(name_mod, "$R_name^$(rank(M))")
+    M_name = get_name(M)
+    if M_name === nothing
+      M_name = "$R_name^$(rank(M))"
     end
+    push!(name_mod, M_name)
     push!(rank_mod, rank(M))
   end
 
@@ -462,7 +451,7 @@ function show(io::IO, C::ComplexOfMorphisms)
   @show_name(io, C)
   @show_special(io, C)
 
-  Cn = get_attribute(C, :name)
+  Cn = get_name(C)
   if Cn === nothing
     Cn = "C"
   end
@@ -481,11 +470,11 @@ function show(io::IO, C::ComplexOfMorphisms)
 
   for i=rng
     M = obj(C, i)
-      if is_chain_complex(C)
-        name_mod[i] = "$(Cn)_$i"
-      else
-        name_mod[i] = "$(Cn)^$i"
-      end
+    if is_chain_complex(C)
+      name_mod[i] = "$(Cn)_$i"
+    else
+      name_mod[i] = "$(Cn)^$i"
+    end
   end
 
   io = IOContext(io, :compact => true)

--- a/src/GrpAb/ChainComplex.jl
+++ b/src/GrpAb/ChainComplex.jl
@@ -352,7 +352,7 @@ function pres_show(io::IO, C::ComplexOfMorphisms)
       if isnothing(M_name)
         M_name = "$R_name^$(rank(M))"
       end
-      push!(name_mod, name)
+      push!(name_mod, M_name)
       push!(rank_mod, rank(M))
     end
   end

--- a/src/Hecke.jl
+++ b/src/Hecke.jl
@@ -385,23 +385,6 @@ function _get_version()
 end
 const pkg_version = _get_version()
 
-######################################################################
-# named printing support
-######################################################################
-
-# to use:
-# in HeckeMap
-#   in the show function, start with @show_name(io, map)
-# for other objects
-#   add @attributes to the struct
-#   add @show_name(io, obj) to show
-#   optionally, add @show_special(io, obj) as well
-# on creation, or whenever, call set_name!(obj, string)
-# @show_name will set on printing if bound in the REPL
-# moved into AbstractAlgebra
-
-#maps are different - as are number fields
-
 ################################################################################
 #
 #  Jupyter notebook check
@@ -423,7 +406,7 @@ abstract type HeckeMap <: SetMap end  #needed here for the hasspecial stuff
 
 import AbstractAlgebra: get_attribute, set_attribute!, @show_name, @show_special,
        _get_attributes, _get_attributes!, _is_attribute_storing_type,
-       @show_special_elem, @attributes, extra_name, set_name!, find_name
+       @show_special_elem, @attributes, extra_name, set_name!, get_name
 
 # Hecke maps store attributes in the header object
 _get_attributes(G::Map{<:Any, <:Any, HeckeMap, <:Any}) = _get_attributes(G.header)

--- a/src/Misc/IJulia.jl
+++ b/src/Misc/IJulia.jl
@@ -29,7 +29,7 @@ function Base.show(io::IO, ::MIME"text/html", a::PolyRingElem)
 end
 
 function math_html(io::IO, a::AbsSimpleNumField)
-  n = find_name(a)
+  n = get_name(a)
   if n === nothing || !get(io, :compact, false)
     print(io, "\\text{Number field over Rational field with defining polynomial }")
     math_html(io, a.pol)
@@ -45,7 +45,7 @@ function Base.show(io::IO, ::MIME"text/html", a::RelNonSimpleNumField)
 end
 
 function math_html(io::IO, a::RelNonSimpleNumField)
-  n = find_name(a)
+  n = get_name(a)
   if n === nothing || !get(io, :compact, false)
     print(io, "\\text{non-simple Relative number field over }")
     math_html(io, base_field(a))
@@ -63,7 +63,7 @@ function Base.show(io::IO, ::MIME"text/html", a::AbsNonSimpleNumField)
 end
 
 function math_html(io::IO, a::AbsNonSimpleNumField)
-  n = find_name(a)
+  n = get_name(a)
   if n === nothing || !get(io, :compact, false)
     print(io, "\\text{non-simple number field with defining polynomials: }")
     math_html(io, a.pol)
@@ -349,12 +349,12 @@ function math_html(io::IO, O::AbsSimpleNumFieldOrder)
     return
   end
 
-  n = find_name(O)
-  if !(n===nothing)
+  n = get_name(O)
+  if n !== nothing
     print(io, string(n))
     return
   end
-  n = find_name(nf(O))
+  n = get_name(nf(O))
   if n === nothing
     print(io, "\\text{$n }")
     math_html(io, nf(O))
@@ -371,7 +371,7 @@ end
 
 
 function math_html(io::IO, M::Map)
-  n = find_name(M)
+  n = get_name(M)
   cio = IOContext(io, :compact => true)
   if n === nothing
     print(io, "\\text{Map from }")
@@ -379,14 +379,14 @@ function math_html(io::IO, M::Map)
     print(io, string(n))
     print(io, ": ")
   end
-  n = find_name(domain(M))
+  n = get_name(domain(M))
   if n === nothing
     math_html(cio, domain(M))
   else
     print(io, string(n))
   end
   print(io, "\\to ")
-  n = find_name(codomain(M))
+  n = get_name(codomain(M))
   if n === nothing
     math_html(cio, codomain(M))
   else
@@ -402,7 +402,7 @@ end
 
 function math_html(io::IO, I::AbsNumFieldOrderIdealSet)
   print(io, "\\text{Set of ideals of }")
-  n = find_name(order(I))
+  n = get_name(order(I))
   if n === nothing || !get(io, :compact, false)
     math_html(IOContext(io, :compact => true), order(I))
   else
@@ -430,7 +430,7 @@ end
 #      add special(?) for class group
 #      add parent of tuple... (occurs in tensor product)
 function math_html(io::IO, G::FinGenAbGroup)
-  n = find_name(G)
+  n = get_name(G)
   if !(n === nothing) && get(io, :compact, false)
     print(io, string(n))
     return
@@ -458,7 +458,7 @@ function math_html(io::IO, G::FinGenAbGroup)
 end
 
 function math_html(io::IO, R::PolyRing)
-  n = find_name(R)
+  n = get_name(R)
   if !(n === nothing) && get(io, :compact, false)
     print(io, string(n))
     return
@@ -474,7 +474,7 @@ function Base.show(io::IO, ::MIME"text/html", K::PolyRing)
 end
 
 function math_html(io::IO, K::RelSimpleNumField)
-  n = find_name(K)
+  n = get_name(K)
   if !(n === nothing) && get(io, :compact, false)
     print(io, string(n))
     return

--- a/src/NumFieldOrd/NfOrd/NfOrd.jl
+++ b/src/NumFieldOrd/NfOrd/NfOrd.jl
@@ -221,15 +221,11 @@ function show(io::IO, S::AbsNumFieldOrderSet)
 end
 
 function extra_name(O::AbsNumFieldOrder)
-  set_name!(O)
-  s = get_attribute(O, :name)
-  s !== nothing && return
-  set_name!(nf(O))
-  s = get_attribute(nf(O), :name)
+  s = get_name(nf(O))
   if s !== nothing
-    set_name!(O, "O_$s")
+    return "O_$s"
   end
-  return get_attribute(O, :name)
+  return nothing
 end
 
 function show(io::IO, O::AbsNumFieldOrder)

--- a/test/QuadForm/Torsion.jl
+++ b/test/QuadForm/Torsion.jl
@@ -39,7 +39,7 @@
   @test lift(inner_product(a,b)) == 1//2
   @test order(a) == 2
   @test order(0*a) == 1
-  set_attribute!(q1, :name, "q1")
+  AbstractAlgebra.set_name!(q1, "q1")
   f = hom(q1,q1, ZZ[2 0; 0 1])
   @test sprint(show, f) isa String
 


### PR DESCRIPTION
Refactors everything about name printing to only use the interface discussed in https://github.com/Nemocas/AbstractAlgebra.jl/pull/1594 (and no longer any internals)