### PR TITLE
Fix uses of `Val` inside Hecke

### DIFF
--- a/examples/MultDep.jl
+++ b/examples/MultDep.jl
@@ -26,7 +26,7 @@ function multiplicative_group_mod_units_fac_elem(A::Vector{AbsSimpleNumFieldElem
     end
     push!(M, sparse_row(FlintZZ, T))
   end
-  h, t = Hecke.hnf_kannan_bachem(M, Val{true}, truncate = true)
+  h, t = Hecke.hnf_kannan_bachem(M, Val(true), truncate = true)
   return h, t, cp
 end
 

--- a/src/AlgAss/AbsAlgAss.jl
+++ b/src/AlgAss/AbsAlgAss.jl
@@ -730,13 +730,13 @@ function _add_row_to_rref!(M::MatElem{T}, v::Vector{T}, pivot_rows::Vector{Int},
 end
 
 @doc raw"""
-    gens(A::AbstractAssociativeAlgebra, return_full_basis::Typel{Val{T}} = Val{false};
+    gens(A::AbstractAssociativeAlgebra, return_full_basis::Val = Val(false);
          thorough_search::Bool = false) where T
       -> Vector{AbstractAssociativeAlgebraElem}
 
 Returns a subset of `basis(A)`, which generates $A$ as an algebra over
 `base_ring(A)`.
-If `return_full_basis` is set to `Val{true}`, the function also returns a
+If `return_full_basis` is set to `Val(true)`, the function also returns a
 `Vector{AbstractAssociativeAlgebraElem}` containing a full basis consisting of monomials in
 the generators and a `Vector{Vector{Tuple{Int, Int}}}` containing the
 information on how these monomials are built. E. g.: If the function returns
@@ -746,9 +746,9 @@ If `thorough_search` is `true`, the number of returned generators is possibly
 smaller. This will in general increase the runtime. It is not guaranteed that
 the number of generators is minimal in any case.
 """
-function gens(A::AbstractAssociativeAlgebra, return_full_basis::Type{Val{T}} = Val{false}; thorough_search::Bool = false) where T
+function gens(A::AbstractAssociativeAlgebra, ::Val{return_full_basis} = Val(false); thorough_search::Bool = false) where return_full_basis
   d = dim(A)
-  if return_full_basis === Val{false}
+  if !return_full_basis
     if isdefined(A, :gens)
       return A.gens::Vector{elem_type(A)}
     end
@@ -858,7 +858,7 @@ function gens(A::AbstractAssociativeAlgebra, return_full_basis::Type{Val{T}} = V
     A.gens = generators
   end
 
-  if return_full_basis == Val{true}
+  if return_full_basis
     return generators, full_basis, elts_in_gens
   else
     return generators

--- a/src/AlgAss/AlgAss.jl
+++ b/src/AlgAss/AlgAss.jl
@@ -893,12 +893,12 @@ end
 # We assume ncols(B) == dim(A).
 # A rref of B will be computed IN PLACE! If return_LU is Val{true}, a LU-factorization
 # of transpose(rref(B)) is returned.
-function _build_subalgebra_mult_table!(A::StructureConstantAlgebra{T}, B::MatElem{T}, return_LU::Type{Val{S}} = Val{false}; is_commutative = false) where { T, S }
+function _build_subalgebra_mult_table!(A::StructureConstantAlgebra{T}, B::MatElem{T}, ::Val{return_LU} = Val(false); is_commutative = false) where { T, return_LU }
   K = base_ring(A)
   n = dim(A)
   r = rref!(B)
   if r == 0
-    if return_LU == Val{true}
+    if return_LU
       return Array{elem_type(K), 3}(undef, 0, 0, 0), solve_init(B)
     else
       return Array{elem_type(K), 3}(undef, 0, 0, 0)
@@ -948,7 +948,7 @@ function _build_subalgebra_mult_table!(A::StructureConstantAlgebra{T}, B::MatEle
     end
   end
 
-  if return_LU == Val{true}
+  if return_LU
     return mult_table, LL #p, L, U, LL
   else
     return mult_table
@@ -971,7 +971,7 @@ function subalgebra(A::StructureConstantAlgebra{T}, e::AssociativeAlgebraElem{T,
   n = dim(A)
   # This is the basis of e*A, resp. A*e
   B1 = representation_matrix(e, action)
-  mult_table, LL = _build_subalgebra_mult_table!(A, B1, Val{true})
+  mult_table, LL = _build_subalgebra_mult_table!(A, B1, Val(true))
 
   r = size(mult_table, 1)
 
@@ -1042,7 +1042,7 @@ function subalgebra(A::StructureConstantAlgebra{T}, basis::Vector{AssociativeAlg
   for i = 1:length(basis)
     elem_to_mat_row!(M, i, basis[i])
   end
-  mt = _build_subalgebra_mult_table!(A, M, is_commutative = is_commutative)
+  mt = _build_subalgebra_mult_table!(A, M; is_commutative = is_commutative)
   B = StructureConstantAlgebra(base_ring(A), mt)
   return B, hom(B, A, sub(M, 1:length(basis), 1:dim(A)))
 end

--- a/src/AlgAss/AlgGrp.jl
+++ b/src/AlgAss/AlgGrp.jl
@@ -312,23 +312,23 @@ function _merge_elts_in_gens!(left::Vector{Tuple{Int, Int}}, mid::Vector{Tuple{I
 end
 
 @doc raw"""
-    gens(A::GroupAlgebra, return_full_basis::Type{Val{T}} = Val{false})
+    gens(A::GroupAlgebra, return_full_basis::Val = Val(false))
       -> Vector{GroupAlgebraElem}
 
 Returns a subset of `basis(A)`, which generates $A$ as an algebra over
 `base_ring(A)`.
-If `return_full_basis` is set to `Val{true}`, the function also returns a
+If `return_full_basis` is set to `Val(true)`, the function also returns a
 `Vector{AbstractAssociativeAlgebraElem}` containing a full basis consisting of monomials in
 the generators and a `Vector{Vector{Tuple{Int, Int}}}` containing the
 information on how these monomials are built. E. g.: If the function returns
 `g`, `full_basis` and `v`, then we have
 `full_basis[i] = prod( g[j]^k for (j, k) in v[i] )`.
 """
-function gens(A::GroupAlgebra, return_full_basis::Type{Val{T}} = Val{false}) where T
+function gens(A::GroupAlgebra, ::Val{return_full_basis} = Val(false)) where return_full_basis
   G = group(A)
   group_gens = gens(G)
 
-  return_full_basis == Val{true} ? nothing : return map(A, group_gens)
+  !return_full_basis && return map(A, group_gens)
 
   full_group = elem_type(G)[ id(G) ]
   elts_in_gens = Vector{Tuple{Int, Int}}[ Tuple{Int, Int}[] ]

--- a/src/AlgAss/AlgMat.jl
+++ b/src/AlgAss/AlgMat.jl
@@ -547,9 +547,9 @@ function _matrix_in_algebra(M::S, A::MatAlgebra{T, S}) where {T, S<:MatElem}
   return t*U
 end
 
-function _check_matrix_in_algebra(M::S, A::MatAlgebra{T, S}, short::Type{Val{U}} = Val{false}) where {S, T, U}
+function _check_matrix_in_algebra(M::S, A::MatAlgebra{T, S}, ::Val{short} = Val(false)) where {S, T, short}
   if nrows(M) != degree(A) || ncols(M) != degree(A)
-    if short == Val{true}
+    if short
       return false
     end
     return false, zeros(base_ring(A), dim(A))
@@ -580,7 +580,7 @@ function _check_matrix_in_algebra(M::S, A::MatAlgebra{T, S}, short::Type{Val{U}}
   end
   C = basis_matrix_solve_context(A)
   b, N = can_solve_with_solution(C, t, side = :left)
-  if short == Val{true}
+  if short
     return b
   end
   s = N #[N[1, i] for i in 1:length(N)]

--- a/src/AlgAssAbsOrd/LocallyFreeClassGroup.jl
+++ b/src/AlgAssAbsOrd/LocallyFreeClassGroup.jl
@@ -16,7 +16,7 @@ add_verbosity_scope(:LocallyFreeClassGroup)
 Given an order $O$ in a semisimple algebra over $\mathbb Q$, this function
 returns the locally free class group of $O$.
 """
-function locally_free_class_group(O::AlgAssAbsOrd, cond::Symbol = :center, return_disc_log_data::Type{Val{T}} = Val{false}) where T
+function locally_free_class_group(O::AlgAssAbsOrd, cond::Symbol = :center, ::Val{return_disc_log_data} = Val(false)) where return_disc_log_data
   A = algebra(O)
   OA = maximal_order(O)
   Z, ZtoA = center(A)
@@ -101,7 +101,7 @@ function locally_free_class_group(O::AlgAssAbsOrd, cond::Symbol = :center, retur
 
   S, StoCl = snf(Cl)
 
-  if return_disc_log_data == Val{true}
+  if return_disc_log_data
     return S, compose(RtoCl, inv(StoCl)), mR, FinZ
   else
     return S
@@ -128,7 +128,7 @@ function locally_free_class_group_with_disc_log(O::AlgAssAbsOrd; check::Bool = t
     end
   end
 
-  Cl, RtoCl, mR, FinZ = locally_free_class_group(O, :left, Val{true})
+  Cl, RtoCl, mR, FinZ = locally_free_class_group(O, :left, Val(true))
 
   IdlSet = IdealSet(O)
   disc_log = DiscLogLocallyFreeClassGroup{typeof(IdlSet), typeof(Cl)}(IdlSet, Cl, RtoCl, mR, FinZ)

--- a/src/AlgAssAbsOrd/Order.jl
+++ b/src/AlgAssAbsOrd/Order.jl
@@ -934,7 +934,7 @@ end
 # for an ideal a of O.
 # See Bley, Johnston "Computing generators of free modules over orders in group
 # algebras", Prop. 5.1.
-function _simple_maximal_order(O::AlgAssAbsOrd{S1, S2}, with_trafo::Type{Val{T}} = Val{false}) where { S1 <: MatAlgebra, S2, T }
+function _simple_maximal_order(O::AlgAssAbsOrd{S1, S2}, ::Val{with_transform} = Val(false)) where { S1 <: MatAlgebra, S2, with_transform }
   A = algebra(O)
 
   if !(A isa MatAlgebra)
@@ -966,7 +966,7 @@ function _simple_maximal_order(O::AlgAssAbsOrd{S1, S2}, with_trafo::Type{Val{T}}
 
   @assert basis_matrix(FakeFmpqMat, simpleOrder) == FakeFmpqMat(identity_matrix(FlintQQ, n^2))
 
-  if with_trafo == Val{true}
+  if with_transform
     return simpleOrder, A(M)
   else
     return simpleOrder
@@ -987,7 +987,7 @@ function nice_order(O::AlgAssAbsOrd{S, T}) where {S, T}
   if isdefined(O, :nice_order)
     return O.nice_order::Tuple{typeof(O), T}
   else
-    sO, A = _simple_maximal_order(O, Val{true})
+    sO, A = _simple_maximal_order(O, Val(true))
     O.nice_order = sO, A
     return sO, A
   end

--- a/src/AlgAssAbsOrd/Order.jl
+++ b/src/AlgAssAbsOrd/Order.jl
@@ -326,14 +326,14 @@ end
 #
 ################################################################################
 
-function _check_elem_in_order(a::T, O::AlgAssAbsOrd{S, T}, short::Type{Val{U}} = Val{false}) where {S, T, U}
+function _check_elem_in_order(a::T, O::AlgAssAbsOrd{S, T}, ::Val{short} = Val(false)) where {S, T, short}
   t = zero_matrix(FlintQQ, 1, degree(O))
   elem_to_mat_row!(t, 1, a)
   t = FakeFmpqMat(t)
   t = t*basis_mat_inv(FakeFmpqMat, O, copy = false)
-  if short == Val{true}
+  if short
     return isone(t.den)
-  elseif short == Val{false}
+  else
     if !isone(t.den)
       return false, Vector{ZZRingElem}()
     else
@@ -352,7 +352,7 @@ end
 Returns `true` if the algebra element $x$ is in $O$ and `false` otherwise.
 """
 function in(x::T, O::AlgAssAbsOrd{S, T}) where {S, T}
-  return _check_elem_in_order(x, O, Val{true})
+  return _check_elem_in_order(x, O, Val(true))
 end
 
 ################################################################################

--- a/src/AlgAssAbsOrd/ResidueRingMultGrp.jl
+++ b/src/AlgAssAbsOrd/ResidueRingMultGrp.jl
@@ -201,7 +201,7 @@ function _multgrp_mod_p(p::AlgAssAbsOrdIdl, P::AlgAssAbsOrdIdl)
   if qq == q
     # Maybe we are lucky and don't need to search for another generator
     aa = OAtoOAP\GtoOAP(G[1])
-    x = _check_elem_in_order(elem_in_algebra(aa, copy = false), O, Val{true})
+    x = _check_elem_in_order(elem_in_algebra(aa, copy = false), O, Val(true))
     if x
       a = O(aa, false)
     end

--- a/src/AlgAssAbsOrd/ResidueRingMultGrp.jl
+++ b/src/AlgAssAbsOrd/ResidueRingMultGrp.jl
@@ -324,7 +324,7 @@ function _1_plus_p_mod_1_plus_q_generators(p::AlgAssAbsOrdIdl, q::AlgAssAbsOrdId
     l = 2*k
     pl = pl^2
     plq = pl + q
-    append!(g, _1_plus_pu_plus_q_mod_1_plus_pv_plus_q(pkq, plq, Val{true}))
+    append!(g, _1_plus_pu_plus_q_mod_1_plus_pv_plus_q(pkq, plq, Val(true)))
   end
 
   return g
@@ -366,7 +366,7 @@ end
 # Compute the group (1 + puq)/(1 + pvq), where it should hold puq = p^u + q and
 # pvq = p^v + q with v <= 2*u.
 # Cohen "Advanced Topics in Computational Number Theory" Algorithm 4.2.15.
-function _1_plus_pu_plus_q_mod_1_plus_pv_plus_q(puq::AlgAssAbsOrdIdl, pvq::AlgAssAbsOrdIdl, only_generators::Type{Val{T}} = Val{false}) where T
+function _1_plus_pu_plus_q_mod_1_plus_pv_plus_q(puq::AlgAssAbsOrdIdl, pvq::AlgAssAbsOrdIdl, ::Val{only_generators} = Val(false)) where only_generators
   O = order(puq)
   b = [ O(x) for x in basis(puq, copy = false) ]
 
@@ -388,7 +388,7 @@ function _1_plus_pu_plus_q_mod_1_plus_pv_plus_q(puq::AlgAssAbsOrdIdl, pvq::AlgAs
   # We want generators of (1 + p^u + q)/(1 + p^v + q)
   map!(x -> x + one(O), gens, gens)
 
-  if only_generators == Val{true}
+  if only_generators
     return gens
   end
 

--- a/src/AlgAssRelOrd/Order.jl
+++ b/src/AlgAssRelOrd/Order.jl
@@ -248,12 +248,12 @@ end
 #
 ################################################################################
 
-function _check_elem_in_order(a::AbstractAssociativeAlgebraElem{S}, O::AlgAssRelOrd{S, T, V}, short::Type{Val{U}} = Val{false}) where {S, T, U, V}
+function _check_elem_in_order(a::AbstractAssociativeAlgebraElem{S}, O::AlgAssRelOrd{S, T, V}, ::Val{short} = Val(false)) where {S, T, V, short}
   t = zero_matrix(base_ring(algebra(O)), 1, degree(O))
   elem_to_mat_row!(t, 1, a)
   t = t*basis_mat_inv(O, copy = false)
   b_pmat = basis_pmatrix(O, copy = false)
-  if short == Val{true}
+  if short
     for i = 1:degree(O)
       if !(t[1, i] in b_pmat.coeffs[i])
         return false
@@ -280,7 +280,7 @@ end
 Returns `true` if the algebra element $a$ is in $O$ and `false` otherwise.
 """
 function in(a::AbstractAssociativeAlgebraElem{S}, O::AlgAssRelOrd{S, T, U}) where {S, T, U}
-  return _check_elem_in_order(a, O, Val{true})
+  return _check_elem_in_order(a, O, Val(true))
 end
 
 ################################################################################

--- a/src/AlgAssRelOrd/Order.jl
+++ b/src/AlgAssRelOrd/Order.jl
@@ -565,7 +565,7 @@ _denominator_of_mult_table(A::GroupAlgebra{T}, R::Union{ AbsNumFieldOrder, RelNu
 # for an ideal a of O.
 # See Bley, Johnston "Computing generators of free modules over orders in group
 # algebras", Prop. 5.1.
-function _simple_maximal_order(O::AlgAssRelOrd, make_free::Bool = true, with_trafo::Type{Val{T}} = Val{false}) where T
+function _simple_maximal_order(O::AlgAssRelOrd, make_free::Bool = true, ::Val{with_transform} = Val(false)) where {with_transform}
   A = algebra(O)
   @assert A isa MatAlgebra
   n = degree(A)
@@ -621,7 +621,7 @@ function _simple_maximal_order(O::AlgAssRelOrd, make_free::Bool = true, with_tra
   niceorder.isnice = true
   niceorder.nice_order_ideal = a
 
-  if with_trafo == Val{true}
+  if with_transform
     return niceorder, A(iM)
   else
     return niceorder
@@ -638,7 +638,7 @@ function nice_order(O::AlgAssRelOrd{S, T, U}; cached::Bool = true) where {S, T, 
   if cached && isdefined(O, :nice_order)
     return O.nice_order::Tuple{typeof(O), elem_type(U)}
   else
-    sO, A = _simple_maximal_order(O, true, Val{true})
+    sO, A = _simple_maximal_order(O, true, Val(true))
     if cached
       O.nice_order = sO, A
     end

--- a/src/AlgAssRelOrd/Order.jl
+++ b/src/AlgAssRelOrd/Order.jl
@@ -709,7 +709,7 @@ is_maximal_known(O::AlgAssRelOrd) = O.is_maximal != 0
 Returns an order $O'$ containing $O$ such that the localization $O'_p$ is
 hereditary where $p$ is a prime ideal of the base ring of $O$.
 """
-function phereditary_overorder(O::AlgAssRelOrd, p::Union{ AbsNumFieldOrderIdeal, RelNumFieldOrderIdeal }; return_pradical::Type{Val{T}} = Val{false}) where T
+function phereditary_overorder(O::AlgAssRelOrd, p::Union{ AbsNumFieldOrderIdeal, RelNumFieldOrderIdeal }; return_pradical::Val{return_pradical_bool} = Val(false)) where return_pradical_bool
   d = discriminant(O)
   prad = pradical(O, p)
   OO = left_order(prad)
@@ -723,7 +723,7 @@ function phereditary_overorder(O::AlgAssRelOrd, p::Union{ AbsNumFieldOrderIdeal,
       break
     end
   end
-  if return_pradical == Val{true}
+  if return_pradical_bool
     return OO, prad
   else
     return OO
@@ -760,7 +760,7 @@ order $O''$ containing $O$ is not divisible by $p$ where $p$ is a prime ideal
 of the base ring of $O$.
 """
 function pmaximal_overorder(O::AlgAssRelOrd, p::Union{ AbsNumFieldOrderIdeal, RelNumFieldOrderIdeal })
-  O, prad = phereditary_overorder(O, p, return_pradical = Val{true})
+  O, prad = phereditary_overorder(O, p; return_pradical = Val(true))
   return _pmaximal_overorder(O, prad, p, strict_containment = true)
 end
 

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -230,3 +230,5 @@
 
 @deprecate force_coerce_cyclo(a::AbsSimpleNumField, b::AbsSimpleNumFieldElem, throw_error::Type{Val{T}}) where {T} force_coerce_cyclo(a, b, Val(T))
 @deprecate reduce_full(A::SMat{T}, g::SRow{T}, trafo::Type{Val{N}}) where {N, T} reduce_full(A, g, Val(N))
+@deprecate gens(A::GroupAlgebra, return_full_basis::Type{Val{T}}) where T gens(A, Val(T))
+@deprecate gens(A::AbstractAssociativeAlgebra, return_full_basis::Type{Val{T}}; thorough_search::Bool = false) where T gens(A, Val(T); thorough_search)

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -228,4 +228,5 @@
 
 # Deprecated during 0.30.x
 
+@deprecate force_coerce_cyclo(a::AbsSimpleNumField, b::AbsSimpleNumFieldElem, throw_error::Type{Val{T}}) where {T} force_coerce_cyclo(a, b, Val(T))
 @deprecate reduce_full(A::SMat{T}, g::SRow{T}, trafo::Type{Val{N}}) where {N, T} reduce_full(A, g, Val(N))

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -225,3 +225,7 @@
 @deprecate b_invars b_invariants
 @deprecate c_invars c_invariants
 @deprecate basis_mat_inv(x; copy = true) basis_mat_inv(FakeFmpqMat, x; copy)
+
+# Deprecated during 0.30.x
+
+@deprecate reduce_full(A::SMat{T}, g::SRow{T}, trafo::Type{Val{N}}) where {N, T} reduce_full(A, g, Val(N))

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -226,9 +226,15 @@
 @deprecate c_invars c_invariants
 @deprecate basis_mat_inv(x; copy = true) basis_mat_inv(FakeFmpqMat, x; copy)
 
-# Deprecated during 0.30.x
+# Deprecated in 0.31.0
 
-@deprecate force_coerce_cyclo(a::AbsSimpleNumField, b::AbsSimpleNumFieldElem, throw_error::Type{Val{T}}) where {T} force_coerce_cyclo(a, b, Val(T))
-@deprecate reduce_full(A::SMat{T}, g::SRow{T}, trafo::Type{Val{N}}) where {N, T} reduce_full(A, g, Val(N))
-@deprecate gens(A::GroupAlgebra, return_full_basis::Type{Val{T}}) where T gens(A, Val(T))
-@deprecate gens(A::AbstractAssociativeAlgebra, return_full_basis::Type{Val{T}}; thorough_search::Bool = false) where T gens(A, Val(T); thorough_search)
+# TODO: remove the following functions and uncomment the deprecation for the 0.31.0 minor breaking release
+
+force_coerce_cyclo(a::AbsSimpleNumField, b::AbsSimpleNumFieldElem, throw_error::Type{Val{T}}) where {T} = force_coerce_cyclo(a, b, Val(T))
+reduce_full(A::SMat{T}, g::SRow{T}, trafo::Type{Val{N}}) where {N, T} = reduce_full(A, g, Val(N))
+gens(A::GroupAlgebra, return_full_basis::Type{Val{T}}) where T = gens(A, Val(T))
+gens(A::AbstractAssociativeAlgebra, return_full_basis::Type{Val{T}}; thorough_search::Bool = false) where T = gens(A, Val(T); thorough_search)
+# @deprecate force_coerce_cyclo(a::AbsSimpleNumField, b::AbsSimpleNumFieldElem, throw_error::Type{Val{T}}) where {T} force_coerce_cyclo(a, b, Val(T)) false
+# @deprecate reduce_full(A::SMat{T}, g::SRow{T}, trafo::Type{Val{N}}) where {N, T} reduce_full(A, g, Val(N))
+# @deprecate gens(A::GroupAlgebra, return_full_basis::Type{Val{T}}) where T gens(A, Val(T))
+# @deprecate gens(A::AbstractAssociativeAlgebra, return_full_basis::Type{Val{T}}; thorough_search::Bool = false) where T gens(A, Val(T); thorough_search)

--- a/src/FieldFactory/ab_exts.jl
+++ b/src/FieldFactory/ab_exts.jl
@@ -520,7 +520,7 @@ end
 #
 ###############################################################################
 
-function quadratic_fields(bound::Int; tame::Bool=false, real::Bool=false, complex::Bool=false, with_autos::Type{Val{T}}=Val{false}) where T
+function quadratic_fields(bound::Int; tame::Bool=false, real::Bool=false, complex::Bool=false, with_autos::Val{unused}=Val(false)) where unused
 
   @assert !(real && complex)
   Qx,x=polynomial_ring(FlintQQ, "x")

--- a/src/ModAlgAss/Lattices/Morphisms.jl
+++ b/src/ModAlgAss/Lattices/Morphisms.jl
@@ -171,7 +171,7 @@ function is_locally_isomorphic_with_isomophism(L::ModAlgAssLat, M::ModAlgAssLat,
   @req base_ring(L.base_ring) isa ZZRing "Order must be a Z-order"
 
   if is_absolutely_irreducible_known(L.V) && is_absolutely_irreducible(L.V)
-    fl, t = _is_locl_iso_abs_irred(L, M, p, Val{true})
+    fl, t = _is_loc_iso_abs_irred(L, M, p, Val(true))
   else
     fl, t = _is_loc_iso_gen(L, M, p, Val(true))
   end
@@ -186,11 +186,11 @@ function is_locally_isomorphic(L::ModAlgAssLat, M::ModAlgAssLat, p::IntegerUnion
   @req L.base_ring === M.base_ring "Orders of lattices must agree"
   @req base_ring(L.base_ring) isa ZZRing "Order must be a Z-order"
   if is_absolutely_irreducible_known(L.V) && is_absolutely_irreducible(L.V)
-    fl = _is_loc_iso_abs_irred(L, M, p, Val{false})
+    fl = _is_loc_iso_abs_irred(L, M, p, Val(false))
   else
     fl = _is_loc_iso_gen(L, M, p, Val(false))
     if is_absolutely_irreducible_known(L.V) && is_absolutely_irreducible(L.V)
-      @assert _is_loc_iso_gen(L, M, p, Val(false)) == _is_loc_iso_abs_irred(L, M, p, Val{false})
+      @assert _is_loc_iso_gen(L, M, p, Val(false)) == _is_loc_iso_abs_irred(L, M, p, Val(false))
     end
   end
   return fl
@@ -247,13 +247,13 @@ end
 function _is_loc_iso_abs_irred(L::ModAlgAssLat,
                                M::ModAlgAssLat,
                                p::IntegerUnion,
-                               with_iso::Type{Val{S}} = Val{true}) where {S}
+                               ::Val{with_iso} = Val(true)) where {with_iso}
   # We are assuming that L.V === M.V is absolutely irreducible
   # I will not even check this.
   T = basis_matrix(L) * basis_matrix_inverse(M)
   d = denominator(T)
   T = d * T
-  if with_iso === Val{true}
+  if with_iso
     fl = iszero(valuation(det(T), p))
     if fl
       error("Tell the developers to finally do it!")

--- a/src/ModAlgAss/Lattices/Morphisms.jl
+++ b/src/ModAlgAss/Lattices/Morphisms.jl
@@ -300,14 +300,14 @@ function _is_isomorphic_with_isomorphism_same_ambient_module(L::ModAlgAssLat, M:
 end
 
 function is_isomorphic_with_isomorphism(L::ModAlgAssLat, M::ModAlgAssLat)
-  return _is_isomorphic(L, M, Val{true})
+  return _is_isomorphic(L, M, Val(true))
 end
 
 function is_isomorphic(L::ModAlgAssLat, M::ModAlgAssLat)
-  return _is_isomorphic(L, M, Val{false})
+  return _is_isomorphic(L, M, Val(false))
 end
 
-function _is_isomorphic(L::ModAlgAssLat, M::ModAlgAssLat, with_iso::Type{Val{T}}) where {T}
+function _is_isomorphic(L::ModAlgAssLat, M::ModAlgAssLat, with_iso_val::Val{with_iso}) where {with_iso}
   # the hom_space function wants L and M sitting inside the same ambient space
   # there is some choice we can make
   # we try to choose the order, where we already computed the endomorphism
@@ -321,17 +321,17 @@ function _is_isomorphic(L::ModAlgAssLat, M::ModAlgAssLat, with_iso::Type{Val{T}}
   if endoMVknown || (!endoMVknown && !endoLVknown)
     fl, iso = is_isomorphic_with_isomorphism(L.V, M.V)
     if !fl
-      if with_iso === Val{false}
+      if !with_iso
         return false
       else
         return false, zero_map(L.V, M.V)
       end
     end
     LL = iso(L)
-    if with_iso === Val{false}
-      return _is_isomorphic_with_isomorphism_same_ambient_module(LL, M, with_iso())
+    if !with_iso
+      return _is_isomorphic_with_isomorphism_same_ambient_module(LL, M, with_iso_val)
     else
-      fl, LLtoM = _is_isomorphic_with_isomorphism_same_ambient_module(LL, M, with_iso())
+      fl, LLtoM = _is_isomorphic_with_isomorphism_same_ambient_module(LL, M, with_iso_val)
       if fl
         _iso = iso * LLtoM
         @assert _iso(L) == M
@@ -343,17 +343,17 @@ function _is_isomorphic(L::ModAlgAssLat, M::ModAlgAssLat, with_iso::Type{Val{T}}
   else
     fl, iso = is_isomorphic_with_isomorphism(M.V, L.V)
     if !fl
-      if with_iso === Val{false}
+      if !with_iso
         return false
       else
         return false, zero_map(L.V, M.V)
       end
     end
     MM = iso(M)
-    if with_iso === Val{false}
-      return _is_isomorphic_with_isomorphism_same_ambient_module(L, MM, with_iso())
+    if !with_iso
+      return _is_isomorphic_with_isomorphism_same_ambient_module(L, MM, with_iso_val)
     else
-      fl, LtoMM = _is_isomorphic_with_isomorphism_same_ambient_module(L, MM, with_iso())
+      fl, LtoMM = _is_isomorphic_with_isomorphism_same_ambient_module(L, MM, with_iso_val)
       if fl
         _iso = LtoMM * inv(iso)
         @assert _iso(L) == M

--- a/src/ModAlgAss/Lattices/Morphisms.jl
+++ b/src/ModAlgAss/Lattices/Morphisms.jl
@@ -271,7 +271,7 @@ end
 #
 ################################################################################
 
-function _is_isomorphic_with_isomorphism_same_ambient_module(L::ModAlgAssLat, M::ModAlgAssLat, with_iso::Type{Val{T}} = Val{true}) where {T}
+function _is_isomorphic_with_isomorphism_same_ambient_module(L::ModAlgAssLat, M::ModAlgAssLat, ::Val{with_iso} = Val(true)) where {with_iso}
   @vprintln :PIP 1 "is_isomorphic: computing hom space as ideal"
   E, f, O, I = _hom_space_as_ideal(L, M)
   # This is BHJ, 2022, Prop. 3.3
@@ -281,8 +281,8 @@ function _is_isomorphic_with_isomorphism_same_ambient_module(L::ModAlgAssLat, M:
     @vprintln :PIP 1 "is_isomorphic: not locally isomorphic"
     return false
   end
-    @vprintln :PIP 1 "is_isomorphic: locally isomorphic"
-  if with_iso === Val{true}
+  @vprintln :PIP 1 "is_isomorphic: locally isomorphic"
+  if with_iso
     @vprintln :PIP 1 "is_isomorphic: doing pip test"
     # Not that at this point, we know what L and M are locally isomorphic.
     # In particular, I is locally free
@@ -329,9 +329,9 @@ function _is_isomorphic(L::ModAlgAssLat, M::ModAlgAssLat, with_iso::Type{Val{T}}
     end
     LL = iso(L)
     if with_iso === Val{false}
-      return _is_isomorphic_with_isomorphism_same_ambient_module(LL, M, with_iso)
+      return _is_isomorphic_with_isomorphism_same_ambient_module(LL, M, with_iso())
     else
-      fl, LLtoM = _is_isomorphic_with_isomorphism_same_ambient_module(LL, M, with_iso)
+      fl, LLtoM = _is_isomorphic_with_isomorphism_same_ambient_module(LL, M, with_iso())
       if fl
         _iso = iso * LLtoM
         @assert _iso(L) == M
@@ -351,9 +351,9 @@ function _is_isomorphic(L::ModAlgAssLat, M::ModAlgAssLat, with_iso::Type{Val{T}}
     end
     MM = iso(M)
     if with_iso === Val{false}
-      return _is_isomorphic_with_isomorphism_same_ambient_module(L, MM, with_iso)
+      return _is_isomorphic_with_isomorphism_same_ambient_module(L, MM, with_iso())
     else
-      fl, LtoMM = _is_isomorphic_with_isomorphism_same_ambient_module(L, MM, with_iso)
+      fl, LtoMM = _is_isomorphic_with_isomorphism_same_ambient_module(L, MM, with_iso())
       if fl
         _iso = LtoMM * inv(iso)
         @assert _iso(L) == M

--- a/src/ModAlgAss/Lattices/Morphisms.jl
+++ b/src/ModAlgAss/Lattices/Morphisms.jl
@@ -159,7 +159,7 @@ function _is_locally_isomorphic_same_ambient_module(L::ModAlgAssLat, M::ModAlgAs
   E, f, O, I = _hom_space_as_ideal(L, M)
 
   for p in ps
-    if !_is_loc_iso_gen(L, M, p, E, f, O, I, Val{false})
+    if !_is_loc_iso_gen(L, M, p, E, f, O, I, Val(false))
       return false
     end
   end
@@ -173,7 +173,7 @@ function is_locally_isomorphic_with_isomophism(L::ModAlgAssLat, M::ModAlgAssLat,
   if is_absolutely_irreducible_known(L.V) && is_absolutely_irreducible(L.V)
     fl, t = _is_locl_iso_abs_irred(L, M, p, Val{true})
   else
-    fl, t =  _is_loc_iso_gen(L, M, p, Val{true})
+    fl, t = _is_loc_iso_gen(L, M, p, Val(true))
   end
 
   if fl
@@ -188,9 +188,9 @@ function is_locally_isomorphic(L::ModAlgAssLat, M::ModAlgAssLat, p::IntegerUnion
   if is_absolutely_irreducible_known(L.V) && is_absolutely_irreducible(L.V)
     fl = _is_loc_iso_abs_irred(L, M, p, Val{false})
   else
-    fl = _is_loc_iso_gen(L, M, p, Val{false})
+    fl = _is_loc_iso_gen(L, M, p, Val(false))
     if is_absolutely_irreducible_known(L.V) && is_absolutely_irreducible(L.V)
-      @assert _is_loc_iso_gen(L, M, p, Val{false}) == _is_loc_iso_abs_irred(L, M, p, Val{false})
+      @assert _is_loc_iso_gen(L, M, p, Val(false)) == _is_loc_iso_abs_irred(L, M, p, Val{false})
     end
   end
   return fl
@@ -199,9 +199,9 @@ end
 function _is_loc_iso_gen(L::ModAlgAssLat,
                          M::ModAlgAssLat,
                          p::IntegerUnion,
-                         with_iso::Type{Val{S}} = Val{true}) where {S}
+                         with_iso_val::Val{with_iso} = Val(true)) where {with_iso}
   E, f, O, I = _hom_space_as_ideal(L, M)
-  return _is_loc_iso_gen(L, M, p, E, f, O, I, with_iso)
+  return _is_loc_iso_gen(L, M, p, E, f, O, I, with_iso_val)
 end
 
 function _is_loc_iso_gen(L::ModAlgAssLat,
@@ -211,7 +211,7 @@ function _is_loc_iso_gen(L::ModAlgAssLat,
                          f,
                          O,
                          I,
-                         with_iso::Type{Val{S}} = Val{true}) where {S}
+                         ::Val{with_iso} = Val(true)) where {with_iso}
   fl, alpha = is_locally_free(I, p, side = :right)
   imal = image(f, alpha)
   if !fl
@@ -227,7 +227,7 @@ function _is_loc_iso_gen(L::ModAlgAssLat,
   for i in 1:nrows(newbasmat)
     for j in 1:ncols(newbasmat)
       if !iszero(newbasmat[i, j]) && valuation(newbasmat[i, j], p) < 0
-        if with_iso === Val{true}
+        if with_iso
           return false, imal
         else
           return false
@@ -237,7 +237,7 @@ function _is_loc_iso_gen(L::ModAlgAssLat,
   end
   # This means (L * mat)_p \subseteq M_p
   # This is an equality if and only if the base change matrix is invertible modulo p.
-  if with_iso === Val{true}
+  if with_iso
     return valuation(det(newbasmat), p) == 0, imal
   else
     return valuation(det(newbasmat), p) == 0

--- a/src/NumField/NfAbs/NfAbs.jl
+++ b/src/NumField/NfAbs/NfAbs.jl
@@ -921,9 +921,9 @@ end
 #
 ################################################################################
 
-function force_coerce(a::NumField{T}, b::NumFieldElem, ::Val{throw_error} = Val(true)) where {T, throw_error}
+function force_coerce(a::NumField{T}, b::NumFieldElem, throw_error_val::Val{throw_error} = Val(true)) where {T, throw_error}
   if Nemo.is_cyclo_type(a) && Nemo.is_cyclo_type(parent(b))
-    return force_coerce_cyclo(a, b, Val{throw_error})::elem_type(a)
+    return force_coerce_cyclo(a, b, throw_error_val)::elem_type(a)
   end
   if absolute_degree(parent(b)) <= absolute_degree(a)
     c = find_one_chain(parent(b), a)
@@ -1191,7 +1191,7 @@ function embedding(k::NumField, K::NumField)
   end
 end
 
-function force_coerce_cyclo(a::AbsSimpleNumField, b::AbsSimpleNumFieldElem, throw_error::Type{Val{T}} = Val{true}) where {T}
+function force_coerce_cyclo(a::AbsSimpleNumField, b::AbsSimpleNumFieldElem, ::Val{throw_error} = Val(true)) where {throw_error}
   if iszero(b)
     return a(0)
   end
@@ -1215,7 +1215,7 @@ function force_coerce_cyclo(a::AbsSimpleNumField, b::AbsSimpleNumFieldElem, thro
     # the code below would not work
     if is_rational(b)
       return a(coeff(b, 0))
-    elseif throw_error === Val{true}
+    elseif throw_error
       error("no coercion possible")
     else
       return
@@ -1254,7 +1254,7 @@ function force_coerce_cyclo(a::AbsSimpleNumField, b::AbsSimpleNumFieldElem, thro
     for i=0:length(f)
       c = coeff(f, i)
       if !is_rational(c)
-        if throw_error === Val{true}
+        if throw_error
           error("no coercion possible")
         else
           return

--- a/src/NumField/NfAbs/NfAbs.jl
+++ b/src/NumField/NfAbs/NfAbs.jl
@@ -774,10 +774,10 @@ function splitting_field(fl::Vector{QQPolyRingElem}; coprime::Bool = false, do_r
   end
 
   if do_roots
-    K, R = _splitting_field(gl, coprime = true, do_roots = Val{true})
+    K, R = _splitting_field(gl, coprime = true, do_roots = Val(true))
     return K, vcat(r, [K(a)], R)
   else
-    return _splitting_field(gl, coprime = true, do_roots = Val{false})
+    return _splitting_field(gl, coprime = true, do_roots = Val(false))
   end
 end
 
@@ -823,14 +823,14 @@ function splitting_field(fl::Vector{<:PolyRingElem{AbsSimpleNumFieldElem}}; do_r
     R = [K(x) for x = r]
     push!(R, a)
     Kst, t = polynomial_ring(K, cached = false)
-    return _splitting_field(vcat(ggl, [t-y for y in R]), coprime = true, do_roots = Val{true})
+    return _splitting_field(vcat(ggl, [t-y for y in R]), coprime = true, do_roots = Val(do_roots))
   else
-    return _splitting_field(ggl, coprime = true, do_roots = Val{false})
+    return _splitting_field(ggl, coprime = true, do_roots = Val(do_roots))
   end
 end
 
 
-function _splitting_field(fl::Vector{<:PolyRingElem{<:NumFieldElem}}; do_roots::Type{Val{T}} = Val{false}, coprime::Bool = false) where T
+function _splitting_field(fl::Vector{<:PolyRingElem{<:NumFieldElem}}; do_roots::Val{do_roots_bool} = Val(false), coprime::Bool = false) where do_roots_bool
   if !coprime
     fl = coprime_base(fl)
   end
@@ -841,12 +841,12 @@ function _splitting_field(fl::Vector{<:PolyRingElem{<:NumFieldElem}}; do_roots::
   fl = ffl
   K = base_ring(fl[1])
   r = elem_type(K)[]
-  if do_roots == Val{true}
+  if do_roots_bool
     r = elem_type(K)[roots(x)[1] for x = fl if degree(x) == 1]
   end
   lg = eltype(fl)[k for k = fl if degree(k) > 1]
   if iszero(length(lg))
-    if do_roots == Val{true}
+    if do_roots_bool
       return K, r
     else
       return K
@@ -854,7 +854,7 @@ function _splitting_field(fl::Vector{<:PolyRingElem{<:NumFieldElem}}; do_roots::
   end
 
   K, a = number_field(lg[1], check = false, cached = false)
-  do_embedding = length(lg) > 1 || degree(K)>2 || (do_roots == Val{true})
+  do_embedding = length(lg) > 1 || degree(K)>2 || do_roots_bool
   Ks, nk, mk = collapse_top_layer(K, do_embedding = do_embedding)
   if !do_embedding
     return Ks
@@ -867,13 +867,13 @@ function _splitting_field(fl::Vector{<:PolyRingElem{<:NumFieldElem}}; do_roots::
   for i = 2:length(lg)
     push!(ggl, map_coefficients(mk, lg[i], parent = parent(ggl[1])))
   end
-  if do_roots == Val{true}
+  if do_roots_bool
     R = [mk(x) for x = r]
     push!(R, preimage(nk, a))
     Kst, t = polynomial_ring(Ks, cached = false)
-    return _splitting_field(vcat(ggl, [t-y for y in R]), coprime = true, do_roots = Val{true})
+    return _splitting_field(vcat(ggl, [t-y for y in R]), coprime = true, do_roots = do_roots)
   else
-    return _splitting_field(ggl, coprime = true, do_roots = Val{false})
+    return _splitting_field(ggl, coprime = true, do_roots = do_roots)
   end
 end
 

--- a/src/NumFieldOrd/NfOrd/Clgp/Map.jl
+++ b/src/NumFieldOrd/NfOrd/Clgp/Map.jl
@@ -384,15 +384,15 @@ Tests if $A$ is principal and returns $(\mathtt{true}, \alpha)$ if $A =
 The generator will be in factored form.
 """
 function is_principal_fac_elem(A::AbsNumFieldOrderIdeal{AbsSimpleNumField, AbsSimpleNumFieldElem})
-  return _isprincipal_fac_elem(A::AbsNumFieldOrderIdeal{AbsSimpleNumField, AbsSimpleNumFieldElem}, Val{false})
+  return _isprincipal_fac_elem(A::AbsNumFieldOrderIdeal{AbsSimpleNumField, AbsSimpleNumFieldElem}, Val(false))
 end
 
-function _isprincipal_fac_elem(A::AbsNumFieldOrderIdeal{AbsSimpleNumField, AbsSimpleNumFieldElem}, support::Type{Val{U}} = Val{false}) where {U}
-  # If support === Val{true}, also compute the support of the factored element.
+function _isprincipal_fac_elem(A::AbsNumFieldOrderIdeal{AbsSimpleNumField, AbsSimpleNumFieldElem}, ::Val{support} = Val(false)) where {support}
+  # If `support`, also compute the support of the factored element.
   # (This is not the same as the support of the ideal A!)
   if A.is_principal == 1
     if isdefined(A, :princ_gen_fac_elem)
-      if support === Val{false}
+      if !support
         return true, A.princ_gen_fac_elem
       else
         #a = A.princ_gen_fac_elem
@@ -403,7 +403,7 @@ function _isprincipal_fac_elem(A::AbsNumFieldOrderIdeal{AbsSimpleNumField, AbsSi
         A.princ_gen_fac_elem = FacElem(A.princ_gen.elem_in_nf)
       end
       a = A.princ_gen_fac_elem
-      if support === Val{false}
+      if !support
         return true, a
       else
         #return true, a, factor_coprime(IdealSet(order(A)), a, refine = true)::Dict{AbsNumFieldOrderIdeal{AbsSimpleNumField, AbsSimpleNumFieldElem}, ZZRingElem}
@@ -413,7 +413,7 @@ function _isprincipal_fac_elem(A::AbsNumFieldOrderIdeal{AbsSimpleNumField, AbsSi
   O = order(A)
   @assert is_maximal_known_and_maximal(O)
   if A.is_principal == 2
-    if support === Val{false}
+    if !support
       return false, FacElem(one(nf(O)))
     else
       return false, FacElem(one(nf(O))), Dict{AbsNumFieldOrderIdeal{AbsSimpleNumField, AbsSimpleNumFieldElem}, ZZRingElem}()
@@ -465,7 +465,7 @@ function _isprincipal_fac_elem(A::AbsNumFieldOrderIdeal{AbsSimpleNumField, AbsSi
   A.princ_gen_fac_elem = e
   # TODO: if we set it to be principal, we need to set the generator. Otherwise the ^ function is broken
 
-  if support === Val{false}
+  if !support
     return true, e
   else
     prime_exponents = sparse_row(FlintZZ, collect(1:length(base)), rs) * vcat(c.M.bas_gens, c.M.rel_gens)

--- a/src/NumFieldOrd/NfOrd/LinearAlgebra.jl
+++ b/src/NumFieldOrd/NfOrd/LinearAlgebra.jl
@@ -1449,18 +1449,18 @@ function number_of_columns(m::PMat2)
 end
 
 function pseudo_snf_kb(P::PMat2)
-   return _pseudo_snf_kb(P, Val{false})
+   return _pseudo_snf_kb(P, Val(false))
 end
 
 function pseudo_snf_kb_with_transform(P::PMat2)
-   return _pseudo_snf_kb(P, Val{true})
+   return _pseudo_snf_kb(P, Val(true))
 end
 
-function _pseudo_snf_kb(P::PMat2, trafo::Type{Val{T}} = Val{false}) where T
+function _pseudo_snf_kb(P::PMat2, ::Val{with_transform} = Val(false)) where with_transform
    S = deepcopy(P)
    m = nrows(S)
    n = ncols(S)
-   if trafo == Val{true}
+   if with_transform
       U = identity_matrix(base_ring(S.matrix), m)
       K = identity_matrix(base_ring(S.matrix), m)
       pseudo_snf_kb!(S, U, K, true)

--- a/src/NumFieldOrd/NfOrd/LinearAlgebra.jl
+++ b/src/NumFieldOrd/NfOrd/LinearAlgebra.jl
@@ -1898,15 +1898,15 @@ function integral_and_coprime_to(a::Union{ AbsSimpleNumFieldOrderFractionalIdeal
 end
 
 function steinitz_form(P::PMat)
-  return _steinitz_form(P, Val{false})
+  return _steinitz_form(P, Val(false))
 end
 
 function steinitz_form_with_transform(P::PMat)
-  return _steinitz_form(P, Val{true})
+  return _steinitz_form(P, Val(true))
 end
 
-function _steinitz_form(P::PMat, trafo::Type{Val{T}} = Val{false}) where T
-  if trafo == Val{true}
+function _steinitz_form(P::PMat, ::Val{with_transform} = Val(false)) where with_transform
+  if with_transform
     S, U = pseudo_hnf_with_transform(P, :lowerleft)
   else
     S = pseudo_hnf(P, :lowerleft)
@@ -1923,7 +1923,7 @@ function _steinitz_form(P::PMat, trafo::Type{Val{T}} = Val{false}) where T
     end
     S.coeffs[i] = oneK*O
   end
-  if trafo == Val{true}
+  if with_transform
     steinitz_form!(S, U, true, start_row)
     return S, U
   else

--- a/src/NumFieldOrd/NfOrd/LinearAlgebra.jl
+++ b/src/NumFieldOrd/NfOrd/LinearAlgebra.jl
@@ -967,17 +967,17 @@ function sub(P::PMat, rows::AbstractUnitRange{Int}, cols::AbstractUnitRange{Int}
 end
 
 function pseudo_hnf_cohen(P::PMat)
-   return _pseudo_hnf_cohen(P, Val{false})
+   return _pseudo_hnf_cohen(P, Val(false))
 end
 
 function pseudo_hnf_cohen_with_transform(P::PMat)
-   return _pseudo_hnf_cohen(P, Val{true})
+   return _pseudo_hnf_cohen(P, Val(true))
 end
 
-function _pseudo_hnf_cohen(P::PMat, trafo::Type{Val{T}} = Val{false}) where T
+function _pseudo_hnf_cohen(P::PMat, ::Val{with_transform} = Val(false)) where with_transform
    H = deepcopy(P)
    m = nrows(H)
-   if trafo == Val{true}
+   if with_transform
       U = identity_matrix(base_ring(H.matrix), m)
       pseudo_hnf_cohen!(H, U, true)
       return H, U

--- a/src/NumFieldOrd/NfOrd/LinearAlgebra.jl
+++ b/src/NumFieldOrd/NfOrd/LinearAlgebra.jl
@@ -1125,13 +1125,13 @@ end
 
 function pseudo_hnf_kb(P::PMat, shape::Symbol = :upperright)
   if shape == :lowerleft
-    H = _pseudo_hnf_kb(pseudo_matrix(reverse_cols(P.matrix), P.coeffs), Val{false})
+    H = _pseudo_hnf_kb(pseudo_matrix(reverse_cols(P.matrix), P.coeffs), Val(false))
     reverse_cols!(H.matrix)
     reverse_rows!(H.matrix)
     reverse!(H.coeffs)
     return H
   elseif shape == :upperright
-    return _pseudo_hnf_kb(P, Val{false})
+    return _pseudo_hnf_kb(P, Val(false))
   else
     error("Not yet implemented")
   end
@@ -1139,23 +1139,23 @@ end
 
 function pseudo_hnf_kb_with_transform(P::PMat, shape::Symbol = :upperright)
   if shape == :lowerleft
-    H, U = _pseudo_hnf_kb(pseudo_matrix(reverse_cols(P.matrix), P.coeffs), Val{true})
+    H, U = _pseudo_hnf_kb(pseudo_matrix(reverse_cols(P.matrix), P.coeffs), Val(true))
     reverse_cols!(H.matrix)
     reverse_rows!(H.matrix)
     reverse!(H.coeffs)
     reverse_rows!(U)
     return H, U
   elseif shape == :upperright
-    return _pseudo_hnf_kb(P, Val{true})
+    return _pseudo_hnf_kb(P, Val(true))
   else
     error("Not yet implemented")
   end
 end
 
-function _pseudo_hnf_kb(P::PMat, trafo::Type{Val{T}} = Val{false}) where T
+function _pseudo_hnf_kb(P::PMat, ::Val{with_transform} = Val(false)) where with_transform
    H = deepcopy(P)
    m = nrows(H)
-   if trafo === Val{true}
+   if with_transform
       U = identity_matrix(base_ring(H.matrix), m)
       pseudo_hnf_kb!(H, U, true)
       return H, U

--- a/src/NumFieldOrd/NfOrd/MaxOrd/DedekindCriterion.jl
+++ b/src/NumFieldOrd/NfOrd/MaxOrd/DedekindCriterion.jl
@@ -32,11 +32,11 @@
 #
 ################################################################################
 
-function dedekind_test(O::AbsSimpleNumFieldOrder, p::ZZRingElem, compute_order::Type{Val{S}} = Val{true}) where S
+function dedekind_test(O::AbsSimpleNumFieldOrder, p::ZZRingElem, ::Val{compute_order} = Val(true)) where compute_order
   !is_equation_order(O) && error("Order must be an equation order")
 
   if rem(discriminant(O), p^2) != 0
-    if compute_order == Val{true}
+    if compute_order
       return true, O
     else
       return true
@@ -72,7 +72,7 @@ function dedekind_test(O::AbsSimpleNumFieldOrder, p::ZZRingElem, compute_order::
   g1modp = Kx(g1)
   U = gcd(gcd(g, h), g1modp)
 
-  if compute_order == Val{false}
+  if !compute_order
     if isone(U)
       return true
     else
@@ -115,7 +115,7 @@ end
 
 dedekind_test(O::AbsSimpleNumFieldOrder, p::Integer) = dedekind_test(O, FlintZZ(p))
 
-dedekind_ispmaximal(O::AbsSimpleNumFieldOrder, p::ZZRingElem) = dedekind_test(O, p, Val{false})
+dedekind_ispmaximal(O::AbsSimpleNumFieldOrder, p::ZZRingElem) = dedekind_test(O, p, Val(false))
 
 dedekind_ispmaximal(O::AbsSimpleNumFieldOrder, p::Integer) = dedekind_ispmaximal(O, FlintZZ(p))
 

--- a/src/NumFieldOrd/NfOrd/NfOrd.jl
+++ b/src/NumFieldOrd/NfOrd/NfOrd.jl
@@ -491,15 +491,14 @@ end
 # Check if a number field element is contained in O
 # In this case, the second return value is the coefficient vector with respect
 # to the basis of O
-function _check_elem_in_order(a::T, O::AbsNumFieldOrder{S, T},
-                              short::Type{Val{U}} = Val{false}) where {S, T, U}
+function _check_elem_in_order(a::T, O::AbsNumFieldOrder{S, T}, ::Val{short} = Val(false)) where {S, T, short}
   assure_has_basis_mat_inv(O)
   t = O.tcontain
   elem_to_mat_row!(t.num, 1, t.den, a)
   t = mul!(t, t, O.basis_mat_inv)
-  if short == Val{true}
+  if short
     return isone(t.den)
-  elseif short == Val{false}
+  else
     if !isone(t.den)
       return false, Vector{ZZRingElem}()
     else
@@ -515,7 +514,7 @@ end
 
 function in(a::AbsNonSimpleNumFieldElem, O::AbsNumFieldOrder)
   @assert parent(a) == nf(O)
-  return _check_elem_in_order(a, O, Val{true})
+  return _check_elem_in_order(a, O, Val(true))
 end
 
 @doc raw"""
@@ -547,7 +546,7 @@ function in(a::AbsSimpleNumFieldElem, O::AbsSimpleNumFieldOrder)
       return _check_containment(R1, M.num, t.num)
     end
   end
-  return _check_elem_in_order(a, O, Val{true})
+  return _check_elem_in_order(a, O, Val(true))
 end
 
 function _check_containment(R, M, t)

--- a/src/NumFieldOrd/NfOrd/ResidueField.jl
+++ b/src/NumFieldOrd/NfOrd/ResidueField.jl
@@ -158,18 +158,18 @@ function _residue_field_generic_fq_default(O, P)
  	return codomain(f), f
 end
 
-function _residue_field_generic(O, P, small::Type{Val{T}} = Val{false}, degree_one::Type{Val{S}} = Val{false}) where {S, T}
-  if small == Val{true}
+function _residue_field_generic(O, P, ::Val{small} = Val(false), ::Val{degree_one} = Val(false)) where {small, degree_one}
+  if small
     @assert fits(Int, minimum(P, copy = false))
-    if degree_one === Val{true}
+    if degree_one
 			f1 = NfOrdToGFMor(O, P)
       return codomain(f1), f1
 		else
     	f = NfOrdToFqNmodMor(O, P)
     	return codomain(f), f
     end
-  elseif small === Val{false}
-    if degree_one === Val{true}
+  else
+    if degree_one
     	f3 = NfOrdToGFFmpzMor(O, P)
       return codomain(f3), f3
 		else
@@ -209,24 +209,24 @@ function ResidueFieldSmall(O::AbsSimpleNumFieldOrder, P::AbsNumFieldOrderIdeal{A
   p = minimum(P)
   !fits(Int, p) && error("Minimum of prime ideal must be small (< 64 bits)")
   if !is_maximal_known(O) || !is_maximal(O) || !is_defining_polynomial_nice(nf(O))
-    return _residue_field_generic(O, P, Val{true})
+    return _residue_field_generic(O, P, Val(true))
   end
   if !is_index_divisor(O, minimum(P))
     return _residue_field_nonindex_divisor(O, P, Val(true))
   else
-    return _residue_field_generic(O, P, Val{true})
+    return _residue_field_generic(O, P, Val(true))
   end
 end
 
 function ResidueFieldDegree1(O::AbsSimpleNumFieldOrder, P::AbsNumFieldOrderIdeal{AbsSimpleNumField, AbsSimpleNumFieldElem})
   @assert degree(P) == 1
   if !is_maximal_known(O) || !is_maximal(O)
-    return _residue_field_generic(O, P, Val{false}, Val{true})
+    return _residue_field_generic(O, P, Val(false), Val(true))
   end
   if !is_index_divisor(O, minimum(P)) && has_2_elem(P)
     return _residue_field_nonindex_divisor(O, P, Val(false), Val(true))
   else
-    return _residue_field_generic(O, P, Val{false}, Val{true})
+    return _residue_field_generic(O, P, Val(false), Val(true))
   end
 end
 
@@ -236,12 +236,12 @@ function ResidueFieldSmallDegree1(O::AbsSimpleNumFieldOrder, P::AbsNumFieldOrder
   !fits(Int, p) && error("Minimum of prime ideal must be small (< 64 bits)")
   @assert degree(P) == 1
   if !is_maximal_known(O) || !is_maximal(O) || !is_defining_polynomial_nice(nf(O))
-    return _residue_field_generic(O, P, Val{true}, Val{true})
+    return _residue_field_generic(O, P, Val(true), Val(true))
   end
   if !is_index_divisor(O, minimum(P))
     return _residue_field_nonindex_divisor(O, P, Val(true), Val(true))
   else
-    return _residue_field_generic(O, P, Val{true}, Val{true})
+    return _residue_field_generic(O, P, Val(true), Val(true))
   end
 end
 

--- a/src/NumFieldOrd/NfOrd/ResidueField.jl
+++ b/src/NumFieldOrd/NfOrd/ResidueField.jl
@@ -83,7 +83,7 @@ function _residue_field_nonindex_divisor_helper_fq_default(f::QQPolyRingElem, g:
 end
 
 # It is assumed that p is not an index divisor
-function _residue_field_nonindex_divisor_helper(f::QQPolyRingElem, g::QQPolyRingElem, p, degree_one::Type{Val{S}} = Val{false}) where S
+function _residue_field_nonindex_divisor_helper(f::QQPolyRingElem, g::QQPolyRingElem, p, ::Val{degree_one} = Val(false)) where degree_one
   R = Native.GF(p, cached = false, check = false)
 
   Zy, y = polynomial_ring(FlintZZ, "y", cached = false)
@@ -94,7 +94,7 @@ function _residue_field_nonindex_divisor_helper(f::QQPolyRingElem, g::QQPolyRing
 
   h = gcd(gmodp,fmodp)
 
-  if degree_one === Val{true}
+  if degree_one
     return R, h
   else
     if isa(p, Int)
@@ -120,7 +120,7 @@ function _residue_field_nonindex_divisor_fq_default(O, P)
   mF.P = P
 end
 
-function _residue_field_nonindex_divisor(O, P, small::Type{Val{T}} = Val{false}, degree_one::Type{Val{S}} = Val{false}) where {S, T}
+function _residue_field_nonindex_divisor(O, P, ::Val{small} = Val(false), degree_one_val::Val{degree_one} = Val(false)) where {small, degree_one}
   # This code assumes that P comes from prime_decomposition
   @assert has_2_elem(P) && is_prime_known(P) && is_prime(P)
 
@@ -129,18 +129,18 @@ function _residue_field_nonindex_divisor(O, P, small::Type{Val{T}} = Val{false},
   f = nf(O).pol
   g = parent(f)(elem_in_nf(gtwo))
 
-  if small === Val{true}
+  if small
     @assert fits(Int, minimum(P, copy = false))
-    F, h = _residue_field_nonindex_divisor_helper(f, g, Int(minimum(P)), degree_one)
+    F, h = _residue_field_nonindex_divisor_helper(f, g, Int(minimum(P)), degree_one_val)
     mF = Mor(O, F, h)
     mF.P = P
     return F, mF
-  elseif small === Val{false}
+  else
     F, h = _residue_field_nonindex_divisor_helper_fq_default(f, g, minimum(P))
     mF = Mor(O, F, h)
     mF.P = P
     return F, mF
-    #F, h = _residue_field_nonindex_divisor_helper(f, g, minimum(P), degree_one)
+    #F, h = _residue_field_nonindex_divisor_helper(f, g, minimum(P), degree_one_val)
     #mF = Mor(O, F, h)
     #mF.P = P
     #return F, mF
@@ -212,7 +212,7 @@ function ResidueFieldSmall(O::AbsSimpleNumFieldOrder, P::AbsNumFieldOrderIdeal{A
     return _residue_field_generic(O, P, Val{true})
   end
   if !is_index_divisor(O, minimum(P))
-    return _residue_field_nonindex_divisor(O, P, Val{true})
+    return _residue_field_nonindex_divisor(O, P, Val(true))
   else
     return _residue_field_generic(O, P, Val{true})
   end
@@ -224,7 +224,7 @@ function ResidueFieldDegree1(O::AbsSimpleNumFieldOrder, P::AbsNumFieldOrderIdeal
     return _residue_field_generic(O, P, Val{false}, Val{true})
   end
   if !is_index_divisor(O, minimum(P)) && has_2_elem(P)
-    return _residue_field_nonindex_divisor(O, P, Val{false}, Val{true})
+    return _residue_field_nonindex_divisor(O, P, Val(false), Val(true))
   else
     return _residue_field_generic(O, P, Val{false}, Val{true})
   end
@@ -239,7 +239,7 @@ function ResidueFieldSmallDegree1(O::AbsSimpleNumFieldOrder, P::AbsNumFieldOrder
     return _residue_field_generic(O, P, Val{true}, Val{true})
   end
   if !is_index_divisor(O, minimum(P))
-    return _residue_field_nonindex_divisor(O, P, Val{true}, Val{true})
+    return _residue_field_nonindex_divisor(O, P, Val(true), Val(true))
   else
     return _residue_field_generic(O, P, Val{true}, Val{true})
   end

--- a/src/NumFieldOrd/NfOrd/Unit/Map.jl
+++ b/src/NumFieldOrd/NfOrd/Unit/Map.jl
@@ -20,7 +20,7 @@ function unit_group_disc_log(x::FacElem{AbsSimpleNumFieldElem, AbsSimpleNumField
   if length(U.units) == 0
     r = [-1]
   else
-    r = _add_dependent_unit!(U, x, Val{true})
+    r = _add_dependent_unit!(U, x, Val(true))
   end
   @assert r[end] == -1
 

--- a/src/NumFieldOrd/NfOrd/Unit/UnitGrpCtx.jl
+++ b/src/NumFieldOrd/NfOrd/Unit/UnitGrpCtx.jl
@@ -79,7 +79,7 @@ function _search_rational_relation(U::UnitGrpCtx{S}, y::S, bound::ZZRingElem) wh
   return rel, p
 end
 
-function _add_dependent_unit!(U::UnitGrpCtx{S}, y::S, rel_only::Type{Val{T}} = Val{false}; post_reduction::Bool = true) where {S <: Union{AbsSimpleNumFieldElem, FacElem{AbsSimpleNumFieldElem, AbsSimpleNumField}}, T}
+function _add_dependent_unit!(U::UnitGrpCtx{S}, y::S, ::Val{rel_only} = Val(false); post_reduction::Bool = true) where {S <: Union{AbsSimpleNumFieldElem, FacElem{AbsSimpleNumFieldElem, AbsSimpleNumField}}, rel_only}
   @assert has_full_rank(U)
 
   K = nf(order(U))
@@ -117,7 +117,7 @@ function _add_dependent_unit!(U::UnitGrpCtx{S}, y::S, rel_only::Type{Val{T}} = V
     @vprintln :UnitGroup 3 "For $p rel: $rel"
   end
 
-  if rel_only === Val{true}
+  if rel_only
     return rel
   end
 

--- a/src/NumFieldOrd/NfRelOrd/FracIdeal.jl
+++ b/src/NumFieldOrd/NfRelOrd/FracIdeal.jl
@@ -269,9 +269,9 @@ end
 
 Returns the norm of $a$.
 """
-function norm(a::RelNumFieldOrderFractionalIdeal{S, U, V}, copy::Type{Val{T}} = Val{true}) where {S, T, U, V}
+function norm(a::RelNumFieldOrderFractionalIdeal{S, U, V}, ::Val{copy} = Val(true)) where {S, U, V, copy}
   assure_has_norm(a)
-  if copy == Val{true}
+  if copy
     return deepcopy(a.norm)::U
   else
     return a.norm::U

--- a/src/NumFieldOrd/NfRelOrd/NfRelOrd.jl
+++ b/src/NumFieldOrd/NfRelOrd/NfRelOrd.jl
@@ -431,12 +431,12 @@ end
 #
 ################################################################################
 
-function _check_elem_in_order(a::U, O::RelNumFieldOrder{T, S, U}, short::Type{Val{V}} = Val{false}) where {T, S, U, V}
+function _check_elem_in_order(a::U, O::RelNumFieldOrder{T, S, U}, ::Val{short} = Val(false)) where {T, S, U, short}
   b_pmat = basis_pmatrix(O, copy = false)
   t = zero_matrix(base_field(nf(O)), 1, degree(O))
   elem_to_mat_row!(t, 1, a)
   t = t*basis_mat_inv(O, copy = false)
-  if short == Val{true}
+  if short
     for i = 1:degree(O)
       if !(t[1, i] in b_pmat.coeffs[i])
         return false
@@ -458,7 +458,7 @@ function _check_elem_in_order(a::U, O::RelNumFieldOrder{T, S, U}, short::Type{Va
 end
 
 function in(a::U, O::RelNumFieldOrder{T, S, U}) where {T, S, U}
-  return _check_elem_in_order(a, O, Val{true})
+  return _check_elem_in_order(a, O, Val(true))
 end
 
 ################################################################################

--- a/src/NumFieldOrd/NfRelOrd/NfRelOrd.jl
+++ b/src/NumFieldOrd/NfRelOrd/NfRelOrd.jl
@@ -689,7 +689,7 @@ end
 
 # Algorithm IV.6. in "Berechnung relativer Ganzheitsbasen mit dem
 # Round-2-Algorithmus" by C. Friedrichs.
-function dedekind_test(O::RelNumFieldOrder{U1, V, Z}, p::Union{AbsNumFieldOrderIdeal, RelNumFieldOrderIdeal}, compute_order::Type{Val{S}} = Val{true}) where {S, U1, V, Z <: RelSimpleNumFieldElem}
+function dedekind_test(O::RelNumFieldOrder{U1, V, Z}, p::Union{AbsNumFieldOrderIdeal, RelNumFieldOrderIdeal}, ::Val{compute_order} = Val(true)) where {compute_order, U1, V, Z <: RelSimpleNumFieldElem}
   !is_equation_order(O) && error("Order must be an equation order")
 
   L = nf(O)
@@ -717,7 +717,7 @@ function dedekind_test(O::RelNumFieldOrder{U1, V, Z}, p::Union{AbsNumFieldOrderI
 
   d = gcd(fmodp, gcd(gmodp, hmodp))
 
-  if compute_order == Val{false}
+  if !compute_order
     return isone(d)
   else
     if isone(d)
@@ -735,7 +735,7 @@ function dedekind_test(O::RelNumFieldOrder{U1, V, Z}, p::Union{AbsNumFieldOrderI
   end
 end
 
-dedekind_ispmaximal(O::RelNumFieldOrder, p::Union{AbsNumFieldOrderIdeal, RelNumFieldOrderIdeal}) = dedekind_test(O, p, Val{false})
+dedekind_ispmaximal(O::RelNumFieldOrder, p::Union{AbsNumFieldOrderIdeal, RelNumFieldOrderIdeal}) = dedekind_test(O, p, Val(false))
 
 dedekind_poverorder(O::RelNumFieldOrder, p::Union{AbsNumFieldOrderIdeal, RelNumFieldOrderIdeal}) = dedekind_test(O, p)[2]
 

--- a/src/QuadForm/Lattices.jl
+++ b/src/QuadForm/Lattices.jl
@@ -296,7 +296,7 @@ function generators(L::AbstractLat; minimal::Bool = false)
     if isdefined(L, :minimal_generators)
       return L.minimal_generators::Vector{Vector{T}}
     end
-    St = _steinitz_form(pseudo_matrix(L), Val{false})
+    St = steinitz_form(pseudo_matrix(L))
     d = nrows(St)
     n = degree(L)
     v = Vector{T}[]

--- a/src/Sparse/HNF.jl
+++ b/src/Sparse/HNF.jl
@@ -228,12 +228,9 @@ function find_row_starting_with(A::SMat, p::Int)
   return stop
 end
 
-# If trafo is set to Val{true}, then additionally an Array of transformations
+# If with_transform is set to true, then additionally an Array of transformations
 # is returned.
-function reduce_up(A::SMat{T}, piv::Vector{Int},
-                                  trafo::Type{Val{N}} = Val{false}) where {N, T}
-
-  with_transform = (trafo == Val{true})
+function reduce_up(A::SMat{T}, piv::Vector{Int}, with_transform_val::Val{with_transform} = Val(false)) where {T, with_transform}
   if with_transform
     trafos = SparseTrafoElem{T, dense_matrix_type(T)}[]
   end
@@ -244,7 +241,7 @@ function reduce_up(A::SMat{T}, piv::Vector{Int},
   for red=p-1:-1:1
     # the last argument should be the smallest pivot larger then pos[1]
     if with_transform
-      A[red], new_trafos = reduce_right(A, A[red], max(A[red].pos[1]+1, piv[1]), trafo)
+      A[red], new_trafos = reduce_right(A, A[red], max(A[red].pos[1]+1, piv[1]), typeof(with_transform_val))
       for t in new_trafos
         t.j = red
       end
@@ -499,7 +496,7 @@ function hnf_extend!(A::SMat{T}, b::SMat{T}, trafo::Type{Val{N}} = Val{false}; t
     end
     if length(w) > 0
       if with_transform
-        new_trafos = reduce_up(A, w, trafo)
+        new_trafos = reduce_up(A, w, trafo())
         append!(trafos, new_trafos)
       else
         reduce_up(A, w)
@@ -584,7 +581,7 @@ function hnf_kannan_bachem(A::SMat{T}, trafo::Type{Val{N}} = Val{false}; truncat
     end
     if length(w) > 0
       if with_transform
-        new_trafos = reduce_up(B, w, trafo)
+        new_trafos = reduce_up(B, w, trafo())
         append!(trafos, new_trafos)
       else
         reduce_up(B, w)

--- a/src/Sparse/HNF.jl
+++ b/src/Sparse/HNF.jl
@@ -257,21 +257,18 @@ end
 # is returned.
 @doc raw"""
     reduce_full(A::SMat{ZZRingElem}, g::SRow{ZZRingElem},
-                          trafo = Val{false}) -> SRow{ZZRingElem}, Vector{Int}
+                          with_transform = Val(false)) -> SRow{ZZRingElem}, Vector{Int}
 
 Reduces $g$ modulo $A$ and assumes that $A$ is upper triangular.
 
 The second return value is the array of pivot elements of $A$ that changed.
 
-If `trafo` is set to `Val{true}`, then additionally an array of transformations
+If `with_transform` is set to `Val(true)`, then additionally an array of transformations
 is returned.
 """
-function reduce_full(A::SMat{T}, g::SRow{T}, trafo::Type{Val{N}} = Val{false}) where {N, T}
+function reduce_full(A::SMat{T}, g::SRow{T}, with_transform_val::Val{with_transform} = Val(false)) where {T, with_transform}
 #  @hassert :HNF 1  is_upper_triangular(A)
   #assumes A is upper triangular, reduces g modulo A
-
-  with_transform = (trafo == Val{true})
-  no_trafo = (trafo == Val{false})
 
   if with_transform
     trafos = SparseTrafoElem{T, dense_matrix_type(T)}[]
@@ -305,7 +302,7 @@ function reduce_full(A::SMat{T}, g::SRow{T}, trafo::Type{Val{N}} = Val{false}) w
 
       _g = g
       if with_transform
-        g, new_trafos  = reduce_right(A, g, 1, trafo())
+        g, new_trafos  = reduce_right(A, g, 1, with_transform_val)
         append!(trafos, new_trafos)
       else
         g = reduce_right(A, g)
@@ -344,7 +341,7 @@ function reduce_full(A::SMat{T}, g::SRow{T}, trafo::Type{Val{N}} = Val{false}) w
       @hassert :HNF 1  length(g)==0 || g.pos[1] > A[j].pos[1]
       push!(piv, A[j].pos[1])
       if with_transform
-        A[j], new_trafos = reduce_right(A, A[j], A[j].pos[1]+1, trafo())
+        A[j], new_trafos = reduce_right(A, A[j], A[j].pos[1]+1, with_transform_val)
         # We are updating the jth row
         # Have to adjust the transformations
         for t in new_trafos
@@ -353,7 +350,7 @@ function reduce_full(A::SMat{T}, g::SRow{T}, trafo::Type{Val{N}} = Val{false}) w
         # Now append
         append!(trafos, new_trafos)
       else
-        A[j] = reduce_right(A, A[j], A[j].pos[1]+1, trafo())
+        A[j] = reduce_right(A, A[j], A[j].pos[1]+1, with_transform_val)
       end
 
       if A.r == A.c
@@ -376,7 +373,7 @@ function reduce_full(A::SMat{T}, g::SRow{T}, trafo::Type{Val{N}} = Val{false}) w
     new_g = false
   end
   if with_transform
-    g, new_trafos = reduce_right(A, g, 1, trafo())
+    g, new_trafos = reduce_right(A, g, 1, with_transform_val)
     append!(trafos, new_trafos)
   else
     g = reduce_right(A, g)
@@ -460,7 +457,7 @@ function hnf_extend!(A::SMat{T}, b::SMat{T}, trafo::Type{Val{N}} = Val{false}; t
   nc = 0
   for i=b
     if with_transform
-      q, w, new_trafos = reduce_full(A, i, trafo)
+      q, w, new_trafos = reduce_full(A, i, trafo())
       append!(trafos, new_trafos)
     else
       q, w = reduce_full(A, i)
@@ -545,7 +542,7 @@ function hnf_kannan_bachem(A::SMat{T}, trafo::Type{Val{N}} = Val{false}; truncat
   nc = 0
   for i=A
     if with_transform
-      q, w, new_trafos = reduce_full(B, i, trafo)
+      q, w, new_trafos = reduce_full(B, i, trafo())
       append!(trafos, new_trafos)
     else
       q, w = reduce_full(B, i)

--- a/src/Sparse/HNF.jl
+++ b/src/Sparse/HNF.jl
@@ -241,7 +241,7 @@ function reduce_up(A::SMat{T}, piv::Vector{Int}, with_transform_val::Val{with_tr
   for red=p-1:-1:1
     # the last argument should be the smallest pivot larger then pos[1]
     if with_transform
-      A[red], new_trafos = reduce_right(A, A[red], max(A[red].pos[1]+1, piv[1]), typeof(with_transform_val))
+      A[red], new_trafos = reduce_right(A, A[red], max(A[red].pos[1]+1, piv[1]), with_transform_val)
       for t in new_trafos
         t.j = red
       end
@@ -305,7 +305,7 @@ function reduce_full(A::SMat{T}, g::SRow{T}, trafo::Type{Val{N}} = Val{false}) w
 
       _g = g
       if with_transform
-        g, new_trafos  = reduce_right(A, g, 1, trafo)
+        g, new_trafos  = reduce_right(A, g, 1, trafo())
         append!(trafos, new_trafos)
       else
         g = reduce_right(A, g)
@@ -344,7 +344,7 @@ function reduce_full(A::SMat{T}, g::SRow{T}, trafo::Type{Val{N}} = Val{false}) w
       @hassert :HNF 1  length(g)==0 || g.pos[1] > A[j].pos[1]
       push!(piv, A[j].pos[1])
       if with_transform
-        A[j], new_trafos = reduce_right(A, A[j], A[j].pos[1]+1, trafo)
+        A[j], new_trafos = reduce_right(A, A[j], A[j].pos[1]+1, trafo())
         # We are updating the jth row
         # Have to adjust the transformations
         for t in new_trafos
@@ -353,7 +353,7 @@ function reduce_full(A::SMat{T}, g::SRow{T}, trafo::Type{Val{N}} = Val{false}) w
         # Now append
         append!(trafos, new_trafos)
       else
-        A[j] = reduce_right(A, A[j], A[j].pos[1]+1, trafo)
+        A[j] = reduce_right(A, A[j], A[j].pos[1]+1, trafo())
       end
 
       if A.r == A.c
@@ -376,7 +376,7 @@ function reduce_full(A::SMat{T}, g::SRow{T}, trafo::Type{Val{N}} = Val{false}) w
     new_g = false
   end
   if with_transform
-    g, new_trafos = reduce_right(A, g, 1, trafo)
+    g, new_trafos = reduce_right(A, g, 1, trafo())
     append!(trafos, new_trafos)
   else
     g = reduce_right(A, g)
@@ -389,9 +389,7 @@ function reduce_full(A::SMat{T}, g::SRow{T}, trafo::Type{Val{N}} = Val{false}) w
   with_transform ? (return g, piv, trafos) : (return g, piv)
 end
 
-function reduce_right(A::SMat{T}, b::SRow{T},
-                      start::Int = 1, trafo::Type{Val{N}} = Val{false}) where {N, T}
-  with_transform = (trafo == Val{true})
+function reduce_right(A::SMat{T}, b::SRow{T}, start::Int = 1, ::Val{with_transform} = Val(false)) where {T, with_transform}
   with_transform ? trafos = [] : nothing
   new = true
   if length(b.pos) == 0

--- a/src/Sparse/HNF.jl
+++ b/src/Sparse/HNF.jl
@@ -443,13 +443,12 @@ end
 Given a matrix $A$ in HNF, extend this to get the HNF of the concatenation
 with $b$.
 """
-function hnf_extend!(A::SMat{T}, b::SMat{T}, trafo::Type{Val{N}} = Val{false}; truncate::Bool = false, offset::Int = 0) where {N, T}
+function hnf_extend!(A::SMat{T}, b::SMat{T}, with_transform_val::Val{with_transform} = Val(false); truncate::Bool = false, offset::Int = 0) where {T, with_transform}
   rA = nrows(A)
   @vprintln :HNF 1 "Extending HNF by:"
   @vprint :HNF 1 b
   @vprint :HNF 1 "density $(density(A)) $(density(b))"
 
-  with_transform = (trafo == Val{true})
   with_transform ? trafos = SparseTrafoElem{T, dense_matrix_type(T)}[] : nothing
 
   A_start_rows = nrows(A)  # for the offset stuff
@@ -457,7 +456,7 @@ function hnf_extend!(A::SMat{T}, b::SMat{T}, trafo::Type{Val{N}} = Val{false}; t
   nc = 0
   for i=b
     if with_transform
-      q, w, new_trafos = reduce_full(A, i, trafo())
+      q, w, new_trafos = reduce_full(A, i, with_transform_val)
       append!(trafos, new_trafos)
     else
       q, w = reduce_full(A, i)
@@ -491,7 +490,7 @@ function hnf_extend!(A::SMat{T}, b::SMat{T}, trafo::Type{Val{N}} = Val{false}; t
     end
     if length(w) > 0
       if with_transform
-        new_trafos = reduce_up(A, w, trafo())
+        new_trafos = reduce_up(A, w, with_transform_val)
         append!(trafos, new_trafos)
       else
         reduce_up(A, w)

--- a/src/Sparse/HNF.jl
+++ b/src/Sparse/HNF.jl
@@ -528,12 +528,11 @@ end
 
 Compute the Hermite normal form of $A$ using the Kannan-Bachem algorithm.
 """
-function hnf_kannan_bachem(A::SMat{T}, trafo::Type{Val{N}} = Val{false}; truncate::Bool = false) where {N, T}
+function hnf_kannan_bachem(A::SMat{T}, with_transform_val::Val{with_transform} = Val(false); truncate::Bool = false) where {T, with_transform}
   @vprintln :HNF 1 "Starting Kannan Bachem HNF on:"
   @vprint :HNF 1 A
   @vprintln :HNF 1 " with density $(density(A)); truncating $truncate"
 
-  with_transform = (trafo == Val{true})
   with_transform ? trafos = SparseTrafoElem{T, dense_matrix_type(T)}[] : nothing
 
   B = sparse_matrix(base_ring(A))
@@ -541,7 +540,7 @@ function hnf_kannan_bachem(A::SMat{T}, trafo::Type{Val{N}} = Val{false}; truncat
   nc = 0
   for i=A
     if with_transform
-      q, w, new_trafos = reduce_full(B, i, trafo())
+      q, w, new_trafos = reduce_full(B, i, with_transform_val)
       append!(trafos, new_trafos)
     else
       q, w = reduce_full(B, i)
@@ -575,7 +574,7 @@ function hnf_kannan_bachem(A::SMat{T}, trafo::Type{Val{N}} = Val{false}; truncat
     end
     if length(w) > 0
       if with_transform
-        new_trafos = reduce_up(B, w, trafo())
+        new_trafos = reduce_up(B, w, with_transform_val)
         append!(trafos, new_trafos)
       else
         reduce_up(B, w)
@@ -609,7 +608,7 @@ end
 Return the upper right Hermite normal form of $A$.
 """
 function hnf(A::SMat{ZZRingElem}; truncate::Bool = false)
-  return hnf_kannan_bachem(A, truncate = truncate)
+  return hnf_kannan_bachem(A; truncate = truncate)
 end
 
 @doc raw"""

--- a/src/Sparse/Module.jl
+++ b/src/Sparse/Module.jl
@@ -195,7 +195,7 @@ function module_trafo_assure(M::ModuleCtx_fmpz)
 
   else
     z = vcat(M.bas_gens, M.rel_gens)
-    h, t = hnf_kannan_bachem(z, Val{true}, truncate = true)
+    h, t = hnf_kannan_bachem(z, Val(true); truncate = true)
     M.trafo = t
     M.basis = h
   end

--- a/src/Sparse/Module.jl
+++ b/src/Sparse/Module.jl
@@ -190,7 +190,7 @@ function module_trafo_assure(M::ModuleCtx_fmpz)
   end
   if isdefined(M, :trafo)
     st = M.done_up_to + 1
-    _, t = hnf_extend!(M.basis, sub(M.rel_gens, st:nrows(M.rel_gens), 1:ncols(M.rel_gens)), Val{true}, offset = st-1, truncate = true)
+    _, t = hnf_extend!(M.basis, sub(M.rel_gens, st:nrows(M.rel_gens), 1:ncols(M.rel_gens)), Val(true), offset = st-1, truncate = true)
     append!(M.trafo, t)
 
   else

--- a/test/AlgAss/AbsAlgAss.jl
+++ b/test/AlgAss/AbsAlgAss.jl
@@ -84,7 +84,7 @@
   @testset "Generators" begin
     Qx, x = FlintQQ["x"]
     A = StructureConstantAlgebra((x^2 + 1)*(x^2 + 3))
-    g, full_basis, v = gens(A, Val{true})
+    g, full_basis, v = gens(A, Val(true))
 
     @test length(full_basis) == dim(A)
 

--- a/test/AlgAss/AlgGrp.jl
+++ b/test/AlgAss/AlgGrp.jl
@@ -16,7 +16,7 @@
   end
 
   @testset "Generators" begin
-    g, full_basis, v = gens(A, Val{true})
+    g, full_basis, v = gens(A, Val(true))
 
     @test length(full_basis) == dim(A)
 

--- a/test/NfAbs/NfAbs.jl
+++ b/test/NfAbs/NfAbs.jl
@@ -44,7 +44,7 @@
       if n % m != 0 && ! (isodd(n) && (2*n) % m == 0)
         Fm, zm = cyclotomic_field(m)
         @test_throws ErrorException Hecke.force_coerce_cyclo(Fn, zm)
-        @test Hecke.force_coerce_cyclo(Fn, zm, Val{false}) === nothing
+        @test Hecke.force_coerce_cyclo(Fn, zm, Val(false)) === nothing
       end
     end
   end

--- a/test/Sparse/HNF.jl
+++ b/test/Sparse/HNF.jl
@@ -6,7 +6,7 @@
     As = sparse_matrix(A)
     @test hnf(A) == ZZMatrix(hnf(As))
 
-    H, T = Hecke.hnf_kannan_bachem(As, Val{true})
+    H, T = Hecke.hnf_kannan_bachem(As, Val(true))
     B = deepcopy(As)
 
     for t in T


### PR DESCRIPTION
This is similar to https://github.com/Nemocas/AbstractAlgebra.jl/pull/1664.

`Val{T}` is a type and `Val(T)` its singleton object. This is the way it is described in the julia docs (https://docs.julialang.org/en/v1/manual/types/#%22Value-types%22).

I went through all the uses and corrected them.

For all exported functions where the parameter occurred in a docstring, I already added deprecations. If you want more deprecations, please let me know.