### PR TITLE
Change _zero_algebra -> zero_algebra

### DIFF
--- a/src/AlgAss/AlgAss.jl
+++ b/src/AlgAss/AlgAss.jl
@@ -190,7 +190,7 @@ end
 # Does anyone actually use this?
 function StructureConstantAlgebra(R::Ring, d::Int, arr::Vector{T}) where {T}
   if d == 0
-    return _zero_algebra(R)
+    return zero_algebra(R)
   end
   mult_table = Array{T, 3}(undef, d, d, d)
   n = d^2
@@ -302,7 +302,7 @@ function StructureConstantAlgebra(O::Union{AbsNumFieldOrder, AlgAssAbsOrd}, I::U
   Fp = GF(p, cached = false)
 
   if r == 0
-    A = _zero_algebra(Fp)
+    A = zero_algebra(Fp)
 
     local _image_zero
 
@@ -430,7 +430,7 @@ function StructureConstantAlgebra(I::Union{ AbsNumFieldOrderIdeal, AlgAssAbsOrdI
   Fp = GF(p, cached = false)
 
   if r == 0
-    A = _zero_algebra(Fp)
+    A = zero_algebra(Fp)
 
     local _image_zero
 
@@ -574,7 +574,7 @@ function StructureConstantAlgebra(O::Union{ RelNumFieldOrder{T, S}, AlgAssRelOrd
   r = length(basis_elts)
 
   if r == 0
-    A = _zero_algebra(Fp)
+    A = zero_algebra(Fp)
 
     local _image_zero
 
@@ -729,7 +729,7 @@ function StructureConstantAlgebra(I::Union{ RelNumFieldOrderIdeal{T, S}, AlgAssR
   r = length(basis_elts)
 
   if r == 0
-    A = _zero_algebra(Fp)
+    A = zero_algebra(Fp)
 
     local _image_zero
 
@@ -995,7 +995,7 @@ function subalgebra(A::StructureConstantAlgebra{T}, e::AssociativeAlgebraElem{T,
   r = size(mult_table, 1)
 
   if r == 0
-    eA = _zero_algebra(R)
+    eA = zero_algebra(R)
     return eA, hom(eA, A, zero_matrix(R, 0, n))
   end
 

--- a/src/AlgAssAbsOrd/LocallyFreeClassGroup.jl
+++ b/src/AlgAssAbsOrd/LocallyFreeClassGroup.jl
@@ -336,7 +336,7 @@ function _unit_group_generators(A::MatAlgebra{<:FinFieldElem})
     @assert is_unit(det(g2))
     push!(res, g1, g2)
   end
-  return map(A, res)
+  return map(A, res)::Vector{elem_type(A)}
 end
 
 # Computes generators for 1 + J where J is the Jacobson Radical of A

--- a/src/GenOrd/Ideal.jl
+++ b/src/GenOrd/Ideal.jl
@@ -749,7 +749,7 @@ function Hecke.StructureConstantAlgebra(O::GenOrd, I::GenOrdIdl, p::RingElem)
   FQ, phi = residue_field(O.R,p)
 
   if r == 0
-    A = _zero_algebra(FQ)
+    A = zero_algebra(FQ)
 
     local _image_zero
 

--- a/src/Misc/Poly.jl
+++ b/src/Misc/Poly.jl
@@ -728,7 +728,8 @@ end
 function _roots(f::QQPolyRingElem, ::PosInf; prec::Int=64)
   g = squarefree_part(f)
   all_rts = _roots(g, prec)
-  rl_rts = real.(filter(isreal, all_rts))
+  # real.(filter(...)) leads to worse type inference
+  rl_rts = map(real, (filter(isreal, all_rts)))
   compl_rts = filter(x -> !isreal(x) && is_positive(imag(x)), all_rts)
   @assert length(rl_rts) + 2 * length(compl_rts) == degree(g)
   return all_rts, rl_rts, compl_rts


### PR DESCRIPTION
The function _zero_algebra was renamed to zero_algebra some time ago, but not all places calling it were updated.

I found this because it caused a bunch of invalidations in code found while investigating #746 (indirectly, of course, as any actual call to `_zero_algebra` could not have worked).