### PR TITLE
fix: missing ring interface function for local fields

### DIFF
--- a/src/LocalField/Elem.jl
+++ b/src/LocalField/Elem.jl
@@ -13,6 +13,8 @@ function Base.show(io::IO, a::LocalFieldElem)
   print(io, AbstractAlgebra.obj_to_string(a, context = io))
 end
 
+canonical_unit(x::LocalFieldElem) = x
+
 ################################################################################
 #
 #  Deepcopy

--- a/test/LocalField/LocalField.jl
+++ b/test/LocalField/LocalField.jl
@@ -297,4 +297,15 @@
     C, mC = completion(K, P)
     @test valuation(log(mC(u))) == 1//2
   end
+
+  let
+    # missing canonical unit
+    K, a = quadratic_field(5);
+    OK = maximal_order(K)
+    lp = prime_decomposition(OK, 7)
+    C, mC = completion(K, lp[1][1], 20)
+    Ct, t = C["t"];
+    s = sprint(show, "text/plain", t//(1 + t))
+    @test s isa String
+  end
 end


### PR DESCRIPTION
- `canonical_unit` was missing, which made the printing
  of rational functions fail
