### PR TITLE
sparse_row: don't sort 1-element lists

### DIFF
--- a/src/Sparse/Row.jl
+++ b/src/Sparse/Row.jl
@@ -73,7 +73,6 @@ function sparse_row(R::Ring)
   return SRow(R)
 end
 
-const _sort = sort
 @doc raw"""
     sparse_row(R::Ring, J::Vector{Tuple{Int, T}}) -> SRow{T}
 
@@ -81,8 +80,8 @@ Constructs the sparse row $(a_i)_i$ with $a_{i_j} = x_j$, where $J = (i_j, x_j)_
 The elements $x_i$ must belong to the ring $R$.
 """
 function sparse_row(R::Ring, A::Vector{Tuple{Int, T}}; sort::Bool = true) where T
-  if sort
-    A = _sort(A, lt=(a,b) -> isless(a[1], b[1]))
+  if sort && length(A) > 1
+    A = Base.sort(A, lt=(a,b) -> isless(a[1], b[1]))
   end
   return SRow(R, A)
 end
@@ -94,8 +93,8 @@ Constructs the sparse row $(a_i)_i$ over $R$ with $a_{i_j} = x_j$,
 where $J = (i_j, x_j)_j$.
 """
 function sparse_row(R::Ring, A::Vector{Tuple{Int, Int}}; sort::Bool = true)
-  if sort
-    A = _sort(A, lt=(a,b)->isless(a[1], b[1]))
+  if sort && length(A) > 1
+    A = Base.sort(A, lt=(a,b) -> isless(a[1], b[1]))
   end
   return SRow(R, A)
 end
@@ -119,7 +118,7 @@ Constructs the sparse row $(a_i)_i$ over $R$ with $a_{i_j} = x_j$, where
 $J = (i_j)_j$ and $V = (x_j)_j$.
 """
 function sparse_row(R::Ring, pos::Vector{Int}, val::AbstractVector{T}; sort::Bool = true) where T
-  if sort
+  if sort && length(pos) > 1
     p = sortperm(pos)
     pos = pos[p]
     val = val[p]

--- a/src/Sparse/ZZRow.jl
+++ b/src/Sparse/ZZRow.jl
@@ -220,8 +220,8 @@ function ==(a::SRow{ZZRingElem, ZZRingElem_Array}, b::SRow{ZZRingElem, ZZRingEle
 end
 
 function sparse_row(R::ZZRing, A::Vector{Tuple{Int64, Int64}}; sort::Bool = true)
-  if sort
-    A = _sort(A, lt=(a,b)->isless(a[1], b[1]))
+  if sort && length(A) > 1
+    A = Base.sort(A, lt=(a,b)->isless(a[1], b[1]))
   end
   a = ZZRingElem_Array()
   sizehint!(a, length(A))
@@ -236,8 +236,8 @@ function sparse_row(R::ZZRing, A::Vector{Tuple{Int64, Int64}}; sort::Bool = true
 end
 
 function sparse_row(R::ZZRing, A::Vector{Tuple{Int64, ZZRingElem}}; sort::Bool = true)
-  if sort
-    A = _sort(A, lt=(a,b)->isless(a[1], b[1]))
+  if sort && length(A) > 1
+    A = Base.sort(A, lt=(a,b)->isless(a[1], b[1]))
   end
   a = ZZRingElem_Array()
   sizehint!(a, length(A))
@@ -252,7 +252,7 @@ function sparse_row(R::ZZRing, A::Vector{Tuple{Int64, ZZRingElem}}; sort::Bool =
 end
 
 function sparse_row(R::ZZRing, pos::Vector{Int64}, val::AbstractVector{T}; sort::Bool = true) where T
-  if sort
+  if sort && length(pos) > 1
     p = sortperm(pos)
     pos = pos[p]
     val = val[p]


### PR DESCRIPTION
This is obviously pointless and incurs allocations. At the same time it
is a relatively common case in Oscar, so optimizing this pays off.
