### PR TITLE
Simplify MatAlgebraElem type params

### DIFF
--- a/src/AlgAss/AlgMat.jl
+++ b/src/AlgAss/AlgMat.jl
@@ -18,7 +18,7 @@ basis(A::MatAlgebra) = A.basis
 
 has_one(A::MatAlgebra) = true
 
-elem_type(::Type{MatAlgebra{T, S}}) where { T, S } = MatAlgebraElem{T, MatAlgebra{T, S}, S}
+elem_type(::Type{MatAlgebra{T, S}}) where { T, S } = MatAlgebraElem{T, S}
 
 order_type(::MatAlgebra{QQFieldElem, S}) where { S } = AlgAssAbsOrd{MatAlgebra{QQFieldElem, S}, elem_type(MatAlgebra{QQFieldElem, S})}
 order_type(::Type{MatAlgebra{QQFieldElem, S}}) where { S } = AlgAssAbsOrd{MatAlgebra{QQFieldElem, S}, elem_type(MatAlgebra{QQFieldElem, S})}

--- a/src/AlgAss/AlgMatElem.jl
+++ b/src/AlgAss/AlgMatElem.jl
@@ -1,4 +1,4 @@
-parent_type(::Type{MatAlgebraElem{T, S, Mat}}) where {T, S, Mat} = S
+parent_type(::Type{MatAlgebraElem{T, S}}) where {T, S} = MatAlgebra{T, S}
 
 @doc raw"""
     matrix(a::MatAlgebraElem; copy::Bool = true) -> MatElem
@@ -80,7 +80,7 @@ end
 #
 ################################################################################
 
-function +(a::MatAlgebraElem{T, S, V}, b::MatAlgebraElem{T, S, V}) where {T, S, V}
+function +(a::T, b::T) where {T <: MatAlgebraElem}
   parent(a) != parent(b) && error("Parents don't match.")
   c = parent(a)(matrix(a, copy = false) + matrix(b, copy = false), check = false)
   if a.has_coeffs && b.has_coeffs
@@ -90,7 +90,7 @@ function +(a::MatAlgebraElem{T, S, V}, b::MatAlgebraElem{T, S, V}) where {T, S, 
   return c
 end
 
-function -(a::MatAlgebraElem{T, S, V}, b::MatAlgebraElem{T, S, V}) where {T, S, V}
+function -(a::T, b::T) where {T <: MatAlgebraElem}
   parent(a) != parent(b) && error("Parents don't match.")
   c = parent(a)(matrix(a, copy = false) - matrix(b, copy = false))
   if a.has_coeffs && b.has_coeffs
@@ -116,7 +116,7 @@ function zero!(a::MatAlgebraElem)
   return a
 end
 
-function add!(c::MatAlgebraElem{T, S, V}, a::MatAlgebraElem{T, S, V}, b::MatAlgebraElem{T, S, V}) where {T, S, V}
+function add!(c::T, a::T, b::T) where {T <: MatAlgebraElem}
   parent(a) != parent(b) && error("Parents don't match.")
   parent(c) != parent(b) && error("Parents don't match.")
   A = parent(a)
@@ -133,7 +133,7 @@ function add!(c::MatAlgebraElem{T, S, V}, a::MatAlgebraElem{T, S, V}, b::MatAlge
   return c
 end
 
-function mul!(c::MatAlgebraElem{T, S, V}, a::MatAlgebraElem{T, S, V}, b::MatAlgebraElem{T, S, V}) where {T, S, V}
+function mul!(c::T, a::T, b::T) where {T <: MatAlgebraElem}
   parent(a) != parent(b) && error("Parents don't match.")
   A = parent(a)
 
@@ -171,12 +171,12 @@ function *(b::T, a::MatAlgebraElem) where {T <: RingElem}
   return A(b*matrix(a, copy = false), check = false)::elem_type(A)
 end
 
-function *(a::MatAlgebraElem{S, T, U}, b::U) where { S, T, U <: MatElem }
+function *(a::MatAlgebraElem{T,S}, b::S) where { T, S <: MatElem }
   A = parent(a)
   return A(matrix(a, copy = false)*b, check = false)
 end
 
-function *(b::U, a::MatAlgebraElem{S, T, U}) where { S, T, U <: MatElem }
+function *(b::S, a::MatAlgebraElem{T,S}) where { T, S <: MatElem }
   A = parent(a)
   return A(b*matrix(a, copy = false), check = false)
 end
@@ -242,12 +242,12 @@ function (A::MatAlgebra{T, S})(M::S; check::Bool = true, deepcopy::Bool = true) 
   if check
     b, c = _check_matrix_in_algebra(M, A)
     @req b "Matrix not an element of the matrix algebra"
-    z = MatAlgebraElem{T, typeof(A), S}(A, deepcopy ? Base.deepcopy(M) : M)
+    z = MatAlgebraElem{T, S}(A, deepcopy ? Base.deepcopy(M) : M)
     z.coeffs = c
     z.has_coeffs = true
     return z
   else
-    return MatAlgebraElem{T, typeof(A), S}(A, deepcopy ? Base.deepcopy(M) : M)
+    return MatAlgebraElem{T, S}(A, deepcopy ? Base.deepcopy(M) : M)
   end
 end
 
@@ -294,7 +294,7 @@ end
 
 Returns `true` if $a$ and $b$ are equal and `false` otherwise.
 """
-function ==(a::MatAlgebraElem{T, S, V}, b::MatAlgebraElem{T, S, V}) where {T, S, V}
+function ==(a::T, b::T) where {T <: MatAlgebraElem}
   parent(a) != parent(b) && return false
   return matrix(a, copy = false) == matrix(b, copy = false)
 end

--- a/src/AlgAss/Types.jl
+++ b/src/AlgAss/Types.jl
@@ -275,7 +275,7 @@ end
 ################################################################################
 
 # T == elem_type(base_ring), S == dense_matrix_type(coefficient_ring)
-@attributes mutable struct MatAlgebra{T, S} <: AbstractAssociativeAlgebra{T}
+@attributes mutable struct MatAlgebra{T, S <: MatElem} <: AbstractAssociativeAlgebra{T}
   base_ring::Ring
   coefficient_ring::NCRing
   one::S
@@ -322,22 +322,22 @@ end
   end
 end
 
-mutable struct MatAlgebraElem{T, S, Mat} <: AbstractAssociativeAlgebraElem{T}
-  parent::S
-  matrix::Mat # over the coefficient ring of the parent
+mutable struct MatAlgebraElem{T, S <: MatElem} <: AbstractAssociativeAlgebraElem{T}
+  parent::MatAlgebra{T, S}
+  matrix::S # over the coefficient ring of the parent
   coeffs::Vector{T} # over the base ring of the parent
   has_coeffs::Bool
 
-  function MatAlgebraElem{T, S, Mat}(A::S) where {T, S, Mat}
-    z = new{T, S, Mat}()
+  function MatAlgebraElem{T, S}(A::MatAlgebra{T, S}) where {T, S}
+    z = new{T, S}()
     z.parent = A
     z.matrix = zero_matrix(base_ring(A), degree(A), degree(A))
     z.has_coeffs = false
     return z
   end
 
-  function MatAlgebraElem{T, S, Mat}(A::S, M::Mat) where {T, S, Mat}
-    z = new{T, S, Mat}()
+  function MatAlgebraElem{T, S}(A::MatAlgebra{T, S}, M::S) where {T, S}
+    z = new{T, S}()
     z.parent = A
     z.matrix = M
     z.has_coeffs = false


### PR DESCRIPTION
The second type param is fully determined by the first and third,
so get rid of it.
