### PR TITLE
Padics done right

### DIFF
--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -269,3 +269,6 @@ end
 
 @deprecate hom(G::FinGenAbGroup, H::FinGenAbGroup, A::Matrix{ <: Map{FinGenAbGroup, FinGenAbGroup}}) hom_direct_sum(G, H, A)
 @deprecate hom(G::FinGenAbGroup, H::FinGenAbGroup, A::Vector{ <: Map{FinGenAbGroup, FinGenAbGroup}}) hom_tensor(G, H, A)
+
+@deprecate lift(a::QadicRingElem) lift(ZZ, a)
+@deprecate prime_field(L::Union{QadicField, LocalField}) absolute_base_field(L)

--- a/src/LocalField/Completions.jl
+++ b/src/LocalField/Completions.jl
@@ -34,7 +34,7 @@ function preimage(f::CompletionMap{LocalField{QadicFieldElem, EisensteinLocalFie
   pr = ceil(Int, min(f.precision, precision(a)) / ramification_index(Kp))
   for i = 0:degree(a.data)
     as_pol = Qpx(coeff(a.data, i))
-    as_fmpq_poly = map_coefficients(x->lift(setprecision(x, min(precision(x), pr))), as_pol, cached = false)
+    as_fmpq_poly = map_coefficients(x->lift(ZZ, setprecision(x, min(precision(x), pr))), as_pol, cached = false)
     push!(coeffs, evaluate(as_fmpq_poly, f.inv_img[1]))
   end
   K = domain(f)
@@ -45,7 +45,7 @@ end
 
 function preimage(f::CompletionMap{LocalField{PadicFieldElem, EisensteinLocalField}, LocalFieldElem{PadicFieldElem, EisensteinLocalField}}, a::LocalFieldElem{PadicFieldElem, EisensteinLocalField})
   @assert codomain(f) === parent(a)
-  return evaluate(map_coefficients(lift, a.data, cached = false), f.inv_img[2])
+  return evaluate(map_coefficients(x -> lift(ZZ, x), a.data, cached = false), f.inv_img[2])
 end
 
 function preimage(f::CompletionMap{QadicField, QadicFieldElem}, a::QadicFieldElem)
@@ -53,7 +53,7 @@ function preimage(f::CompletionMap{QadicField, QadicFieldElem}, a::QadicFieldEle
   @assert Kp == parent(a)
   Qpx = parent(defining_polynomial(Kp))
   as_pol = Qpx(a)
-  as_fmpq_poly = map_coefficients(lift, as_pol, cached = false)
+  as_fmpq_poly = map_coefficients(x -> lift(ZZ, x), as_pol, cached = false)
   return evaluate(as_fmpq_poly, f.inv_img[1])
 end
 
@@ -160,7 +160,7 @@ function completion(K::AbsSimpleNumField, P::AbsNumFieldOrderIdeal{AbsSimpleNumF
   g = gen(q)
   gq_in_K = (mF\(mp(g))).elem_in_nf
   Zx = polynomial_ring(FlintZZ, "x", cached = false)[1]
-  pol_gq = map_coefficients(lift,  defining_polynomial(Qq), cached = false)
+  pol_gq = map_coefficients(x -> lift(ZZ, x),  defining_polynomial(Qq), cached = false)
   gq_in_K = _lift(gq_in_K, pol_gq, precision, P)
   #@assert mF(OK(gq_in_K)) == mp(g)
 
@@ -290,11 +290,11 @@ function setprecision!(f::CompletionMap{LocalField{QadicFieldElem, EisensteinLoc
     gq, u = f.inv_img
     ex = div(new_prec+e-1, e)
     Zx = polynomial_ring(FlintZZ, "x", cached = false)[1]
-    pol_gq = map_coefficients(lift, defining_polynomial(base_field(Kp)), cached = false)
+    pol_gq = map_coefficients(x -> lift(ZZ, x), defining_polynomial(base_field(Kp)), cached = false)
     gq = _increase_precision(gq, pol_gq, div(f.precision+e-1, e), ex, P)
     f.inv_img = (gq, f.inv_img[2])
 
-    Zp = maximal_order(prime_field(Kp))
+    Zp = maximal_order(absolute_base_field(Kp))
     Qq = base_field(Kp)
 
     setprecision!(Qq, ex)

--- a/src/LocalField/Conjugates.jl
+++ b/src/LocalField/Conjugates.jl
@@ -53,15 +53,17 @@ function newton_lift(f::ZZPolyRingElem, r::LocalFieldElem, precision::Int = pare
   for p = reverse(chain)
     r = setprecision!(r, p)
     o = setprecision!(o, p)
-    setprecision!(Q, p)
     setprecision!(qf, p)
     setprecision!(qfs, p)
-    r = r - qf(r)*o
+    r = with_precision(Q, p) do
+      return r - qf(r)*o
+    end
     if Nemo.precision(r) >= n
-      setprecision!(Q, n)
       return r
     end
-    o = o*(2-qfs(r)*o)
+    o = with_precision(Q, p) do
+      return o*(2-qfs(r)*o)
+    end
   end
   return r
 end

--- a/src/LocalField/Conjugates.jl
+++ b/src/LocalField/Conjugates.jl
@@ -609,11 +609,11 @@ function completion(K::AbsSimpleNumField, ca::QadicFieldElem)
       d = c
     end
     n = x.length
-    r = K(lift(coeff(x, n-1)))
+    r = K(lift(ZZ, coeff(x, n-1)))
     pk = p^precision(x)
     while n > 1
       n -= 1
-      r = mod_sym(r*d, pk) + lift(coeff(x, n-1))
+      r = mod_sym(r*d, pk) + lift(ZZ, coeff(x, n-1))
     end
     return r#*K(p)^valuation(x)
   end

--- a/src/LocalField/Elem.jl
+++ b/src/LocalField/Elem.jl
@@ -864,7 +864,7 @@ function divexact(a::LocalFieldElem, b::Union{Integer, ZZRingElem}; check::Bool=
   e = absolute_ramification_index(K)
   v = valuation(b, p)
   iszero(a) && return setprecision(a, precision(a) - v*e)
-  Qp = prime_field(K)
+  Qp = absolute_base_field(K)
   bb = with_precision(Qp, e*precision(a)+round(Int, e*valuation(a)) + v) do
     return inv(Qp(b))
   end

--- a/src/LocalField/LocalField.jl
+++ b/src/LocalField/LocalField.jl
@@ -381,9 +381,9 @@ function setprecision!(K::LocalField, n::Int)
   return nothing
 end
 
-function setprecision(f::Function, K::Union{LocalField, PadicField, QadicField}, n::Int)
+function with_precision(f, K::LocalField, n::Int)
+  @assert n >= 0
   old = precision(K)
-#  @assert n>=0
   setprecision!(K, n)
   v = try
         setprecision(f, base_field(K), ceil(Int, n/ramification_index(K)))
@@ -393,6 +393,7 @@ function setprecision(f::Function, K::Union{LocalField, PadicField, QadicField},
   return v
 end
 
+setprecision(f, K::LocalField, n::Int) = with_precision(f, K, n)
 
 ################################################################################
 #
@@ -485,7 +486,7 @@ end
 
  ################### unramified extension over local field L of a given degree n ####################
 
- function unramified_extension(L::Union{PadicField, QadicField, LocalField}, n::Int)
+ function unramified_extension(L::Union{QadicField, LocalField}, n::Int)
    R, mR = residue_field(L)
    Rt, t = polynomial_ring(R, "t", cached = false)
    f = Rt(push!([rand(R) for i = 0:n-1], one(R)))

--- a/src/LocalField/LocalField.jl
+++ b/src/LocalField/LocalField.jl
@@ -131,15 +131,6 @@ end
 #
 ################################################################################
 
-function prime_field(L::Union{QadicField, LocalField})
-  L = base_ring(defining_polynomial(L))
-  while typeof(L) != PadicField
-    L = base_ring(defining_polynomial(L))
-  end
-  return L
-end
-
-
 function base_field(L::LocalField)
   return base_ring(defining_polynomial(L))
 end

--- a/src/LocalField/Poly.jl
+++ b/src/LocalField/Poly.jl
@@ -168,7 +168,7 @@ function fun_factor(g::Generic.Poly{PadicFieldElem})
   pv = prime(K)^v
   R = residue_ring(FlintZZ, pv, cached = false)[1]
   Rt = polynomial_ring(R, "t", cached = false)[1]
-  fR = Rt([R(Hecke.lift(coeff(g, i))) for i = 0:degree(g)])
+  fR = Rt([R(Hecke.lift(ZZ, coeff(g, i))) for i = 0:degree(g)])
   u, g1 = Hecke.fun_factor(fR)
   liftu = Kt(elem_type(K)[lift(coeff(u, i), K) for i in 0:degree(u)])
   liftg1 = Kt(elem_type(K)[lift(coeff(g1, i), K) for i in 0:degree(g1)])
@@ -321,8 +321,8 @@ function invmod(u::Generic.Poly{PadicFieldElem}, f::Generic.Poly{PadicFieldElem}
     pv = prime(K)^v
     R = residue_ring(FlintZZ, pv, cached = false)[1]
     Rt = polynomial_ring(R, "t", cached = false)[1]
-    fR = Rt(elem_type(R)[R(Hecke.lift(coeff(f, i))) for i = 0:degree(f)])
-    uR = Rt(elem_type(R)[R(Hecke.lift(coeff(u, i))) for i = 0:degree(u)])
+    fR = Rt(elem_type(R)[R(Hecke.lift(ZZ, coeff(f, i))) for i = 0:degree(f)])
+    uR = Rt(elem_type(R)[R(Hecke.lift(ZZ, coeff(u, i))) for i = 0:degree(u)])
     iuR = invmod(uR, fR)
     s = map_coefficients(x -> lift(x, K), iuR, parent = Kt)
     if maximum(valuation, coefficients(s)) + vu < v
@@ -525,11 +525,11 @@ function rres(f::Generic.Poly{PadicFieldElem}, g::Generic.Poly{PadicFieldElem})
   R = residue_ring(FlintZZ, p^v, cached = false)[1]
   cf = Vector{elem_type(R)}(undef, degree(f)+1)
   for i = 1:length(cf)
-    cf[i] = R(Hecke.lift(coeff(f, i-1)))
+    cf[i] = R(Hecke.lift(ZZ, coeff(f, i-1)))
   end
   cg = Vector{elem_type(R)}(undef, degree(g)+1)
   for i = 1:length(cg)
-    cg[i] = R(Hecke.lift(coeff(g, i-1)))
+    cg[i] = R(Hecke.lift(ZZ, coeff(g, i-1)))
   end
   Rt = polynomial_ring(R, "t", cached = false)[1]
   r = Hecke.rres_sircana_pp(Rt(cf), Rt(cg))

--- a/src/LocalField/Poly.jl
+++ b/src/LocalField/Poly.jl
@@ -712,8 +712,6 @@ function _rres(f::Generic.Poly{T}, g::Generic.Poly{T}) where T <: Union{PadicFie
   return res*res1
 end
 
-base_field(Q::QadicField) = base_ring(defining_polynomial(Q))
-
 function norm(f::PolyRingElem{T}) where T <: Union{QadicFieldElem, LocalFieldElem}
   Kx = parent(f)
   K = base_ring(f)
@@ -929,7 +927,7 @@ function lift(C::HenselCtxdr, mx::Int)
   N = minimum([precision(x) for x in C.lf])
   N = min(N, minimum([precision(x) for x in C.la]))
   #have: N need mx
-  one = setprecision(parent(p), mx) do
+  one = with_precision(parent(p), mx) do
     Base.one(parent(p))
   end
   ch = Int[mx]

--- a/src/LocalField/Ring.jl
+++ b/src/LocalField/Ring.jl
@@ -125,12 +125,12 @@ function _map(Q::QadicField, a::PadicFieldElem)
   @assert prime(K) == prime(Q)
   v = valuation(a)
   if v >= 0
-    q = Q(lift(a))
+    q = Q(lift(ZZ, a))
     return setprecision(q, a.N)
   else
     d = uniformizer(K)^-v
     n = a*d
-    n1 = divexact(Q(lift(n)), Q(lift(d)))
+    n1 = divexact(Q(lift(ZZ, n)), Q(lift(ZZ, d)))
     return n1
   end
 end
@@ -211,7 +211,7 @@ coefficient_ring(K::LocalField) = base_field(K)
 
 function absolute_coordinates(a::QadicRingElem)
   v = absolute_coordinates(a.x)
-  Zp = ring_of_integers(prime_field(parent(a.x)))
+  Zp = ring_of_integers(absolute_base_field(parent(a.x)))
   return Zp.(v)
 end
 

--- a/src/LocalField/Ring.jl
+++ b/src/LocalField/Ring.jl
@@ -19,7 +19,7 @@ mutable struct QadicRing{S, T} <: Generic.Ring
 end
 
 function Base.show(io::IO, Q::QadicRing)
-  println("Integers of ", Q.Q)
+  print("Integers of ", Q.Q)
 end
 
 function MaximalOrder(Q::QadicField)
@@ -187,6 +187,10 @@ Base.precision(a::QadicRingElem) = precision(a.x)
 
 function setprecision!(Q::QadicRing, n::Int)
   setprecision!(Q.Q, n)
+end
+
+function with_precision(f, Q::QadicRing, n::Int)
+  return with_precision(f, Q.Q, n)
 end
 
 function Base.setprecision(a::QadicRingElem, n::Int)

--- a/src/LocalField/automorphisms.jl
+++ b/src/LocalField/automorphisms.jl
@@ -106,7 +106,9 @@ function _roots(f::Generic.Poly{T}) where T <: Union{PadicFieldElem, QadicFieldE
 end
 
 function automorphism_list(K::T) where T <: Union{LocalField, QadicField}
-  f = map_coefficients(K, defining_polynomial(K), cached = false)
+  f = with_precision(base_field(K), precision(K)) do
+    map_coefficients(K, defining_polynomial(K), cached = false)
+  end
   rt = roots(f)
   rt = refine_roots1(f, rt)
 

--- a/src/LocalField/neq.jl
+++ b/src/LocalField/neq.jl
@@ -110,7 +110,7 @@ function h2_is_iso(K::Hecke.LocalField)
   k, mk = residue_field(K)
   pi = uniformizer(K)
   pi = setprecision(pi, 2*e)
-  eps = setprecision(K, precision(K)+e) do
+  eps = with_precision(K, precision(K)+e) do
     -inv(divexact(pi^e, p))
   end
   #assert valuation(eps) == 0
@@ -148,7 +148,7 @@ function _unit_group_gens_case2(K::Union{QadicField, Hecke.LocalField})
   #we need p/pi^e, the unit, with enough precision,
   #precision(eps) = k -> p, pi needs 2k
   pi = setprecision(pi, precision(K)+2*e)
-  eps = setprecision(K, precision(K)+e) do
+  eps = with_precision(K, precision(K)+e) do
     -inv(divexact(pi^e, p))
   end
   #  @assert precision(eps) >= precision(K) # does not (quite) work
@@ -233,92 +233,90 @@ function solve_1_units(a::Vector{T}, b::T) where T
   #Z_p (and Z) operates on the 1-units...
   k = precision(b)
   K = parent(b)
-  old = precision(K)
-  setprecision!(K, k)
-  one = K(1)
-  if iszero(b-one)
-    setprecision!(K, old)
-    return ZZRingElem[0 for i=a], ZZRingElem(1)
-  end
-  @assert valuation(b-one) > 0
-  @assert all(x->parent(x) == K , a)
-  #plan:
-  # (1+p^k/1+p^l, *) = (p^k/p^l, +) for k<=l<=2k
-  #so we start with k=1, l=2 to find the exponents mod p
-  #remove this from b
-  #try to find the next part (mod p^2), ...
-  #
-  e = absolute_ramification_index(K)
-  f = absolute_inertia_degree(K)
-  pi = uniformizer(K)
-  p = prime(K)
-  l = 1
-  cur_a = copy(a)
-  cur_b = b
-#  @assert degree(K) == e
-  Qp = prime_field(K)
-  Zp = ring_of_integers(Qp)
-  expo_mult = identity_matrix(ZZ, length(cur_a))
-  #transformation of cur_a to a
-  expo = zero_matrix(ZZ, 1, length(cur_a))
-  pk = ZZRingElem(p)
+  return with_precision(K, k) do
+    one = K(1)
+    if iszero(b-one)
+      return ZZRingElem[0 for i=a], ZZRingElem(1)
+    end
+    @assert valuation(b-one) > 0
+    @assert all(x->parent(x) == K , a)
+    #plan:
+    # (1+p^k/1+p^l, *) = (p^k/p^l, +) for k<=l<=2k
+    #so we start with k=1, l=2 to find the exponents mod p
+    #remove this from b
+    #try to find the next part (mod p^2), ...
+    #
+    e = absolute_ramification_index(K)
+    f = absolute_inertia_degree(K)
+    pi = uniformizer(K)
+    p = prime(K)
+    l = 1
+    cur_a = copy(a)
+    cur_b = b
+#    @assert degree(K) == e
+    Qp = prime_field(K)
+    Zp = ring_of_integers(Qp)
+    expo_mult = identity_matrix(ZZ, length(cur_a))
+    #transformation of cur_a to a
+    expo = zero_matrix(ZZ, 1, length(cur_a))
+    pk = ZZRingElem(p)
 
-  val_offset = e .* map(valuation, absolute_basis(K))
-  pow_b = ZZRingElem(1)
+    val_offset = e .* map(valuation, absolute_basis(K))
+    pow_b = ZZRingElem(1)
 
-  while l <= k
-#    @show 1, l, pow_b, k, expo
-    last_val = e*valuation(cur_b-one)
-#    @show expo_mult
-    @assert e*valuation(cur_b-one) >= l
-    @assert all(x->isone(x) || e*valuation(x-one) >= l, cur_a)
+    while l <= k
+#      @show 1, l, pow_b, k, expo
+      last_val = e*valuation(cur_b-one)
+#      @show expo_mult
+      @assert e*valuation(cur_b-one) >= l
+      @assert all(x->isone(x) || e*valuation(x-one) >= l, cur_a)
 
-    A = abelian_group([p^max(0, ceil(Int, (l-v)//e)) for v = val_offset])
-    h = hom(free_abelian_group(length(cur_a)), A, [A([lift(ZZ, x) for x =  absolute_coordinates(divexact(y-one, pi^l))]) for y = cur_a])
-    lhs = A([lift(ZZ, x) for x = absolute_coordinates(divexact(cur_b -one, pi^l))])
-    fl, s = has_preimage_with_preimage(h, lhs)
-    _k, _mk = kernel(h)
-    #if kernel has HNF, the next step is cheaper...
-    _mk.map = hnf(_mk.map)
-    #to find a nice preimage
-    reduce_mod_hnf_ur!(s.coeff, _mk.map)
-#    @show s
-    # to verify that this is a "legal" operation... the hom constructor
-    # will verify that this is legal
-    # hom(domain(_mk), codomain(_mk), [_mk(x) for x = gens(domain(_mk))])
+      A = abelian_group([p^max(0, ceil(Int, (l-v)//e)) for v = val_offset])
+      h = hom(free_abelian_group(length(cur_a)), A, [A([lift(ZZ, x) for x =  absolute_coordinates(divexact(y-one, pi^l))]) for y = cur_a])
+      lhs = A([lift(ZZ, x) for x = absolute_coordinates(divexact(cur_b -one, pi^l))])
+      fl, s = has_preimage_with_preimage(h, lhs)
+      _k, _mk = kernel(h)
+      #if kernel has HNF, the next step is cheaper...
+      _mk.map = hnf(_mk.map)
+      #to find a nice preimage
+      reduce_mod_hnf_ur!(s.coeff, _mk.map)
+#      @show s
+      # to verify that this is a "legal" operation... the hom constructor
+      # will verify that this is legal
+      # hom(domain(_mk), codomain(_mk), [_mk(x) for x = gens(domain(_mk))])
 
-    if !fl
-      pow_b *= p
-      cur_b = cur_b^p
-      expo = expo * p
-      if iszero(cur_b-one)
+      if !fl
+        pow_b *= p
+        cur_b = cur_b^p
+        expo = expo * p
+        if iszero(cur_b-one)
+          break
+        end
+        last_val = e*valuation(cur_b-one)
+        continue
+      end
+
+      expo += s.coeff * expo_mult
+      expo_mult = reduce(vcat, [_mk(x).coeff for x = gens(_k)])*expo_mult
+      cur_a = [prod(cur_a[i]^_mk(x)[i] for i=1:length(cur_a)) for x = gens(_k)]
+#      @show [e*valuation(x-1) for x = cur_a]
+
+      cur_b = divexact(b^pow_b, prod(a[i]^expo[i] for i=1:length(a)))
+      if iszero(cur_b-one) || e*valuation(cur_b-one) >= k
         break
       end
+#      @show e*valuation(cur_b-one), 2l-1, last_val, k
+      @assert e*valuation(cur_b-one) >= min(2*l-1, last_val)
       last_val = e*valuation(cur_b-one)
-      continue
-    end
 
-    expo += s.coeff * expo_mult
-    expo_mult = reduce(vcat, [_mk(x).coeff for x = gens(_k)])*expo_mult
-    cur_a = [prod(cur_a[i]^_mk(x)[i] for i=1:length(cur_a)) for x = gens(_k)]
-#    @show [e*valuation(x-1) for x = cur_a]
-
-    cur_b = divexact(b^pow_b, prod(a[i]^expo[i] for i=1:length(a)))
-    if iszero(cur_b-one) || e*valuation(cur_b-one) >= k
-      break
+      if l == k
+        break
+      end
+      l *= 2
+      l = min(l, k)
     end
-#    @show e*valuation(cur_b-one), 2l-1, last_val, k
-    @assert e*valuation(cur_b-one) >= min(2*l-1, last_val)
-    last_val = e*valuation(cur_b-one)
-
-    if l == k
-      break
-    end
-    l *= 2
-    l = min(l, k)
-  end
-  setprecision!(K, old)
-  return [expo[1, i] for i=1:length(cur_a)], pow_b
+    return [expo[1, i] for i=1:length(cur_a)], pow_b
+  end # with_precision
 end
 
 function is_norm(K::Hecke.LocalField, b::Union{QadicFieldElem,PadicFieldElem,Hecke.LocalFieldElem})
@@ -369,7 +367,7 @@ function _norm_equation(K:: Hecke.LocalField, b::Union{QadicFieldElem,PadicField
   # - if v(b-1) > 1/(p-1), then exp/log work and we can reduce
   #   to trace equation..
   bb = setprecision(b, ceil(Int, e//(p-1)))
-  g = setprecision(K, precision(bb)*ramification_index(K)) do
+  g = with_precision(K, precision(bb)*ramification_index(K)) do
     one_unit_group_gens(K)
   end
   ng = map(norm, g)
@@ -618,7 +616,7 @@ function frobenius_equation(c::Hecke.LocalFieldElem, F::Union{PadicField, QadicF
   end
 
   v_deg = valuation(absolute_degree(E), prime(E))
-  setprecision(E, precision(E) + v_deg) do
+  with_precision(E, precision(E) + v_deg) do
     c = setprecision(c, precision(E))
     cnt = 0
     while true
@@ -650,7 +648,7 @@ function frobenius_equation(c::Hecke.LocalFieldElem, F::Union{PadicField, QadicF
         return frobenius_equation2(c, F, frobenius = fr)
       end
     end
-  end #setprecision
+  end # with_precision
 end
 
 #solve the same as above, but pi-adic digit by pi-adic digit, thus

--- a/src/LocalField/neq.jl
+++ b/src/LocalField/neq.jl
@@ -215,7 +215,7 @@ function coordinates(a::Union{QadicFieldElem, LocalFieldElem}, k)
   return c
 end
 coordinates(a::PadicFieldElem, ::PadicField) = [a]
-lift(a::Hecke.QadicRingElem{PadicField, PadicFieldElem}) = lift(a.x)
+lift(R::Ring, a::Hecke.QadicRingElem{PadicField, PadicFieldElem}) = lift(R, a.x)
 
 function setprecision!(A::Generic.MatSpaceElem{Hecke.QadicRingElem{PadicField, PadicFieldElem}}, n::Int)
   for i=1:nrows(A)
@@ -254,7 +254,7 @@ function solve_1_units(a::Vector{T}, b::T) where T
     cur_a = copy(a)
     cur_b = b
 #    @assert degree(K) == e
-    Qp = prime_field(K)
+    Qp = absolute_base_field(K)
     Zp = ring_of_integers(Qp)
     expo_mult = identity_matrix(ZZ, length(cur_a))
     #transformation of cur_a to a
@@ -564,7 +564,7 @@ struct MapEvalCtx
   map::Generic.MatSpaceElem{PadicFieldElem}
 
   function MapEvalCtx(M::LocalFieldMor)
-    mat = matrix(prime_field(domain(M)),
+    mat = matrix(absolute_base_field(domain(M)),
                  absolute_degree(domain(M)),
                  absolute_degree(codomain(M)),
                  reduce(vcat, [absolute_coordinates(M(x))
@@ -757,8 +757,8 @@ function local_fundamental_class_serre(mKL::LocalFieldMor)
   e = divexact(absolute_ramification_index(L), absolute_ramification_index(K))
   d = divexact(absolute_inertia_degree(L), absolute_inertia_degree(K))
   E = unramified_extension(L, e)[1]
-  G = automorphism_list(L, prime_field(L))
-  gK = map(mKL, gens(K, prime_field(K)))
+  G = automorphism_list(L, absolute_base_field(L))
+  gK = map(mKL, gens(K, absolute_base_field(K)))
   G = [g for g = G if map(g, gK) == gK]
   @assert Base.length(G) == absolute_degree(L)/absolute_degree(K)
 
@@ -777,7 +777,7 @@ function local_fundamental_class_serre(mKL::LocalFieldMor)
     #thus Gal(E/base_field(L)) = Gal(L/base_field(L)) x unram of base_field
     bL = base_field(L)
     E2, _ = unramified_extension(map_coefficients(x->bL(coeff(x, 0)), defining_polynomial(E), cached = false))
-    G2 = automorphism_list(E2, prime_field(E2))
+    G2 = automorphism_list(E2, absolute_base_field(E2))
     GG = morphism_type(E)[]
     for e = G2
       ime = e(gen(E2))
@@ -793,7 +793,7 @@ function local_fundamental_class_serre(mKL::LocalFieldMor)
     @assert length(GG) == divexact(absolute_degree(E), absolute_degree(K))
 #    @assert all(x->x in GG, automorphism_list(E, K))
   else
-    GG = automorphism_list(E, prime_field(E))
+    GG = automorphism_list(E, absolute_base_field(E))
     gK = map(E, gK)
     GG = [g for g = GG if map(g, gK) == gK]
   end
@@ -827,7 +827,7 @@ function local_fundamental_class_serre(mKL::LocalFieldMor)
   beta = []
   sigma_hat = []
   #need to map and compare all generators
-  gL = gens(L, prime_field(L))
+  gL = gens(L, absolute_base_field(L))
   imGG = map(x->map(x, map(E, gL)), GG)
   imG = map(x->map(x, gL), G)
 

--- a/src/LocalField/pAdic.jl
+++ b/src/LocalField/pAdic.jl
@@ -2,10 +2,10 @@ function _lift(a::PadicFieldElem)
   R = parent(a)
   v = valuation(a)
   if v >= 0
-    return QQFieldElem(lift(a))
+    return QQFieldElem(lift(ZZ, a))
   else
     m = prime(R)^-v
-    return QQFieldElem(lift(m * a))//m
+    return QQFieldElem(lift(ZZ, m * a))//m
   end
 end
 
@@ -41,7 +41,7 @@ function my_log_one_minus(x::PadicFieldElem)
   pp = prime(parent(x), 2)
   X = 1-x
   while true
-    y = lift(1-X) % pp
+    y = lift(ZZ, 1-X) % pp
     lg += parent(x)(my_log_one_minus_inner(y, precision(x), le, prime(parent(x))))
     X = X*inv(parent(x)(1-y))
     pp *= pp
@@ -76,10 +76,10 @@ function my_log_one_minus(x::QadicFieldElem)
   pp = prime(parent(x))^2
   X = 1-x
   R, _ = polynomial_ring(QQ, cached = false)
-  S, _ = residue_ring(R, map_coefficients(x->QQ(lift(x)), defining_polynomial(parent(x)), parent = R))
+  S, _ = residue_ring(R, map_coefficients(x->QQ(lift(ZZ, x)), defining_polynomial(parent(x)), parent = R))
   while true
     Y = 1-X
-    y = S(R([lift(coeff(Y, i)) % pp for i=0:length(Y)]))
+    y = S(R([lift(ZZ, coeff(Y, i)) % pp for i=0:length(Y)]))
     lg += parent(x)(my_log_one_minus_inner(y, precision(x), le, prime(parent(x))).data)
     X = X*inv(parent(x)(1-y.data))
     pp *= pp

--- a/src/LocalField/qAdic.jl
+++ b/src/LocalField/qAdic.jl
@@ -11,7 +11,7 @@ function residue_field(Q::QadicField)
   Fp = finite_field(prime(Q), 1, :o, cached = false, check = false)[1]
   Fpt = polynomial_ring(Fp, cached = false)[1]
   g = defining_polynomial(Q) #no Conway if parameters are too large!
-  f = Fpt([Fp(lift(coeff(g, i))) for i=0:degree(Q)])
+  f = Fpt([Fp(lift(ZZ, coeff(g, i))) for i=0:degree(Q)])
   k, = Nemo._residue_field(f, "o")
   pro = function(x::QadicFieldElem)
     v = valuation(x)
@@ -19,7 +19,7 @@ function residue_field(Q::QadicField)
     v > 0 && return k(0)
     _z = Fpt()
     for i=0:degree(Q)
-      setcoeff!(_z, i, Fp(lift(coeff(x, i))))
+      setcoeff!(_z, i, Fp(lift(ZZ, coeff(x, i))))
     end
     return k(_z)
   end
@@ -45,7 +45,7 @@ function residue_field(Q::PadicField)
     v = valuation(x)
     v < 0 && error("elt non integral")
     v > 0 && return k(0)
-    z = k(lift(x))
+    z = k(lift(ZZ, x))
     return z
   end
   lif = function(x::FqFieldElem)
@@ -79,7 +79,7 @@ function lift_reco(::QQField, a::PadicFieldElem; reco::Bool = false)
       return x*prime(R, v)
     end
   else
-    return lift(FlintQQ, a)
+    return lift(QQ, a)
   end
 end
 

--- a/src/NumField/NfAbs/MPolyAbsFact.jl
+++ b/src/NumField/NfAbs/MPolyAbsFact.jl
@@ -333,61 +333,61 @@ function lift_q(C::HenselCtxFqRelSeries{<:SeriesElem{QadicFieldElem}})
   pr = precision(coeff(coeff(C.lf[1], 0), 0))
   N2 = 2*pr
 
-  setprecision!(Q, N2)
+  return with_precision(Q, N2) do
+    i = length(C.lf)
+    @assert i > 1
+    @assert all(is_monic, C.lf[1:end-1])
+    j = i-1
+    while j > 0
+      if i==length(C.lf)
+        f = evaluate(map_coefficients(Q, C.f, cached = false), [gen(St), St(gen(S))])
+        f *= inv(leading_coefficient(f))
+      else
+#        f = _set_precision(C.lf[i], N2)
+        f = C.lf[i]
+        @assert precision(coeff(coeff(f, 0), 0)) >= N2
+        @assert is_monic(C.lf[i])
+      end
+      @assert is_monic(f)
+      #formulae and names from the Flint doc
+      h = C.lf[j]
+      g = C.lf[j-1]
+      b = C.cf[j]
+      a = C.cf[j-1]
+      h = _set_precision(h, N2)
+      g = _set_precision(g, N2)
+      a = _set_precision(a, N2)
+      b = _set_precision(b, N2)
 
-  i = length(C.lf)
-  @assert i > 1
-  @assert all(is_monic, C.lf[1:end-1])
-  j = i-1
-  while j > 0
-    if i==length(C.lf)
-      f = evaluate(map_coefficients(Q, C.f, cached = false), [gen(St), St(gen(S))])
-      f *= inv(leading_coefficient(f))
-    else
-#      f = _set_precision(C.lf[i], N2)
-      f = C.lf[i]
-      @assert precision(coeff(coeff(f, 0), 0)) >= N2
-      @assert is_monic(C.lf[i])
+      fgh = _shift_coeff_right(f-g*h, pr)
+
+      @assert is_monic(g)
+      @assert !iszero(constant_coefficient(g))
+      @assert is_monic(h)
+      @assert !iszero(constant_coefficient(h))
+      gi = preinv(g)
+      hi = preinv(h)
+
+      G = _shift_coeff_left(rem(fgh*b, gi), pr)+g
+      @assert is_monic(G)
+      H = _shift_coeff_left(rem(fgh*a, hi), pr)+h
+      @assert is_monic(H)
+
+      t = _shift_coeff_right(1-a*G-b*H, pr)
+
+      B = _shift_coeff_left(rem(t*b, gi), pr)+b
+      A = _shift_coeff_left(rem(t*a, hi), pr)+a
+#      check_data(A)
+#      check_data(B)
+
+      C.lf[j-1] = G
+      C.lf[j] = H
+      C.cf[j-1] = A
+      C.cf[j] = B
+      i -= 1
+      j -= 2
     end
-    @assert is_monic(f)
-    #formulae and names from the Flint doc
-    h = C.lf[j]
-    g = C.lf[j-1]
-    b = C.cf[j]
-    a = C.cf[j-1]
-    h = _set_precision(h, N2)
-    g = _set_precision(g, N2)
-    a = _set_precision(a, N2)
-    b = _set_precision(b, N2)
-
-    fgh = _shift_coeff_right(f-g*h, pr)
-
-    @assert is_monic(g)
-    @assert !iszero(constant_coefficient(g))
-    @assert is_monic(h)
-    @assert !iszero(constant_coefficient(h))
-    gi = preinv(g)
-    hi = preinv(h)
-
-    G = _shift_coeff_left(rem(fgh*b, gi), pr)+g
-    @assert is_monic(G)
-    H = _shift_coeff_left(rem(fgh*a, hi), pr)+h
-    @assert is_monic(H)
-
-    t = _shift_coeff_right(1-a*G-b*H, pr)
-
-    B = _shift_coeff_left(rem(t*b, gi), pr)+b
-    A = _shift_coeff_left(rem(t*a, hi), pr)+a
-#    check_data(A)
-#    check_data(B)
-
-    C.lf[j-1] = G
-    C.lf[j] = H
-    C.cf[j-1] = A
-    C.cf[j] = B
-    i -= 1
-    j -= 2
-  end
+  end # with_precision
 end
 
 mutable struct RootCtxSingle{T}
@@ -1025,42 +1025,43 @@ function field(RC::RootCtx, m::MatElem)
     end
     @vprintln :AbsFact 1  "using p-adic precision of $pr"
 
-    setprecision!(Qq, pr+1)
-    if length(fa) > 0
-      H.f = map_coefficients(Qq, _lc, parent = Qqt)
-      @vprintln :AbsFact 2 "lifting leading coeff factorisation"
-      @vtime :AbsFact 2 Hecke.lift(H, pr+1)
-      fH = factor(H)
-      lc = [prod(fH[i]^t[i] for i=1:length(t)) for t = fa]
-    end
+    p, el, fl = with_precision(Qq, pr + 1) do
+      if length(fa) > 0
+        H.f = map_coefficients(Qq, _lc, parent = Qqt)
+        @vprintln :AbsFact 2 "lifting leading coeff factorisation"
+        @vtime :AbsFact 2 Hecke.lift(H, pr+1)
+        fH = factor(H)
+        lc = [prod(fH[i]^t[i] for i=1:length(t)) for t = fa]
+      end
 
-    @vprintln :AbsFact 1 "lifting factors"
-    @vtime :AbsFact 2 while precision(coeff(coeff(HQ.lf[1], 0), 0)) < pr+1
-      lift_q(HQ)
-    end
+      @vprintln :AbsFact 1 "lifting factors"
+      @vtime :AbsFact 2 while precision(coeff(coeff(HQ.lf[1], 0), 0)) < pr+1
+        lift_q(HQ)
+      end
 
-    if length(fa) > 0
-      z = [lc[i](gen(SQq)) * HQ.lf[i] for i=1:HQ.n]
-    else
-      z = HQ.lf[1:HQ.n]
-    end
+      if length(fa) > 0
+        z = [lc[i](gen(SQq)) * HQ.lf[i] for i=1:HQ.n]
+      else
+        z = HQ.lf[1:HQ.n]
+      end
 
-    setprecision!(coeff(X, 1), pr+2)
-    setprecision!(coeff(Y, 1), pr+2)
-    el = [map_coefficients(q -> lift(Qqt, q)(Y), f, cached = false)(X) for f = z]
+      setprecision!(coeff(X, 1), pr+2)
+      setprecision!(coeff(Y, 1), pr+2)
+      el = [map_coefficients(q -> lift(Qqt, q)(Y), f, cached = false)(X) for f = z]
 
-#    # lift mod p^1 -> p^pr x^2+y^2+px+1 was bad I think
-#    @vtime :AbsFact 1 ok, el = lift_prime_power(P*inv(coeff(P, 1)), el, [0], 1, pr)
-#    ok || @vprintln :AbsFact 1 "bad prime found, q-adic lifting failed"
-#    ok || return nothing
-#    @assert ok  # can fail but should fail for only finitely many p
+#      # lift mod p^1 -> p^pr x^2+y^2+px+1 was bad I think
+#      @vtime :AbsFact 1 ok, el = lift_prime_power(P*inv(coeff(P, 1)), el, [0], 1, pr)
+#      ok || @vprintln :AbsFact 1 "bad prime found, q-adic lifting failed"
+#      ok || return nothing
+#      @assert ok  # can fail but should fail for only finitely many p
 
 
-    #to make things integral...
-    fl = Qq(llc) .* el
+      #to make things integral...
+      fl = Qq(llc) .* el
 
-    p = [coeff(sum(pe(x)^l for x = fl), 0) for l=1:length(el)]
-    p = map(rational_reconstruction, p)
+      p = [coeff(sum(pe(x)^l for x = fl), 0) for l=1:length(el)]
+      return map(rational_reconstruction, p), el, fl
+    end # with_precision
 
     if !all(x->x[1], p)
       @vprintln :AbsFact 2 "reco failed (for poly), increasing p-adic precision"
@@ -1083,25 +1084,27 @@ function field(RC::RootCtx, m::MatElem)
 
     @vprintln :AbsFact 1  "using as number field: $k"
 
-    m = transpose(matrix([[pe(x)^l for x = fl] for l=0:degree(k)-1]))
-    kx, x = polynomial_ring(k, "x", cached = false)
-    kX, _ = polynomial_ring(k, ["X", "Y"], cached = false)
-    B = MPolyBuildCtx(kX)
-    for j=1:length(el[1])
-      n = transpose(matrix([[coeff(x, j)] for x = fl]))
-      s = Hecke.solve(m, transpose(n); side = :right)
-      @assert all(x->iszero(coeff(s[x, 1], 1)), 1:degree(k))
-      s = [rational_reconstruction(coeff(s[i, 1], 0)) for i=1:degree(k)]
-      if !all(x->x[1], s)
-        break
+    q = with_precision(Qq, pr+1) do
+      m = transpose(matrix([[pe(x)^l for x = fl] for l=0:degree(k)-1]))
+      kx, x = polynomial_ring(k, "x", cached = false)
+      kX, _ = polynomial_ring(k, ["X", "Y"], cached = false)
+      B = MPolyBuildCtx(kX)
+      for j=1:length(el[1])
+        n = transpose(matrix([[coeff(x, j)] for x = fl]))
+        s = Hecke.solve(m, transpose(n); side = :right)
+        @assert all(x->iszero(coeff(s[x, 1], 1)), 1:degree(k))
+        s = [rational_reconstruction(coeff(s[i, 1], 0)) for i=1:degree(k)]
+        if !all(x->x[1], s)
+          break
+        end
+        push_term!(B, k([x[2]//x[3] for x = s]), exponent_vector(el[1], j))
       end
-      push_term!(B, k([x[2]//x[3] for x = s]), exponent_vector(el[1], j))
-    end
-    q = finish(B)
+      return finish(B)
+    end # with_precision
     if length(q) < length(el[1])
       continue
     end
-    b, r = divrem(map_coefficients(k, P, parent = kX), [q])
+    b, r = divrem(map_coefficients(k, P, parent = parent(q)), [q])
     if iszero(r)
       return q, b[1]
     end

--- a/src/NumField/NfAbs/PolyFact.jl
+++ b/src/NumField/NfAbs/PolyFact.jl
@@ -126,7 +126,7 @@ mutable struct HenselCtxPadic <: Hensel
     Zx = polynomial_ring(FlintZZ, cached = false)[1]
     ff = Zx()
     for i=0:degree(f)
-      setcoeff!(ff, i, lift(coeff(f, i)))
+      setcoeff!(ff, i, lift(ZZ, coeff(f, i)))
     end
     r.X = HenselCtx(ff, prime(base_ring(f)))
     start_lift(r.X, 1)
@@ -136,7 +136,7 @@ end
 
 function lift(C::HenselCtxPadic, mx::Int)
   for i=0:degree(C.f)
-    setcoeff!(C.X.f, i, lift(coeff(C.f, i)))
+    setcoeff!(C.X.f, i, lift(ZZ, coeff(C.f, i)))
   end
   continue_lift(C.X, mx)
 end
@@ -384,7 +384,7 @@ function zassenhaus(f::PolyRingElem{AbsSimpleNumFieldElem}, P::AbsNumFieldOrderI
       lf = factor(H)
 
       if degree(P) == 1
-        S = Set(map(x -> map_coefficients(y -> lift(y), x, parent = parent(f)), lf))
+        S = Set(map(x -> map_coefficients(y -> lift(ZZ, y), x, parent = parent(f)), lf))
       else
         S = Set(map(x -> map_coefficients(y -> preimage(mC, y), x, parent = parent(f)), lf))
       end
@@ -660,7 +660,7 @@ function van_hoeij(f::PolyRingElem{AbsSimpleNumFieldElem}, P::AbsNumFieldOrderId
     C = with_precision(codomain(mC), working_prec) do
       return with_precision(base_field(codomain(mC)), working_prec) do
         if degree(P) == 1
-          mD = MapFromFunc(K, base_ring(vH.H.f), x->coeff(mC(x),0), y->K(lift(y)))
+          mD = MapFromFunc(K, base_ring(vH.H.f), x->coeff(mC(x),0), y->K(lift(ZZ, y)))
           @vtime :PolyFactor 1 C = cld_data(vH.H, up_to, from, mD, vH.pM[1], den*leading_coefficient(f))
         else
           @vtime :PolyFactor 1 C = cld_data(vH.H, up_to, from, mC, vH.pM[1], den*leading_coefficient(f))
@@ -804,7 +804,7 @@ function van_hoeij(f::PolyRingElem{AbsSimpleNumFieldElem}, P::AbsNumFieldOrderId
               return with_precision(base_field(codomain(mC)), working_prec) do
                 a = prod(map(constant_coefficient, factor(vH.H)[v]))
                 if degree(P) == 1
-                  A = K(reco(order(P)(lift(a)), vH.Ml, vH.pMr))
+                  A = K(reco(order(P)(lift(ZZ, a)), vH.Ml, vH.pMr))
                 else
                   A = K(reco(order(P)(preimage(mC, a)), vH.Ml, vH.pMr))
                 end
@@ -824,7 +824,7 @@ function van_hoeij(f::PolyRingElem{AbsSimpleNumFieldElem}, P::AbsNumFieldOrderId
             return with_precision(base_field(codomain(mC)), working_prec) do
               @vtime :PolyFactor 2 g = prod(factor(vH.H)[v])
               if degree(P) == 1
-                @vtime :PolyFactor 2 G = parent(f)([K(reco(lift(coeff(mC(den*leading_coefficient(f)), 0)*coeff(g, l)), vH.Ml, vH.pMr, order(P))) for l=0:degree(g)])
+                @vtime :PolyFactor 2 G = parent(f)([K(reco(lift(ZZ, coeff(mC(den*leading_coefficient(f)), 0)*coeff(g, l)), vH.Ml, vH.pMr, order(P))) for l=0:degree(g)])
               else
                 @vtime :PolyFactor 2 G = parent(f)([K(reco(order(P)(preimage(mC, mC(den*leading_coefficient(f))*coeff(g, l))), vH.Ml, vH.pMr)) for l=0:degree(g)])
               end

--- a/src/NumField/NfAbs/PolyFact.jl
+++ b/src/NumField/NfAbs/PolyFact.jl
@@ -59,8 +59,9 @@ function lift(C::HenselCtxQadic, mx::Int = minimum(precision, coefficients(C.f))
   @vprintln :PolyFactor 1 "using lifting chain $ch"
   for k=length(ch)-1:-1:1
     N2 = ch[k]
-    setprecision!(Q, N2+1)
-    p = Q(prime(Q))^ch[k+1]
+    p = with_precision(Q, N2 + 1) do
+      Q(prime(Q))^ch[k+1]
+    end
     i = length(C.lf)
     j = i-1
     p = setprecision(p, N2)
@@ -84,7 +85,9 @@ function lift(C::HenselCtxQadic, mx::Int = minimum(precision, coefficients(C.f))
       fgh = (f-g*h)*inv(p)
       G = rem(fgh*b, g)*p+g
       H = rem(fgh*a, h)*p+h
-      t = (1-a*G-b*H)*inv(p)
+      t = with_precision(Q, N2 + 1) do
+        (1-a*G-b*H)*inv(p)
+      end
       B = rem(t*b, g)*p+b
       A = rem(t*a, h)*p+a
       if i < length(C.lf)
@@ -98,7 +101,10 @@ function lift(C::HenselCtxQadic, mx::Int = minimum(precision, coefficients(C.f))
       j -= 2
     end
   end
-  C.p = Q(prime(Q))^ch[1]
+  C.p = with_precision(Q, ch[1] + 1) do
+    Q(prime(Q))^ch[1]
+  end
+  return C.p
 end
 
 function factor(C::HenselCtxQadic)
@@ -357,32 +363,36 @@ function zassenhaus(f::PolyRingElem{AbsSimpleNumFieldElem}, P::AbsNumFieldOrderI
   N = ceil(Int, degree(K)/2/log(norm(P))*(log2(c1*c2) + 2*nbits(b)))
   @vprintln :PolyFactor 1 "using a precision of $N"
 
-  setprecision!(C, N)
+  S, M, pM = with_precision(C, N) do
+    return with_precision(base_field(C), N) do
+      vH = vanHoeijCtx()
+      if degree(P) == 1
+        vH.H = HenselCtxPadic(map_coefficients(x->coeff(mC(x), 0), f, cached = false))
+      else
+        vH.H = HenselCtxQadic(map_coefficients(mC, f, cached = false))
+      end
+      vH.C = C
+      vH.P = P
 
-  vH = vanHoeijCtx()
-  if degree(P) == 1
-    vH.H = HenselCtxPadic(map_coefficients(x->coeff(mC(x), 0), f, cached = false))
-  else
-    vH.H = HenselCtxQadic(map_coefficients(mC, f, cached = false))
-  end
-  vH.C = C
-  vH.P = P
+      @vtime :PolyFactor 1 grow_prec!(vH, N)
 
-  @vtime :PolyFactor 1 grow_prec!(vH, N)
+      H = vH.H
 
-  H = vH.H
+      M = vH.Ml
+      pM = vH.pMr
 
-  M = vH.Ml
-  pM = vH.pMr
+      lf = factor(H)
 
-  lf = factor(H)
+      if degree(P) == 1
+        S = Set(map(x -> map_coefficients(y -> lift(y), x, parent = parent(f)), lf))
+      else
+        S = Set(map(x -> map_coefficients(y -> preimage(mC, y), x, parent = parent(f)), lf))
+      end
+      return S, M, pM
+    end # with_precision base_field(C)
+  end # with_precision C
+
   zk = order(P)
-
-  if degree(P) == 1
-    S = Set(map(x -> map_coefficients(y -> lift(y), x, parent = parent(f)), lf))
-  else
-    S = Set(map(x -> map_coefficients(y -> preimage(mC, y), x, parent = parent(f)), lf))
-  end
   #TODO: test reco result for being small, do early abort
   #TODO: test selected coefficients first without computing the product
   #TODO: once a factor is found (need to enumerate by size!!!), remove stuff...
@@ -561,14 +571,16 @@ function van_hoeij(f::PolyRingElem{AbsSimpleNumFieldElem}, P::AbsNumFieldOrderId
   N = degree(f)
   @vprintln :PolyFactor 1  "Having $r local factors for degree $N"
 
-  setprecision!(C, 5)
-
   vH = vanHoeijCtx()
-  if degree(P) == 1
-    vH.H = HenselCtxPadic(map_coefficients(x->coeff(mC(x), 0), f, cached = false))
-  else
-    vH.H = HenselCtxQadic(map_coefficients(mC, f, cached = false))
-  end
+  with_precision(C, 5) do
+    return with_precision(base_field(C), 5) do
+      if degree(P) == 1
+        vH.H = HenselCtxPadic(map_coefficients(x->coeff(mC(x), 0), f, cached = false))
+      else
+        vH.H = HenselCtxQadic(map_coefficients(mC, f, cached = false))
+      end
+    end # with_precision base_field(C)
+  end # with_precision C
   vH.C = C
   vH.P = P
 
@@ -619,16 +631,18 @@ function van_hoeij(f::PolyRingElem{AbsSimpleNumFieldElem}, P::AbsNumFieldOrderId
     else
       i= sort(b)[div(length(b)+1, 2)]
     end
-    i = max(i, kk) #this seems to suggest, that prec is large enough to find factors! So the fail-2 works
-    @vprintln :PolyFactor 1 "setting prec to $i, and lifting the info ..."
-    setprecision!(codomain(mC), i)
-    if degree(P) == 1
-      vH.H.f = map_coefficients(x->coeff(mC(x), 0), f, cached = false)
-    else
-      vH.H.f = map_coefficients(mC, f, cached = false)
-    end
-    @vtime :PolyFactor 1 grow_prec!(vH, i)
-
+    working_prec = max(i, kk) #this seems to suggest, that prec is large enough to find factors! So the fail-2 works
+    @vprintln :PolyFactor 1 "setting prec to $working_prec, and lifting the info ..."
+    with_precision(codomain(mC), working_prec) do
+      return with_precision(base_field(codomain(mC)), working_prec) do
+        if degree(P) == 1
+          vH.H.f = map_coefficients(x->coeff(mC(x), 0), f, cached = false)
+        else
+          vH.H.f = map_coefficients(mC, f, cached = false)
+        end
+        @vtime :PolyFactor 1 grow_prec!(vH, i)
+      end # with_precision base_field(codomain(mC))
+    end # with_precision codomain(mC)
 
     av_bits = sum(nbits, vH.Ml)/degree(K)^2 #Ml: lll basis of P^i?
     @vprintln :PolyFactor 1 "obtaining CLDs..."
@@ -643,12 +657,17 @@ function van_hoeij(f::PolyRingElem{AbsSimpleNumFieldElem}, P::AbsNumFieldOrderId
     b = b[vcat(1:up_to, length(b)-(N-from-1):length(b))]
     have = vcat(0:up_to-1, from:N-2)  #N-1 is always 1
 
-    if degree(P) == 1
-      mD = MapFromFunc(K, base_ring(vH.H.f), x->coeff(mC(x),0), y->K(lift(y)))
-      @vtime :PolyFactor 1 C = cld_data(vH.H, up_to, from, mD, vH.pM[1], den*leading_coefficient(f))
-    else
-      @vtime :PolyFactor 1 C = cld_data(vH.H, up_to, from, mC, vH.pM[1], den*leading_coefficient(f))
-    end
+    C = with_precision(codomain(mC), working_prec) do
+      return with_precision(base_field(codomain(mC)), working_prec) do
+        if degree(P) == 1
+          mD = MapFromFunc(K, base_ring(vH.H.f), x->coeff(mC(x),0), y->K(lift(y)))
+          @vtime :PolyFactor 1 C = cld_data(vH.H, up_to, from, mD, vH.pM[1], den*leading_coefficient(f))
+        else
+          @vtime :PolyFactor 1 C = cld_data(vH.H, up_to, from, mC, vH.pM[1], den*leading_coefficient(f))
+        end
+        return C
+      end # with_precision base_field(codomain(mC))
+    end # with_precision codomain(mC)
 
     # In the end, p-adic precision needs to be large enough to
     # cover some CLDs. If you want the factors, it also has to
@@ -717,7 +736,7 @@ function van_hoeij(f::PolyRingElem{AbsSimpleNumFieldElem}, P::AbsNumFieldOrderId
 
       i = findfirst(x->x == n, have) #new data will be in block i of C
       @vprintln :PolyFactor 2 "trying to use coeff $n which is $i"
-      if b[i] > precision(codomain(mC))
+      if b[i] > working_prec
         @vprintln :PolyFactor 2 "not enough precision for CLD $i, $b, $(precision(codomain(mC))), skipping"
 
 #        error()
@@ -781,12 +800,17 @@ function van_hoeij(f::PolyRingElem{AbsSimpleNumFieldElem}, P::AbsNumFieldOrderId
         for v = values(d)
           #trivial test:
           if isone(den) && is_monic(f) #don't know what to do for non-monics
-            a = prod(map(constant_coefficient, factor(vH.H)[v]))
-            if degree(P) == 1
-              A = K(reco(order(P)(lift(a)), vH.Ml, vH.pMr))
-            else
-              A = K(reco(order(P)(preimage(mC, a)), vH.Ml, vH.pMr))
-            end
+            A = with_precision(codomain(mC), working_prec) do
+              return with_precision(base_field(codomain(mC)), working_prec) do
+                a = prod(map(constant_coefficient, factor(vH.H)[v]))
+                if degree(P) == 1
+                  A = K(reco(order(P)(lift(a)), vH.Ml, vH.pMr))
+                else
+                  A = K(reco(order(P)(preimage(mC, a)), vH.Ml, vH.pMr))
+                end
+                return A
+              end # with_precision base_field(codomain(mC))
+            end # with_precision codomain(mC)
             if denominator(divexact(constant_coefficient(f), A), order(P)) != 1
               @vprintln :PolyFactor 2 "Fail: const coeffs do not divide"
               push!(fail, v)
@@ -796,12 +820,17 @@ function van_hoeij(f::PolyRingElem{AbsSimpleNumFieldElem}, P::AbsNumFieldOrderId
               continue
             end
           end
-          @vtime :PolyFactor 2 g = prod(factor(vH.H)[v])
-          if degree(P) == 1
-            @vtime :PolyFactor 2 G = parent(f)([K(reco(lift(coeff(mC(den*leading_coefficient(f)), 0)*coeff(g, l)), vH.Ml, vH.pMr, order(P))) for l=0:degree(g)])
-          else
-            @vtime :PolyFactor 2 G = parent(f)([K(reco(order(P)(preimage(mC, mC(den*leading_coefficient(f))*coeff(g, l))), vH.Ml, vH.pMr)) for l=0:degree(g)])
-          end
+          G = with_precision(codomain(mC), working_prec) do
+            return with_precision(base_field(codomain(mC)), working_prec) do
+              @vtime :PolyFactor 2 g = prod(factor(vH.H)[v])
+              if degree(P) == 1
+                @vtime :PolyFactor 2 G = parent(f)([K(reco(lift(coeff(mC(den*leading_coefficient(f)), 0)*coeff(g, l)), vH.Ml, vH.pMr, order(P))) for l=0:degree(g)])
+              else
+                @vtime :PolyFactor 2 G = parent(f)([K(reco(order(P)(preimage(mC, mC(den*leading_coefficient(f))*coeff(g, l))), vH.Ml, vH.pMr)) for l=0:degree(g)])
+              end
+              return G
+            end # with_precision base_field(codomain(mC))
+          end # with_precision codomain(mC)
           G *= 1//(den*leading_coefficient(f))
 
           if !iszero(rem(f, G))

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -130,6 +130,7 @@ export abs2
 export abs_upper_bound
 export absolute_automorphism_group
 export absolute_automorphism_list
+export absolute_base_field
 export absolute_basis
 export absolute_basis_matrix
 export absolute_coordinates

--- a/test/LocalField/LocalField.jl
+++ b/test/LocalField/LocalField.jl
@@ -203,7 +203,7 @@
     Qp = PadicField(2, 100)
     Qpx, x = polynomial_ring(Qp)
     K, a = unramified_extension(x^2+x+1)
-    Qq, gQq = QadicField(2, 2, 100)
+    Qq, gQq = unramified_extension(Qp, 2, 100)
     rt = roots(map_coefficients(Qq, defining_polynomial(K)))
 
     f = @inferred hom(K, Qq, rt[1])

--- a/test/LocalField/neq.jl
+++ b/test/LocalField/neq.jl
@@ -36,7 +36,7 @@ end
   l2 = prime_decomposition(maximal_order(k), 2)
   k2, _ = Hecke.completion(k, l2[1][1], 120)
 
-  G, mG = automorphism_group(k2, prime_field(k2))
+  G, mG = automorphism_group(k2, absolute_base_field(k2))
   @test all([mG(x*y) == mG(x) * mG(y) for x = G for y = G])
 
 end
@@ -47,12 +47,12 @@ end
   l2 = prime_decomposition(maximal_order(k), 2)
   k2, _ = Hecke.completion(k, l2[1][1], 120)
 
-  G, mG = automorphism_group(k2, prime_field(k2))
+  G, mG = automorphism_group(k2, absolute_base_field(k2))
 
-  z = Hecke.local_fundamental_class_serre(k2, prime_field(k2))
-  for g = G 
-    for h = G 
-      for k = G 
+  z = Hecke.local_fundamental_class_serre(k2, absolute_base_field(k2))
+  for g = G
+    for h = G
+      for k = G
         a = z(mG(g), mG(h*k))*z(mG(h), mG(k)) - mG(k)(z(mG(g), mG(h)))*z(mG(g*h), mG(k))
          @test iszero(a) || valuation(a) > 20
        end
@@ -70,8 +70,8 @@ end
 
   for i=1:10
     #numerical problems with gen[1] : there is valuation...
-    u = sum(rand(-10:10)*x for x = gens(U)[2:end]) 
-    @test u == preimage(mU, mU(u))  
+    u = sum(rand(-10:10)*x for x = gens(U)[2:end])
+    @test u == preimage(mU, mU(u))
   end
 end
 


### PR DESCRIPTION
* Add a constructor `unramified_extension(::PadicField, ...)` for `QadicField`.
* Remove some 'illegal' `setprecision` calls on parent objects. I did not touch the various `setprecision!(::CompletionMap, ...)` methods which call `setprecision` on a parent object several times. I don't understand whether the precision of domain and codomain is important for the map or not. The only place I found where such a method is called is in the tests.

If we allow the construction of a `QadicField` both via `QadicField(::Int, ::Int)` and `unramified_extension(::PadicField, ::Int)` (so without and with the base field given), we have the following problem:
```
julia> K = PadicField(2)
Field of 2-adic numbers

julia> L, _ = QadicField(2, 2)
(Unramified extension of 2-adic numbers of degree 2, (2^0 + O(2^64))*a)

julia> base_field(L) === K
false

julia> L2, _ = unramified_extension(K, 2)
(Unramified extension of 2-adic numbers of degree 2, (2^0 + O(2^64))*a)

julia> L === L2 # the QadicField is cached
true

julia> base_field(L2) === K # unramified_extension set the base field in the attribute to K
true

julia> base_field(L) === K # the base field changed
true
```
