### PR TITLE
Add `coefficients` and `coeff` for `FinAbGenGroupElem`

### DIFF
--- a/src/GrpAb/Elem.jl
+++ b/src/GrpAb/Elem.jl
@@ -455,3 +455,31 @@ Base.IteratorSize(::Type{FinGenAbGroup}) = Base.HasLength()
 Base.length(G::FinGenAbGroup) = Int(order(G))
 
 Base.eltype(::Type{FinGenAbGroup}) = FinGenAbGroupElem
+
+################################################################################
+#
+#  Coefficients
+#
+################################################################################
+
+@doc raw"""
+    coefficients(a::FinGenAbGroupElem) -> ZZMatrix
+
+Return the coefficients of `a` in the generators of `parent(a)`.
+"""
+function coefficients(a::FinGenAbGroupElem; copy::Bool=true)
+  if !copy
+    return a.coeff
+  else
+    return deepcopy(a.coeff)
+  end
+end
+
+@doc raw"""
+    coeff(a::FinGenAbGroupElem, n::Int) -> ZZRingElem
+
+Return the coefficient of `a` with respect to the `n`-th generator of `parent(a)`.
+"""
+function coeff(a::FinGenAbGroupElem, n::Int)
+  return a.coeff[1, n]
+end

--- a/test/GrpAb/Elem.jl
+++ b/test/GrpAb/Elem.jl
@@ -235,4 +235,12 @@
       @test L*M*R == T
     end
   end
+
+  @testset "Coefficients" begin
+    G = @inferred abelian_group(2, 2, 2)
+    a = @inferred G([1, 1, 1])
+    @test @inferred coefficients(a) == FlintZZ[1 1 1]
+    @test @inferred coefficients(a; copy=false) == FlintZZ[1 1 1]
+    @test @inferred coeff(a, 1) == FlintZZ(1)
+  end
 end


### PR DESCRIPTION
I assume these were not left out for a reason?
