### PR TITLE
Repair _torsion_units_lattice_enum

### DIFF
--- a/src/NumFieldOrd/NfOrd/TorsionUnits.jl
+++ b/src/NumFieldOrd/NfOrd/TorsionUnits.jl
@@ -217,12 +217,11 @@ function _torsion_units_lattice_enum(O::AbsSimpleNumFieldOrder)
 
   could_enumerate = false
 
-  A = ArbField(p, false)
-  M = ArbMatSpace(A, n, n,false)()
+  local A, M
 
   while true
-    A = ArbField(p, false)
-    M = ArbMatSpace(A, n, n, false)()
+    A = ArbField(p; cached=false)
+    M = zero_matrix(A, n, n)
 
     gram_found = true
 

--- a/test/NfOrd/TorsionUnits.jl
+++ b/test/NfOrd/TorsionUnits.jl
@@ -15,4 +15,8 @@
     @test !isone(gen^p)
     @test !isone(gen^2)
   end
+
+  K, a = cyclotomic_field(13, cached = false)
+  O = maximal_order(K)
+  @test (@inferred length(Hecke._torsion_units_lattice_enum(O)[1])) == 26
 end


### PR DESCRIPTION
I verified it works again via this:
```
julia> K, a = cyclotomic_field(13, cached = false);

julia> O = maximal_order(K);

julia> G, mG = torsion_unit_group(O)
(Z/26, Map: G -> O)

julia> length(Hecke._torsion_units_lattice_enum(O)[1])
26
```
Either something like that should be turned into a test -- or alternatively this undocumented function could be deleted, as nothing calls it.

