### PR TITLE
Add `residue_ring(::ZZRing, ::ZZIdl)`

### DIFF
--- a/src/NumField/QQ.jl
+++ b/src/NumField/QQ.jl
@@ -305,6 +305,8 @@ quo(R::ZZRing, I::ZZIdl) = quo(R, gen(I))
 
 residue_ring(R::ZZRing, I::ZZIdl) = quo(R, I)
 
+residue_field(R::ZZRing, I::ZZIdl) = residue_field(R, gen(I))
+
 
 ################################################################################
 #

--- a/test/NumField/QQ.jl
+++ b/test/NumField/QQ.jl
@@ -105,4 +105,7 @@ end
   @test !(1 in I)
   @test Hecke.lifted_numerator(ZZ(1))==ZZ(1)
   @test Hecke.lifted_denominator(ZZ(2))==ZZ(1)
+
+  @test residue_ring(ZZ, ZZ(5))[1] == residue_ring(ZZ, ideal(ZZ, 5))[1]
+  @test residue_field(ZZ, ZZ(5))[1] == residue_field(ZZ, ideal(ZZ, 5))[1]
 end


### PR DESCRIPTION
This change makes the code in https://github.com/oscar-system/Oscar.jl/issues/2915#issuecomment-1801794028 run. And I find it nice to have for consistency (see https://github.com/oscar-system/Oscar.jl/issues/2915#issuecomment-1801794028).