### PR TITLE
fix: simplify for non-monic input

### DIFF
--- a/src/NumField/NfAbs/Simplify.jl
+++ b/src/NumField/NfAbs/Simplify.jl
@@ -64,7 +64,7 @@ function simplify(K::AbsSimpleNumField; canonical::Bool = false, cached::Bool = 
     OK.lllO = ZK
   end
   @vtime :Simplify 3 a = _simplify(ZK)
-  if a == gen(K)
+  if a == gen(K) && is_monic(K.pol) # K.pol is minpoly of a
     f = K.pol
   else
     @vtime :Simplify 3 f = Qx(minpoly(representation_matrix(OK(a))))

--- a/test/NfAbs/Simplify.jl
+++ b/test/NfAbs/Simplify.jl
@@ -32,4 +32,10 @@
   K, a = number_field(f, cached = false)
   _, g = Hecke.polredabs(K)
   @test g == f
+
+  f = -x^3 - 14*x^2 - 13*x + 6
+  K, a = number_field(f, cached = false)
+  L, _ = simplify(K)
+  g = defining_polynomial(L)
+  @test is_monic(g) && is_one(denominator(g))
 end


### PR DESCRIPTION
- simplify(...; canonical = true) relies on
  simplify(...; canonical =  false) returning a nice defining
  polynomial (nice = monic and integral coefficients)
- Closes #1490
