### PR TITLE
isfree: fix another book-example

### DIFF
--- a/src/AlgAssAbsOrd/PIP/bley_johnston.jl
+++ b/src/AlgAssAbsOrd/PIP/bley_johnston.jl
@@ -158,7 +158,8 @@ function __unit_reps(M, F)
   return unit_reps
 end
 
-function _is_principal_with_data_bj(I, O; side = :right, _alpha = nothing)
+function _is_principal_with_data_bj(I, O; side = :right, _alpha = nothing, local_freeness::Bool = false)
+  # local_freeness needs to be accepted since the generic interface uses it
   A = algebra(O)
   if _alpha === nothing
     _assert_has_refined_wedderburn_decomposition(A)

--- a/test/ModAlgAss/Lattices/Lattices.jl
+++ b/test/ModAlgAss/Lattices/Lattices.jl
@@ -13,3 +13,12 @@ begin
   V, f = galois_module(K); OK = ring_of_integers(K); M = f(OK);
   @test !is_free(M)
 end
+
+let
+  Qx, x = QQ["x"]
+  K, a = number_field(x^8 + 105*x^6 + 3465*x^4 + 44100*x^2 + 176400, "a")
+  V, f = galois_module(K)
+  OK = ring_of_integers(K)
+  M = f(OK)
+  @test !is_free(M)
+end


### PR DESCRIPTION
Accept local_freeness argument in `_is_principal_with_data_bj`, similar to `_is_principal_with_data_etale`.

To avoid this error:
```julia
julia> fl = is_free(M)
ERROR: MethodError: no method matching _is_principal_with_data_bj(::Hecke.AlgAssAbsOrdIdl{…}, ::Hecke.AlgAssAbsOrd{…}; side::Symbol, local_freeness::Bool)

Closest candidates are:
  _is_principal_with_data_bj(::Any, ::Any; side, _alpha) got unsupported keyword argument "local_freeness"
   @ Hecke ~/.julia/packages/Hecke/AP42u/src/AlgAssAbsOrd/PIP/bley_johnston.jl:161

Stacktrace:
 [1] kwerr(::@NamedTuple{…}, ::Function, ::Hecke.AlgAssAbsOrdIdl{…}, ::Hecke.AlgAssAbsOrd{…})
   @ Base ./error.jl:165
 [2] _is_principal(::Type, ::Hecke.AlgAssAbsOrdIdl{…}, ::Vararg{…}; kw::@Kwargs{…})
   @ Hecke ~/.julia/packages/Hecke/AP42u/src/AlgAssAbsOrd/PIP.jl:41
 [3] #_is_principal#4598
   @ ~/.julia/packages/Hecke/AP42u/src/AlgAssAbsOrd/PIP.jl:65 [inlined]
 [4] _is_isomorphic_with_isomorphism_same_ambient_module(L::Hecke.ModAlgAssLat{…}, M::Hecke.ModAlgAssLat{…}, with_iso::Type{…})
   @ Hecke ~/.julia/packages/Hecke/AP42u/src/ModAlgAss/Lattices/Morphisms.jl:298
 [5] _is_isomorphic(L::Hecke.ModAlgAssLat{…}, M::Hecke.ModAlgAssLat{…}, with_iso::Type{…})
   @ Hecke ~/.julia/packages/Hecke/AP42u/src/ModAlgAss/Lattices/Morphisms.jl:332
 [6] is_isomorphic(L::Hecke.ModAlgAssLat{…}, M::Hecke.ModAlgAssLat{…})
   @ Hecke ~/.julia/packages/Hecke/AP42u/src/ModAlgAss/Lattices/Morphisms.jl:307
 [7] is_free(L::Hecke.ModAlgAssLat{Hecke.AlgAssAbsOrd{…}, Hecke.ModAlgAss{…}, QQMatrix})
   @ Hecke ~/.julia/packages/Hecke/AP42u/src/ModAlgAss/Lattices/Morphisms.jl:380
 [8] top-level scope
   @ REPL[10]:1
Some type information was truncated. Use `show(err)` to see complete types.
```

The corresponding example unfortunately doesn't run without Oscar, so I can't add it as a test but the booktests should cover this soon™:
```julia
julia> Qx, x = QQ["x"];

julia> k, = number_field(x^4 - 13*x^2 + 16); candidates = []; for F in abelian_normal_extensions(k, [2], ZZ(10)^13)
         K, = absolute_simple_field(number_field(F))
         if !is_tamely_ramified(K)
           continue
         end
         if !is_isomorphic(galois_group(K)[1], quaternion_group(8))
           continue
         end
         push!(candidates, K)
       end


julia> K = candidates[2]; V, f = galois_module(K); OK = ring_of_integers(K); M = f(OK);

julia> @test !is_free(M)
Test Passed
```