### PR TITLE
lattices: fix is_free for some cases

### DIFF
--- a/src/ModAlgAss/Lattices/Morphisms.jl
+++ b/src/ModAlgAss/Lattices/Morphisms.jl
@@ -215,7 +215,11 @@ function _is_loc_iso_gen(L::ModAlgAssLat,
   fl, alpha = is_locally_free(I, p, side = :right)
   imal = image(f, alpha)
   if !fl
-    return fl, imal
+    if with_iso === Val{true}
+      return fl, imal
+    else
+      return fl
+    end
   end
   mat = matrix(imal)
   # I need to test whether M is a (p-)local isomorphism L -> M

--- a/test/ModAlgAss/Lattices/Lattices.jl
+++ b/test/ModAlgAss/Lattices/Lattices.jl
@@ -7,4 +7,9 @@ begin
     @test fl
     @test lattice(V, integral_group_ring(algebra(V)), c) == M
   end
+
+  # from the oscar book
+  K, a = number_field(x^4 + 4*x^2 + 2, "a");
+  V, f = galois_module(K); OK = ring_of_integers(K); M = f(OK);
+  @test !is_free(M)
 end


### PR DESCRIPTION
where `_is_loc_iso_gen` was not respecting `with_iso`

add test from the book

The corresponding code from the book currently fails with:
```julia
julia> is_free(M)
ERROR: MethodError: no method matching !(::Tuple{Bool, Hecke.ModAlgHom{Hecke.ModAlgAss{QQField, QQMatrix, GroupAlgebra{QQFieldElem, MultTableGroup, MultTableGroupElem}}, QQMatrix}})

Closest candidates are:
  !(::Static.True)
   @ Static ~/.julia/packages/Static/6JeQI/src/Static.jl:514
  !(::Static.False)
   @ Static ~/.julia/packages/Static/6JeQI/src/Static.jl:515
  !(::Missing)
   @ Base missing.jl:101
  ...

Stacktrace:
 [1] _is_locally_isomorphic_same_ambient_module(L::Hecke.ModAlgAssLat{Hecke.AlgAssAbsOrd{…}, Hecke.ModAlgAss{…}, QQMatrix}, M::Hecke.ModAlgAssLat{Hecke.AlgAssAbsOrd{…}, Hecke.ModAlgAss{…}, QQMatrix})
   @ Hecke ~/.julia/packages/Hecke/AP42u/src/ModAlgAss/Lattices/Morphisms.jl:162
 [2] is_locally_isomorphic(L::Hecke.ModAlgAssLat{Hecke.AlgAssAbsOrd{…}, Hecke.ModAlgAss{…}, QQMatrix}, M::Hecke.ModAlgAssLat{Hecke.AlgAssAbsOrd{…}, Hecke.ModAlgAss{…}, QQMatrix})
   @ Hecke ~/.julia/packages/Hecke/AP42u/src/ModAlgAss/Lattices/Morphisms.jl:150
 [3] _is_isomorphic_with_isomorphism_same_ambient_module(L::Hecke.ModAlgAssLat{…}, M::Hecke.ModAlgAssLat{…}, with_iso::Type{…})
   @ Hecke ~/.julia/packages/Hecke/AP42u/src/ModAlgAss/Lattices/Morphisms.jl:276
 [4] _is_isomorphic(L::Hecke.ModAlgAssLat{Hecke.AlgAssAbsOrd{…}, Hecke.ModAlgAss{…}, QQMatrix}, M::Hecke.ModAlgAssLat{Hecke.AlgAssAbsOrd{…}, Hecke.ModAlgAss{…}, QQMatrix}, with_iso::Type{Val{…}})
   @ Hecke ~/.julia/packages/Hecke/AP42u/src/ModAlgAss/Lattices/Morphisms.jl:328
 [5] is_isomorphic(L::Hecke.ModAlgAssLat{Hecke.AlgAssAbsOrd{…}, Hecke.ModAlgAss{…}, QQMatrix}, M::Hecke.ModAlgAssLat{Hecke.AlgAssAbsOrd{…}, Hecke.ModAlgAss{…}, QQMatrix})
   @ Hecke ~/.julia/packages/Hecke/AP42u/src/ModAlgAss/Lattices/Morphisms.jl:303
 [6] is_free(L::Hecke.ModAlgAssLat{Hecke.AlgAssAbsOrd{GroupAlgebra{…}, GroupAlgebraElem{…}}, Hecke.ModAlgAss{QQField, QQMatrix, GroupAlgebra{…}}, QQMatrix})
   @ Hecke ~/.julia/packages/Hecke/AP42u/src/ModAlgAss/Lattices/Morphisms.jl:376
 [7] top-level scope
   @ REPL[27]:1
Some type information was truncated. Use `show(err)` to see complete types.
```