### PR TITLE
feat: extend abelian_extension for number fields

### DIFF
--- a/src/FieldFactory/conductors_generic.jl
+++ b/src/FieldFactory/conductors_generic.jl
@@ -579,12 +579,15 @@ end
 
 
 function conductors_generic(K::AbsSimpleNumField, gtype::Vector{Int}, absolute_bound::ZZRingElem; only_tame::Bool = false)
+  return conductors_generic(lll(maximal_order(K)), gtype, absolute_bound; only_tame = only_tame)
+end
+
+function conductors_generic(OK::AbsSimpleNumFieldOrder, gtype::Vector{Int}, absolute_bound::ZZRingElem; only_tame::Bool = false)
   #I am assuming that gtype is in "SNF"
-  conds_tame = conductors_generic_tame(K, gtype, absolute_bound)
+  conds_tame = conductors_generic_tame(OK, gtype, absolute_bound)
   if only_tame
     return Dict{AbsNumFieldOrderIdeal{AbsSimpleNumField, AbsSimpleNumFieldElem}, Int}[(x[1], Dict{AbsNumFieldOrderIdeal{AbsSimpleNumField, AbsSimpleNumFieldElem}, Int}()) for x in conds_tame]
   end
-  OK = maximal_order(K)
   wild = collect(keys(factor(gtype[end]).fac))
   n = prod(gtype)
   bound = div(absolute_bound, abs(discriminant(OK))^n)
@@ -670,7 +673,10 @@ function conductors_generic(K::AbsSimpleNumField, gtype::Vector{Int}, absolute_b
 end
 
 function conductors_generic_tame(K::AbsSimpleNumField, gtype::Vector{Int}, absolute_bound::ZZRingElem)
-  OK = maximal_order(K)
+  return conductors_generic_tame(lll(maximal_order(K), gtype, absolute_bound))
+end
+
+function conductors_generic_tame(OK::AbsSimpleNumFieldOrder, gtype::Vector{Int}, absolute_bound::ZZRingElem)
   n = prod(gtype)
   wild = collect(keys(factor(n).fac))
   pmin = Int(minimum(wild))

--- a/test/RCF/rcf.jl
+++ b/test/RCF/rcf.jl
@@ -348,3 +348,24 @@ end
   l = abelian_extensions([2], collect(1:10^3))
   @test length(l) == 607
 end
+
+let
+  Qx, x = QQ["x"]
+  K, a = rationals_as_number_field()
+  all_fields = abelian_extensions(K, [2], ZZRingElem(10)^3, absolutely_distinct = true)
+  OK = maximal_order(K)
+  lp = prime_ideals_up_to(OK, 10^3)
+  prime_cond = abelian_extensions(K, [2], ZZRingElem(10)^3, absolutely_distinct = true, conductors = lp)
+  @test length(prime_cond) == count(is_prime.(first.(conductor.(all_fields))))
+
+  # with target signatures
+  K, a = number_field(x^3 - x^2 - 2*x + 1, cached = false)
+  l = abelian_extensions(K, [2, 2], ZZRingElem(10)^12)
+  conds = Hecke.conductors_generic(K, [2, 2], ZZ(10)^12)
+  l = abelian_extensions(K, [2, 2], ZZRingElem(10)^12)
+  ll = abelian_extensions(K, [2, 2], ZZRingElem(10)^12, conductors = conds)
+  @test length(l) == length(ll)
+  l1 = abelian_extensions(K, [2, 2], ZZRingElem(10)^12, signatures = [(4, 4)])
+  ll1 = abelian_extensions(K, [2, 2], ZZRingElem(10)^12, signatures = [(4, 4)], conductors = conds)
+  @test length(l1) == length(ll1)
+end


### PR DESCRIPTION
- allow to provide conductors
- fix handling of implicit maximal order
