### PR TITLE
Adapt to deprecations introduced in AA

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,7 +28,7 @@ GAPExt = "GAP"
 PolymakeExt = "Polymake"
 
 [compat]
-AbstractAlgebra = "^0.40.5"
+AbstractAlgebra = "^0.40.9"
 Dates = "1.6"
 Distributed = "1.6"
 GAP = "0.9.6, 0.10, 0.11"

--- a/src/NumField/NfAbs/NfAbs.jl
+++ b/src/NumField/NfAbs/NfAbs.jl
@@ -921,9 +921,9 @@ end
 #
 ################################################################################
 
-function force_coerce(a::NumField{T}, b::NumFieldElem, throw_error::Type{Val{S}} = Val{true}) where {T, S}
+function force_coerce(a::NumField{T}, b::NumFieldElem, ::Val{throw_error} = Val(true)) where {T, throw_error}
   if Nemo.is_cyclo_type(a) && Nemo.is_cyclo_type(parent(b))
-    return force_coerce_cyclo(a, b, throw_error)::elem_type(a)
+    return force_coerce_cyclo(a, b, Val{throw_error})::elem_type(a)
   end
   if absolute_degree(parent(b)) <= absolute_degree(a)
     c = find_one_chain(parent(b), a)
@@ -936,7 +936,7 @@ function force_coerce(a::NumField{T}, b::NumFieldElem, throw_error::Type{Val{S}}
       return x::elem_type(a)
     end
   end
-  if throw_error === Val{true}
+  if throw_error
     error("no coercion possible")
   else
     return false

--- a/src/NumField/NfAbs/NfAbs.jl
+++ b/src/NumField/NfAbs/NfAbs.jl
@@ -1163,12 +1163,12 @@ function common_super(a::NumFieldElem, b::NumFieldElem)
 end
 
 #tries to find a common parent for all "a" and then calls op on it.
-function force_op(op::T, throw_error::Type{Val{S}}, a::NumFieldElem...) where {T <: Function, S}
+function force_op(op::Function, ::Val{throw_error}, a::NumFieldElem...) where {throw_error}
   C = parent(a[1])
   for b = a
     C = common_super(parent(b), C)
     if C === nothing
-      if throw_error === Val{true}
+      if throw_error
         error("no common parent known")
       else
         return nothing


### PR DESCRIPTION
See https://github.com/Nemocas/AbstractAlgebra.jl/pull/1664.

Once https://github.com/Nemocas/AbstractAlgebra.jl/pull/1664 is released, ~~the AA compat needs to be adapted and~~ this merged.