### PR TITLE
Re-add deprecations of #1455

### DIFF
--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -228,13 +228,7 @@
 
 # Deprecated in 0.31.0
 
-# TODO: remove the following functions and uncomment the deprecation for the 0.31.0 minor breaking release
-
-force_coerce_cyclo(a::AbsSimpleNumField, b::AbsSimpleNumFieldElem, throw_error::Type{Val{T}}) where {T} = force_coerce_cyclo(a, b, Val(T))
-reduce_full(A::SMat{T}, g::SRow{T}, trafo::Type{Val{N}}) where {N, T} = reduce_full(A, g, Val(N))
-gens(A::GroupAlgebra, return_full_basis::Type{Val{T}}) where T = gens(A, Val(T))
-gens(A::AbstractAssociativeAlgebra, return_full_basis::Type{Val{T}}; thorough_search::Bool = false) where T = gens(A, Val(T); thorough_search)
-# @deprecate force_coerce_cyclo(a::AbsSimpleNumField, b::AbsSimpleNumFieldElem, throw_error::Type{Val{T}}) where {T} force_coerce_cyclo(a, b, Val(T)) false
-# @deprecate reduce_full(A::SMat{T}, g::SRow{T}, trafo::Type{Val{N}}) where {N, T} reduce_full(A, g, Val(N))
-# @deprecate gens(A::GroupAlgebra, return_full_basis::Type{Val{T}}) where T gens(A, Val(T))
-# @deprecate gens(A::AbstractAssociativeAlgebra, return_full_basis::Type{Val{T}}; thorough_search::Bool = false) where T gens(A, Val(T); thorough_search)
+@deprecate force_coerce_cyclo(a::AbsSimpleNumField, b::AbsSimpleNumFieldElem, throw_error::Type{Val{T}}) where {T} force_coerce_cyclo(a, b, Val(T)) false
+@deprecate reduce_full(A::SMat{T}, g::SRow{T}, trafo::Type{Val{N}}) where {N, T} reduce_full(A, g, Val(N))
+@deprecate gens(A::GroupAlgebra, return_full_basis::Type{Val{T}}) where T gens(A, Val(T))
+@deprecate gens(A::AbstractAssociativeAlgebra, return_full_basis::Type{Val{T}}; thorough_search::Bool = false) where T gens(A, Val(T); thorough_search)


### PR DESCRIPTION
They were removed from #1455 to make it non-breaking.

This PR should be marked as breaking and only merged in the preparation of the 0.31.0 release.