### PR TITLE
Replace some `setprecision!(::ParentObject)`

### DIFF
--- a/examples/NFDB.jl
+++ b/examples/NFDB.jl
@@ -1196,7 +1196,7 @@ function _p_adic_regulator_coates(K::AbsSimpleNumField, p::IntegerUnion)
   while true
     (prec > 2^12 || working_prec > 2^12) && error("Something wrong")
     imK =[QadicRingElem{PadicField, PadicFieldElem}[] for i in 1:degK]
-    Qp = PadicField(p, prec, cached = false)
+    Qp = padic_field(p, precision = prec, cached = false)
     Zp = ring_of_integers(Qp)
     dK = discriminant(OK)
     r = maximum([ramification_index(P) for P in dp])
@@ -1443,7 +1443,7 @@ mutable struct NFDBGeneric{T, S}
     return z
   end
 end
-   
+
 function NFDBGeneric(L::Vector{RelSimpleNumField{AbsSimpleNumFieldElem}})
   res = NFDBGeneric{1, eltype(L)}()
   for K in L

--- a/examples/Plesken.jl
+++ b/examples/Plesken.jl
@@ -183,7 +183,7 @@ function primitive_root_r_div_qm1(R, r::Int)
 end
 
 function get_f(r::Int, p::ZZRingElem, s::Int)
-  R = PadicField(r, s)
+  R = padic_field(r, precision = s)
   return lift(teichmuller(R(p)))
 end
 # plan

--- a/examples/Tropics.jl
+++ b/examples/Tropics.jl
@@ -84,7 +84,7 @@ lp[1].gen_two*lp[2].gen_two^2
 ma = representation_matrix(a)
 mb = representation_matrix(k(ans))
 @assert iszero(ma*mb - mb*ma)
-Qp = PadicField(7, 10)
+Qp = padic_field(7, precision = 10)
 Main.TropicalModule.simultaneous_diagonalization([map_entries(Qp, ma), map_entries(Qp, mb)])
 
 =#

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -269,3 +269,8 @@ end
 
 @deprecate hom(G::FinGenAbGroup, H::FinGenAbGroup, A::Matrix{ <: Map{FinGenAbGroup, FinGenAbGroup}}) hom_direct_sum(G, H, A)
 @deprecate hom(G::FinGenAbGroup, H::FinGenAbGroup, A::Vector{ <: Map{FinGenAbGroup, FinGenAbGroup}}) hom_tensor(G, H, A)
+
+# Deprecated in 0.32
+
+@deprecate lift(a::QadicRingElem) lift(ZZ, a)
+@deprecate prime_field(L::Union{QadicField, LocalField}) absolute_base_field(L)

--- a/src/HeckeTypes.jl
+++ b/src/HeckeTypes.jl
@@ -2239,11 +2239,11 @@ mutable struct qAdicRootCtx
     lf = Hecke.factor_mod_pk(Array, H, 1)
     if splitting_field
       d = lcm([degree(y[1]) for y = lf])
-      R = QadicField(p, d, 1)[1]
+      R = qadic_field(p, d, precision = 1)[1]
       Q = [R]
       r.is_splitting = true
     else
-      Q = [QadicField(p, x, 1)[1] for x = Set(degree(y[1]) for y = lf)]
+      Q = [qadic_field(p, x, precision = 1)[1] for x = Set(degree(y[1]) for y = lf)]
       r.is_splitting = false
     end
     @assert all(x->isone(x[2]), lf)

--- a/src/LocalField/Completions.jl
+++ b/src/LocalField/Completions.jl
@@ -336,7 +336,7 @@ function setprecision!(f::CompletionMap{LocalField{QadicFieldElem, EisensteinLoc
     gq = _increase_precision(gq, pol_gq, div(f.precision+e-1, e), ex, P)
     f.inv_img = (gq, f.inv_img[2])
 
-    Zp = maximal_order(prime_field(Kp))
+    Zp = maximal_order(absolute_base_field(Kp))
     Qq = base_field(Kp)
 
     setprecision!(Qq, ex)

--- a/src/LocalField/Completions.jl
+++ b/src/LocalField/Completions.jl
@@ -173,9 +173,9 @@ The map giving the embedding of $K$ into the completion, admits a pointwise
 preimage to obtain a lift. Note, that the map is not well defined by this
 data: $K$ will have $\deg P$ many embeddings.
 
-The map is guaranteed to yield a relative precision of at least `preciscion`.
+The map is guaranteed to yield a relative precision of at least `precision`.
 """
-function completion(K::AbsSimpleNumField, P::AbsNumFieldOrderIdeal{AbsSimpleNumField, AbsSimpleNumFieldElem}, precision::Int = 64)
+function completion(K::AbsSimpleNumField, P::AbsNumFieldOrderIdeal{AbsSimpleNumField, AbsSimpleNumFieldElem}, precision::Int = 64, Qp::Union{PadicField,Nothing} = nothing)
   #to guarantee a rel_prec we need to account for the index (or the
   #elementary divisor of the trace mat): the map
   #is for the field (equation order), the precision is measured in the
@@ -189,9 +189,11 @@ function completion(K::AbsSimpleNumField, P::AbsNumFieldOrderIdeal{AbsSimpleNumF
   f = degree(P)
   e = ramification_index(P)
   prec_padics = div(precision+e-1, e)
-  Qp = PadicField(minimum(P), prec_padics, cached = false)
+  if isnothing(Qp)
+    Qp = PadicField(minimum(P), prec_padics, cached = false)
+  end
   Zp = maximal_order(Qp)
-  Qq, gQq = QadicField(minimum(P), f, prec_padics, cached = false)
+  Qq, gQq = unramified_extension(Qp, f, precision = prec_padics, cached = false)
   Qqx, gQqx = polynomial_ring(Qq, "x")
   q, mq = residue_field(Qq)
   #F, mF = ResidueFieldSmall(OK, P)
@@ -264,53 +266,50 @@ function _solve_internal(gq_in_K, P, precision, Zp, Qq)
     mul!(bK.num, bK.num, divexact(d, denominator(bK, copy = false)))
   end
 
-  setprecision!(Zp, Hecke.precision(Zp) + valuation(Zp(denominator(MK))))
-
-if true
-  #snf is slower (possibly) but has optimal precision loss.
-  #bad example is completion at prime over 2 in
-  # x^8 - 12*x^7 + 44*x^6 - 24*x^5 - 132*x^4 + 120*x^3 + 208*x^2 - 528*x + 724
-  # the can_solve... returns a precision of just 6 p-adic digits
-  # the snf gets 16 (both for the default precision)
-  # the det(M) has valuation 12, but the elem. divisors only 3
-  #TODO: rewrite can_solve? look at Avi's stuff?
-  # x M = b
-  # u*M*v = s
-  # x inv(u) u M v = b v
-  # x inv(u)   s   = b v
-  # x = b v inv(s) u
-  #lets try:
-  s, _u, v = snf_with_transform(MK.num)
-  bv = bK.num * v
-  bv = map_entries(Zp, bv)
-  for i=1:ncols(s)
-    bv[1, i] = divexact(bv[1, i], Zp(s[i,i]))
-    bv[2, i] = divexact(bv[2, i], Zp(s[i,i]))
-  end
-  xZp = bv * map_entries(Zp, _u[1:ncols(s), 1:ncols(s)])
-else
-  MZp = map_entries(Zp, MK.num)
-  bZp = map_entries(Zp, bK.num)
-  fl, xZp = can_solve_with_solution(MZp, bZp, side = :left)
-  @assert fl
-end
-  coeffs_eisenstein = Vector{QadicFieldElem}(undef, e+1)
-  gQq = gen(Qq)
-  for i = 1:e
-    coeff = zero(Qq)
-    for j = 0:f-1
-      coeff += (gQq^j)*xZp[1, j+1+(i-1)*f].x
+  return with_precision(Zp, Hecke.precision(Zp) + valuation(Zp(denominator(MK)))) do
+    if true
+      #snf is slower (possibly) but has optimal precision loss.
+      #bad example is completion at prime over 2 in
+      # x^8 - 12*x^7 + 44*x^6 - 24*x^5 - 132*x^4 + 120*x^3 + 208*x^2 - 528*x + 724
+      # the can_solve... returns a precision of just 6 p-adic digits
+      # the snf gets 16 (both for the default precision)
+      # the det(M) has valuation 12, but the elem. divisors only 3
+      #TODO: rewrite can_solve? look at Avi's stuff?
+      # x M = b
+      # u*M*v = s
+      # x inv(u) u M v = b v
+      # x inv(u)   s   = b v
+      # x = b v inv(s) u
+      #lets try:
+      s, _u, v = snf_with_transform(MK.num)
+      bv = bK.num * v
+      bv = map_entries(Zp, bv)
+      for i=1:ncols(s)
+        bv[1, i] = divexact(bv[1, i], Zp(s[i,i]))
+        bv[2, i] = divexact(bv[2, i], Zp(s[i,i]))
+      end
+      xZp = bv * map_entries(Zp, _u[1:ncols(s), 1:ncols(s)])
+    else
+      MZp = map_entries(Zp, MK.num)
+      bZp = map_entries(Zp, bK.num)
+      xZp = solve(MZp, bZp, side = :left)
     end
-    coeffs_eisenstein[i] = -coeff
-  end
-  coeffs_eisenstein[e+1] = one(Qq)
-  if iszero(coeffs_eisenstein[1])
-    error("precision not high enough to obtain Esenstein polynomial")
-  end
-  return coeffs_eisenstein, xZp
+    coeffs_eisenstein = Vector{QadicFieldElem}(undef, e+1)
+    gQq = gen(Qq)
+    for i = 1:e
+      coeff = zero(Qq)
+      for j = 0:f-1
+        coeff += (gQq^j)*xZp[1, j+1+(i-1)*f].x
+      end
+      coeffs_eisenstein[i] = -coeff
+    end
+    coeffs_eisenstein[e+1] = one(Qq)
+    if iszero(coeffs_eisenstein[1])
+      error("precision not high enough to obtain Esenstein polynomial")
+    end
+    return coeffs_eisenstein, xZp
+  end # with_precision
 end
-
-
 
 function setprecision!(f::CompletionMap{LocalField{QadicFieldElem, EisensteinLocalField}, LocalFieldElem{QadicFieldElem, EisensteinLocalField}}, new_prec::Int)
   P = prime(f)

--- a/src/LocalField/Completions.jl
+++ b/src/LocalField/Completions.jl
@@ -190,7 +190,7 @@ function completion(K::AbsSimpleNumField, P::AbsNumFieldOrderIdeal{AbsSimpleNumF
   e = ramification_index(P)
   prec_padics = div(precision+e-1, e)
   if isnothing(Qp)
-    Qp = PadicField(minimum(P), prec_padics, cached = false)
+    Qp = padic_field(minimum(P), precision = prec_padics, cached = false)
   end
   Zp = maximal_order(Qp)
   Qq, gQq = unramified_extension(Qp, f, precision = prec_padics, cached = false)
@@ -383,7 +383,7 @@ function totally_ramified_completion(K::AbsSimpleNumField, P::AbsNumFieldOrderId
   @assert nf(OK) == K
   @assert isone(degree(P))
   e = ramification_index(P)
-  Qp = PadicField(minimum(P), precision)
+  Qp = padic_field(minimum(P), precision = precision)
   Zp = maximal_order(Qp)
   Zx = FlintZZ["x"][1]
   Qpx = polynomial_ring(Qp, "x")[1]
@@ -442,7 +442,7 @@ function setprecision!(f::CompletionMap{LocalField{PadicFieldElem, EisensteinLoc
     if r > 0
       ex += 1
     end
-    Qp = PadicField(prime(Kp), div(new_prec, e)+1)
+    Qp = padic_field(prime(Kp), precision = div(new_prec, e)+1)
     Zp = maximal_order(Qp)
     Qpx, _ = polynomial_ring(Qp, "x")
     pows_u = powers(u, e-1)
@@ -494,8 +494,8 @@ function unramified_completion(K::AbsSimpleNumField, P::AbsNumFieldOrderIdeal{Ab
   @assert isone(ramification_index(P))
   f = degree(P)
   p = minimum(P)
-  Qq, gQq = QadicField(p, f, precision)
-  Qp = PadicField(p, precision)
+  Qq, gQq = qadic_field(p, f, precision = precision)
+  Qp = padic_field(p, precision = precision)
   Zp = maximal_order(Qp)
   q, mq = residue_field(Qq)
   F, mF = residue_field(OK, P)

--- a/src/LocalField/Conjugates.jl
+++ b/src/LocalField/Conjugates.jl
@@ -19,14 +19,14 @@ function newton_lift(f::ZZPolyRingElem, r::QadicFieldElem, prec::Int = parent(r)
   for p = reverse(chain)
     setprecision!(r, p)
     setprecision!(o, p)
-    Q.prec_max = r.N
+    setprecision!(Q, r.N)
     if r.N > precision(Q)
       setprecision!(qf, r.N)
       setprecision!(qfs, r.N)
     end
     r = r - qf(r)*o
     if r.N >= n
-      Q.prec_max = n
+      setprecision!(Q, n)
       return r
     end
     o = o*(2-qfs(r)*o)
@@ -93,7 +93,7 @@ function roots(C::qAdicRootCtx, n::Int = 10)
   lf = factor_mod_pk(Array, C.H, n)
   rt = QadicFieldElem[]
   for Q = C.Q
-    Q.prec_max = n
+    setprecision!(Q, n)
     for x = lf
       if is_splitting(C) || degree(x[1]) == degree(Q)
         append!(rt, roots(Q, x[1], max_roots = 1))

--- a/src/LocalField/Conjugates.jl
+++ b/src/LocalField/Conjugates.jl
@@ -1,5 +1,5 @@
 #XXX: valuation(Q(0)) == 0 !!!!!
-function newton_lift(f::ZZPolyRingElem, r::QadicFieldElem, prec::Int = parent(r).prec_max, starting_prec::Int = 2)
+function newton_lift(f::ZZPolyRingElem, r::QadicFieldElem, prec::Int = precision(parent(r)), starting_prec::Int = 2)
   Q = parent(r)
   n = prec
   i = n
@@ -15,28 +15,26 @@ function newton_lift(f::ZZPolyRingElem, r::QadicFieldElem, prec::Int = parent(r)
   o = Q(r)
   s = qf(r)
   o = inv(setprecision(qfs, 1)(o))
-  @assert r.N == 1
+  @assert precision(r) == 1
   for p = reverse(chain)
     setprecision!(r, p)
     setprecision!(o, p)
-    setprecision!(Q, r.N)
-    if r.N > precision(Q)
-      setprecision!(qf, r.N)
-      setprecision!(qfs, r.N)
+    r = with_precision(Q, p) do
+      r - qf(r)*o
     end
-    r = r - qf(r)*o
-    if r.N >= n
-      setprecision!(Q, n)
+    if precision(r) >= n
       return r
     end
-    o = o*(2-qfs(r)*o)
+    o = with_precision(Q, p) do
+      o*(2-qfs(r)*o)
+    end
   end
   return r
 end
 
-function newton_lift(f::ZZPolyRingElem, r::LocalFieldElem, precision::Int = parent(r).prec_max, starting_prec::Int = 2)
+function newton_lift(f::ZZPolyRingElem, r::LocalFieldElem, prec::Int = precision(parent(r)), starting_prec::Int = 2)
   Q = parent(r)
-  n = precision
+  n = prec
   i = n
   chain = [n]
   while i > starting_prec
@@ -53,15 +51,17 @@ function newton_lift(f::ZZPolyRingElem, r::LocalFieldElem, precision::Int = pare
   for p = reverse(chain)
     r = setprecision!(r, p)
     o = setprecision!(o, p)
-    setprecision!(Q, p)
     setprecision!(qf, p)
     setprecision!(qfs, p)
-    r = r - qf(r)*o
-    if Nemo.precision(r) >= n
-      setprecision!(Q, n)
+    r = with_precision(Q, p) do
+      return r - qf(r)*o
+    end
+    if precision(r) >= n
       return r
     end
-    o = o*(2-qfs(r)*o)
+    o = with_precision(Q, p) do
+      return o*(2-qfs(r)*o)
+    end
   end
   return r
 end
@@ -93,10 +93,11 @@ function roots(C::qAdicRootCtx, n::Int = 10)
   lf = factor_mod_pk(Array, C.H, n)
   rt = QadicFieldElem[]
   for Q = C.Q
-    setprecision!(Q, n)
     for x = lf
       if is_splitting(C) || degree(x[1]) == degree(Q)
-        append!(rt, roots(Q, x[1], max_roots = 1))
+        with_precision(Q, n) do
+          append!(rt, roots(Q, x[1], max_roots = 1))
+        end
       end
     end
   end
@@ -222,12 +223,14 @@ end
 function _conjugates(a::AbsSimpleNumFieldElem, C::qAdicConj, n::Int, op::Function)
   R = roots(C.C, n)
   @assert parent(a) == C.K
-  Zx = polynomial_ring(FlintZZ, cached = false)[1]
+  Zx = polynomial_ring(ZZ, cached = false)[1]
   d = denominator(a)
   f = Zx(d*a)
   res = QadicFieldElem[]
   for x = R
-    a = op(inv(parent(x)(d))*f(x))::QadicFieldElem
+    a = with_precision(parent(x), n) do
+      op(inv(parent(x)(d))*f(x))::QadicFieldElem
+    end
     push!(res, a)
   end
   return res
@@ -272,11 +275,13 @@ function conjugates_log(a::FacElem{AbsSimpleNumFieldElem, AbsSimpleNumField}, C:
   for (k, v) = a.fac
     try
       y = conjugates_log(k, C, n, flat = false, all = false)
+      # vy = v .* y but we need to be careful with the precision of v
+      vy = QadicFieldElem[parent(yy)(v, precision = n) * yy for yy in y]
       if first
-        res = v .* y
+        res = vy
         first = false
       else
-        res += v .* y
+        res += vy
       end
     catch e
       if isa(e, DivideError) || isa(e, DomainError)
@@ -286,11 +291,13 @@ function conjugates_log(a::FacElem{AbsSimpleNumFieldElem, AbsSimpleNumField}, C:
         pe = prod(lp[i][1].gen_two^val[i] for i = 1:length(lp) if val[i] != 0)
         aa = k//pe
         y = conjugates_log(aa, C, n, all = false, flat = false)
+        # vy = v .* y but we need to be careful with the precision of v
+        vy = QadicFieldElem[parent(yy)(v, precision = n) * yy for yy in y]
         if first
-          res = v .* y
+          res = vy
           first = false
         else
-          res += v .* y
+          res += vy
         end
       else
         rethrow(e)
@@ -308,18 +315,22 @@ end
 
 function special_gram(m::Vector{Vector{QadicFieldElem}})
   g = Vector{PadicFieldElem}[]
+  if isempty(m)
+    return g
+  end
+  K = base_field(parent(m[1][1]))
   for i = m
     r = PadicFieldElem[]
     for j = m
       k = 1
-      S = 0
+      S = K()
       while k <= length(i)
         s = i[k] * j[k]
         for l = 1:degree(parent(s))-1
           s += i[k+l] * j[k+l]
         end
         S += coeff(s, 0)
-        @assert s == coeff(s, 0)
+        @assert length(s) == 1
         k += degree(parent(s))
       end
       push!(r, S)
@@ -347,7 +358,11 @@ In either case, Leopold's conjecture states that the regulator is zero iff the u
 """
 function regulator(u::Vector{T}, C::qAdicConj, n::Int = 10; flat::Bool = true) where {T<: Union{AbsSimpleNumFieldElem, FacElem{AbsSimpleNumFieldElem, AbsSimpleNumField}}}
   c = map(x -> conjugates_log(x, C, n, all = !flat, flat = flat), u)
-  return det(transpose(matrix(special_gram(c))))
+  K = base_field(parent(c[1][1]))
+  sg = with_precision(K, n) do
+    special_gram(c)
+  end
+  return det(transpose(matrix(sg)))
 end
 
 function regulator(K::AbsSimpleNumField, C::qAdicConj, n::Int = 10; flat::Bool = false)
@@ -529,6 +544,8 @@ function completion(K::AbsSimpleNumField, p::ZZRingElem, i::Int, n = 64)
   @assert 0<i<= degree(K)
 
   ca = conjugates(gen(K), C, n, all = true, flat = false)[i]
+  setprecision!(parent(ca), n)
+  setprecision!(base_field(parent(ca)), n)
   return completion(K, ca)
 end
 
@@ -537,7 +554,7 @@ function completion(K::AbsSimpleNumField, ca::QadicFieldElem)
   C = qAdicConj(K, Int(p))
   r = roots(C.C, precision(ca))
   i = findfirst(x->parent(r[x]) == parent(ca) && r[x] == ca, 1:length(r))
-  Zx = polynomial_ring(FlintZZ, cached = false)[1]
+  Zx = polynomial_ring(ZZ, cached = false)[1]
   function inj(a::AbsSimpleNumFieldElem)
     d = denominator(a)
     pr = precision(parent(ca))
@@ -564,7 +581,7 @@ function completion(K::AbsSimpleNumField, ca::QadicFieldElem)
   for i=1:d
     _num_setcoeff!(a, i-1, lift(ZZ, s[i, 1]))
   end
-  f = defining_polynomial(parent(ca), FlintZZ)
+  f = defining_polynomial(parent(ca), ZZ)
   fso = inv(derivative(f)(gen(R)))
   o = matrix(GF(p), d, 1, [lift(ZZ, coeff(fso, j-1)) for j=1:d])
   s = solve(m, o; side = :right)

--- a/src/LocalField/Elem.jl
+++ b/src/LocalField/Elem.jl
@@ -442,7 +442,7 @@ function norm(a::LocalFieldElem)
   return AbstractAlgebra.det_df(representation_matrix(a))
   #the resultant is not quite stable (yet), it is not using the
   #fun factor stuff...
-  res = setprecision(base_ring(a.data), precision(a.data)) do
+  res = with_precision(base_ring(a.data), precision(a.data)) do
     resultant(defining_polynomial(K, precision(a.data)), a.data)
   end
   return res
@@ -567,7 +567,7 @@ end
 function Base.:+(a::LocalFieldElem{S, T}, b::LocalFieldElem{S, T}) where {S <: FieldElem, T <: LocalFieldParameter}
   check_parent(a, b)
   K = parent(a)
-  c = setprecision(base_ring(a.data), ceil(Int, precision(K)/ramification_index(K))) do
+  c = with_precision(base_ring(a.data), ceil(Int, precision(K)/ramification_index(K))) do
     a.data + b.data
   end
   return LocalFieldElem{S, T}(parent(a), c, min(precision(a), precision(b)))
@@ -576,7 +576,7 @@ end
 function Base.:-(a::LocalFieldElem{S, T}, b::LocalFieldElem{S, T}) where {S <: FieldElem, T <: LocalFieldParameter}
   check_parent(a, b)
   K = parent(a)
-  c = setprecision(base_ring(a.data), ceil(Int, precision(K)/ramification_index(K))) do
+  c = with_precision(base_ring(a.data), ceil(Int, precision(K)/ramification_index(K))) do
     a.data - b.data
   end
   return LocalFieldElem{S, T}(parent(a), c, min(precision(a), precision(b)))
@@ -651,14 +651,14 @@ function mul!(c::LocalFieldElem{S, T}, a::LocalFieldElem{S, T}, b::LocalFieldEle
 end
 
 function uniformizer(L::Union{PadicField, QadicField}, v::Int; prec::Int = 20)  #precision????
-  return setprecision(L, prec) do
+  return with_precision(L, prec) do
     uniformizer(L)^v
   end
 end
 
 function uniformizer(L::LocalField, v::Int; prec::Int = 20)  #precision????
   if v > 0
-    return setprecision(L, prec) do
+    return with_precision(L, prec) do
       uniformizer(L)^v
     end
   end
@@ -674,7 +674,7 @@ function uniformizer(L::LocalField, v::Int; prec::Int = 20)  #precision????
   pr = ceil(Int, (prec-v)/e)+2
   f = defining_polynomial(L, pr)
   local pi_inv
-  setprecision(L, pr*e) do
+  with_precision(L, pr*e) do
     g = parent(f)([coeff(f, i) for i=1:degree(f)])
     pi_inv = g(uniformizer(L))
     pi_inv *= -inv(coeff(f, 0))
@@ -716,13 +716,11 @@ function Base.:(^)(a::LocalFieldElem, n::Int)
   e = absolute_ramification_index(parent(a))
   v = valuation(n, prime(parent(a)))
   if v > 0
-    b = setprecision(base_ring(a.data), precision(a.data)+v) do
-            setprecision(a.data, precision(a.data)+v)
-        end
+    b = setprecision(a.data, precision(a.data)+v)
   else
     b = a.data
   end
-  b = setprecision(base_ring(b), precision(b)) do
+  b = with_precision(base_ring(b), precision(b)) do
     powermod(b, n, defining_polynomial(K, precision(b)))
   end
   return K(b)
@@ -758,22 +756,22 @@ function exp(a::LocalFieldElem)
   N = N_orig + clog(ZZRingElem(N_orig), p)
   a = setprecision(a, N)
   oN = precision(parent(a))
-  setprecision!(parent(a), max(oN, N))
-  res = one(K)
-  res = setprecision(res, N)
-  el = one(K)
-  res = res
-  den = setprecision!(one(Qp), N)
-  #precision is suboptimal, its truncated badly, thus losing it
-  max_i = QQFieldElem(N)//(valuation(a) - QQFieldElem(1, p-1)) + 1
-  bound = Int(floor(ZZRingElem, max_i))
-  for i = 1:bound
-    el *= a//i
-    res += el
-  end
-  setprecision!(res, N_orig)
-  setprecision!(parent(a), oN)
-  return res
+  return with_precision(parent(a), max(oN, N)) do
+    res = one(K)
+    res = setprecision(res, N)
+    el = one(K)
+    res = res
+    den = setprecision!(one(Qp), N)
+    #precision is suboptimal, its truncated badly, thus losing it
+    max_i = QQFieldElem(N)//(valuation(a) - QQFieldElem(1, p-1)) + 1
+    bound = Int(floor(ZZRingElem, max_i))
+    for i = 1:bound
+      el *= a//i
+      res += el
+    end
+    setprecision!(res, N_orig)
+    return res
+  end # with_precision
 end
 
 ################################################################################
@@ -867,16 +865,15 @@ function divexact(a::LocalFieldElem, b::Union{Integer, ZZRingElem}; check::Bool=
   v = valuation(b, p)
   iszero(a) && return setprecision(a, precision(a) - v*e)
   Qp = absolute_base_field(K)
-  old = precision(Qp)
-  setprecision!(Qp, e*precision(a)+round(Int, e*valuation(a)) + v)
-  bb = inv(Qp(b))
-  setprecision!(Qp, old)
+  bb = with_precision(Qp, e*precision(a)+round(Int, e*valuation(a)) + v) do
+    return inv(Qp(b))
+  end
   return a*bb
 end
 
 function _log_one_units_fast(a::LocalFieldElem)
   K = parent(a)
-  fl, b = setprecision(K, precision(a)) do
+  fl, b = with_precision(K, precision(a)) do
     if isone(a) || iszero(a - 1)
       return true, zero(K)
     end

--- a/src/LocalField/Elem.jl
+++ b/src/LocalField/Elem.jl
@@ -866,7 +866,7 @@ function divexact(a::LocalFieldElem, b::Union{Integer, ZZRingElem}; check::Bool=
   e = absolute_ramification_index(K)
   v = valuation(b, p)
   iszero(a) && return setprecision(a, precision(a) - v*e)
-  Qp = prime_field(K)
+  Qp = absolute_base_field(K)
   old = precision(Qp)
   setprecision!(Qp, e*precision(a)+round(Int, e*valuation(a)) + v)
   bb = inv(Qp(b))

--- a/src/LocalField/LocalField.jl
+++ b/src/LocalField/LocalField.jl
@@ -131,15 +131,6 @@ end
 #
 ################################################################################
 
-function prime_field(L::Union{QadicField, LocalField})
-  L = base_ring(defining_polynomial(L))
-  while typeof(L) != PadicField
-    L = base_ring(defining_polynomial(L))
-  end
-  return L
-end
-
-
 function base_field(L::LocalField)
   return base_ring(defining_polynomial(L))
 end

--- a/src/LocalField/LocalField.jl
+++ b/src/LocalField/LocalField.jl
@@ -351,7 +351,7 @@ end
 
 function local_field(f::QQPolyRingElem, p::Int, precision::Int, s::VarName, ::Type{T} = GenericLocalField; check::Bool = true, cached::Bool = true) where T <: LocalFieldParameter
   @assert is_prime(p)
-  K = PadicField(p, precision)
+  K = padic_field(p, precision = precision)
   fK = map_coefficients(K, f, cached = false)
   return local_field(fK, s, T, cached = cached, check = check)
 end

--- a/src/LocalField/LocalField.jl
+++ b/src/LocalField/LocalField.jl
@@ -372,18 +372,19 @@ function setprecision!(K::LocalField, n::Int)
   return nothing
 end
 
-function setprecision(f::Function, K::Union{LocalField, PadicField, QadicField}, n::Int)
+function with_precision(f, K::LocalField, n::Int)
+  @assert n >= 0
   old = precision(K)
-#  @assert n>=0
   setprecision!(K, n)
   v = try
-        setprecision(f, base_field(K), ceil(Int, n/ramification_index(K)))
-      finally
-        setprecision!(K, old)
-      end
+    with_precision(f, base_field(K), ceil(Int, n/ramification_index(K)))
+  finally
+    setprecision!(K, old)
+  end
   return v
 end
 
+setprecision(f, K::LocalField, n::Int) = with_precision(f, K, n)
 
 ################################################################################
 #
@@ -476,7 +477,7 @@ end
 
  ################### unramified extension over local field L of a given degree n ####################
 
- function unramified_extension(L::Union{PadicField, QadicField, LocalField}, n::Int)
+ function unramified_extension(L::Union{QadicField, LocalField}, n::Int)
    R, mR = residue_field(L)
    Rt, t = polynomial_ring(R, "t", cached = false)
    f = Rt(push!([rand(R) for i = 0:n-1], one(R)))

--- a/src/LocalField/Poly.jl
+++ b/src/LocalField/Poly.jl
@@ -712,8 +712,6 @@ function _rres(f::Generic.Poly{T}, g::Generic.Poly{T}) where T <: Union{PadicFie
   return res*res1
 end
 
-base_field(Q::QadicField) = base_ring(defining_polynomial(Q))
-
 function norm(f::PolyRingElem{T}) where T <: Union{QadicFieldElem, LocalFieldElem}
   Kx = parent(f)
   K = base_ring(f)
@@ -929,7 +927,7 @@ function lift(C::HenselCtxdr, mx::Int)
   N = minimum([precision(x) for x in C.lf])
   N = min(N, minimum([precision(x) for x in C.la]))
   #have: N need mx
-  one = setprecision(parent(p), mx) do
+  one = with_precision(parent(p), mx) do
     Base.one(parent(p))
   end
   ch = Int[mx]

--- a/src/LocalField/Poly.jl
+++ b/src/LocalField/Poly.jl
@@ -49,7 +49,7 @@ function setcoeff!(c::Generic.Poly{T}, n::Int, a::T) where {T <: Union{PadicFiel
 end
 
 #TODO: find better crossover points
-#  qp = PadicField(3, 10);
+#  qp = padic_field(3, precision = 10);
 #  qpt, t = qp["t"]
 #  E = eisenstein_extension(cyclotomic(3, gen(Hecke.Globals.Zx))(t+1))[1]
 #  Es, s = E["s"]
@@ -748,7 +748,7 @@ function characteristic_polynomial(f::Generic.Poly{T}, g::Generic.Poly{T}) where
       error("Not yet implemented")
     end
     d1 = clog(ZZRingElem(degree(f)+1), p)
-    L = QadicField(p, d1, min(precision(f), precision(g)))
+    L = qadic_field(p, d1, precision = min(precision(f), precision(g)))
     Lt = polynomial_ring(L, "t")[1]
     fL = change_base_ring(f, L, Lt)
     gL = change_base_ring(g, L, Lt)

--- a/src/LocalField/Ring.jl
+++ b/src/LocalField/Ring.jl
@@ -19,7 +19,7 @@ mutable struct QadicRing{S, T} <: Generic.Ring
 end
 
 function Base.show(io::IO, Q::QadicRing)
-  println("Integers of ", Q.Q)
+  print("Integers of ", Q.Q)
 end
 
 function MaximalOrder(Q::QadicField)
@@ -187,6 +187,10 @@ Base.precision(a::QadicRingElem) = precision(a.x)
 
 function setprecision!(Q::QadicRing, n::Int)
   setprecision!(Q.Q, n)
+end
+
+function with_precision(f, Q::QadicRing, n::Int)
+  return with_precision(f, Q.Q, n)
 end
 
 function Base.setprecision(a::QadicRingElem, n::Int)

--- a/src/LocalField/Ring.jl
+++ b/src/LocalField/Ring.jl
@@ -207,7 +207,7 @@ coefficient_ring(K::LocalField) = base_field(K)
 
 function absolute_coordinates(a::QadicRingElem)
   v = absolute_coordinates(a.x)
-  Zp = ring_of_integers(prime_field(parent(a.x)))
+  Zp = ring_of_integers(absolute_base_field(parent(a.x)))
   return Zp.(v)
 end
 

--- a/src/LocalField/automorphisms.jl
+++ b/src/LocalField/automorphisms.jl
@@ -106,7 +106,9 @@ function _roots(f::Generic.Poly{T}) where T <: Union{PadicFieldElem, QadicFieldE
 end
 
 function automorphism_list(K::T) where T <: Union{LocalField, QadicField}
-  f = map_coefficients(K, defining_polynomial(K), cached = false)
+  f = with_precision(base_field(K), precision(K)) do
+    map_coefficients(K, defining_polynomial(K), cached = false)
+  end
   rt = roots(f)
   rt = refine_roots1(f, rt)
 

--- a/src/LocalField/neq.jl
+++ b/src/LocalField/neq.jl
@@ -110,7 +110,7 @@ function h2_is_iso(K::Hecke.LocalField)
   k, mk = residue_field(K)
   pi = uniformizer(K)
   pi = setprecision(pi, 2*e)
-  eps = setprecision(K, precision(K)+e) do
+  eps = with_precision(K, precision(K)+e) do
     -inv(divexact(pi^e, p))
   end
   #assert valuation(eps) == 0
@@ -148,7 +148,7 @@ function _unit_group_gens_case2(K::Union{QadicField, Hecke.LocalField})
   #we need p/pi^e, the unit, with enough precision,
   #precision(eps) = k -> p, pi needs 2k
   pi = setprecision(pi, precision(K)+2*e)
-  eps = setprecision(K, precision(K)+e) do
+  eps = with_precision(K, precision(K)+e) do
     -inv(divexact(pi^e, p))
   end
   #  @assert precision(eps) >= precision(K) # does not (quite) work
@@ -233,92 +233,90 @@ function solve_1_units(a::Vector{T}, b::T) where T
   #Z_p (and Z) operates on the 1-units...
   k = precision(b)
   K = parent(b)
-  old = precision(K)
-  setprecision!(K, k)
-  one = K(1)
-  if iszero(b-one)
-    setprecision!(K, old)
-    return ZZRingElem[0 for i=a], ZZRingElem(1)
-  end
-  @assert valuation(b-one) > 0
-  @assert all(x->parent(x) == K , a)
-  #plan:
-  # (1+p^k/1+p^l, *) = (p^k/p^l, +) for k<=l<=2k
-  #so we start with k=1, l=2 to find the exponents mod p
-  #remove this from b
-  #try to find the next part (mod p^2), ...
-  #
-  e = absolute_ramification_index(K)
-  f = absolute_inertia_degree(K)
-  pi = uniformizer(K)
-  p = prime(K)
-  l = 1
-  cur_a = copy(a)
-  cur_b = b
-#  @assert degree(K) == e
-  Qp = absolute_base_field(K)
-  Zp = ring_of_integers(Qp)
-  expo_mult = identity_matrix(ZZ, length(cur_a))
-  #transformation of cur_a to a
-  expo = zero_matrix(ZZ, 1, length(cur_a))
-  pk = ZZRingElem(p)
+  return with_precision(K, k) do
+    one = K(1)
+    if iszero(b-one)
+      return ZZRingElem[0 for i=a], ZZRingElem(1)
+    end
+    @assert valuation(b-one) > 0
+    @assert all(x->parent(x) == K , a)
+    #plan:
+    # (1+p^k/1+p^l, *) = (p^k/p^l, +) for k<=l<=2k
+    #so we start with k=1, l=2 to find the exponents mod p
+    #remove this from b
+    #try to find the next part (mod p^2), ...
+    #
+    e = absolute_ramification_index(K)
+    f = absolute_inertia_degree(K)
+    pi = uniformizer(K)
+    p = prime(K)
+    l = 1
+    cur_a = copy(a)
+    cur_b = b
+#    @assert degree(K) == e
+    Qp = absolute_base_field(K)
+    Zp = ring_of_integers(Qp)
+    expo_mult = identity_matrix(ZZ, length(cur_a))
+    #transformation of cur_a to a
+    expo = zero_matrix(ZZ, 1, length(cur_a))
+    pk = ZZRingElem(p)
 
-  val_offset = e .* map(valuation, absolute_basis(K))
-  pow_b = ZZRingElem(1)
+    val_offset = e .* map(valuation, absolute_basis(K))
+    pow_b = ZZRingElem(1)
 
-  while l <= k
-#    @show 1, l, pow_b, k, expo
-    last_val = e*valuation(cur_b-one)
-#    @show expo_mult
-    @assert e*valuation(cur_b-one) >= l
-    @assert all(x->isone(x) || e*valuation(x-one) >= l, cur_a)
+    while l <= k
+#      @show 1, l, pow_b, k, expo
+      last_val = e*valuation(cur_b-one)
+#      @show expo_mult
+      @assert e*valuation(cur_b-one) >= l
+      @assert all(x->isone(x) || e*valuation(x-one) >= l, cur_a)
 
-    A = abelian_group([p^max(0, ceil(Int, (l-v)//e)) for v = val_offset])
-    h = hom(free_abelian_group(length(cur_a)), A, [A([lift(ZZ, x) for x =  absolute_coordinates(divexact(y-one, pi^l))]) for y = cur_a])
-    lhs = A([lift(ZZ, x) for x = absolute_coordinates(divexact(cur_b -one, pi^l))])
-    fl, s = has_preimage_with_preimage(h, lhs)
-    _k, _mk = kernel(h)
-    #if kernel has HNF, the next step is cheaper...
-    _mk.map = hnf(_mk.map)
-    #to find a nice preimage
-    reduce_mod_hnf_ur!(s.coeff, _mk.map)
-#    @show s
-    # to verify that this is a "legal" operation... the hom constructor
-    # will verify that this is legal
-    # hom(domain(_mk), codomain(_mk), [_mk(x) for x = gens(domain(_mk))])
+      A = abelian_group([p^max(0, ceil(Int, (l-v)//e)) for v = val_offset])
+      h = hom(free_abelian_group(length(cur_a)), A, [A([lift(ZZ, x) for x =  absolute_coordinates(divexact(y-one, pi^l))]) for y = cur_a])
+      lhs = A([lift(ZZ, x) for x = absolute_coordinates(divexact(cur_b -one, pi^l))])
+      fl, s = has_preimage_with_preimage(h, lhs)
+      _k, _mk = kernel(h)
+      #if kernel has HNF, the next step is cheaper...
+      _mk.map = hnf(_mk.map)
+      #to find a nice preimage
+      reduce_mod_hnf_ur!(s.coeff, _mk.map)
+#      @show s
+      # to verify that this is a "legal" operation... the hom constructor
+      # will verify that this is legal
+      # hom(domain(_mk), codomain(_mk), [_mk(x) for x = gens(domain(_mk))])
 
-    if !fl
-      pow_b *= p
-      cur_b = cur_b^p
-      expo = expo * p
-      if iszero(cur_b-one)
+      if !fl
+        pow_b *= p
+        cur_b = cur_b^p
+        expo = expo * p
+        if iszero(cur_b-one)
+          break
+        end
+        last_val = e*valuation(cur_b-one)
+        continue
+      end
+
+      expo += s.coeff * expo_mult
+      expo_mult = reduce(vcat, [_mk(x).coeff for x = gens(_k)])*expo_mult
+      cur_a = [prod(cur_a[i]^_mk(x)[i] for i=1:length(cur_a)) for x = gens(_k)]
+#      @show [e*valuation(x-1) for x = cur_a]
+
+      cur_b = divexact(b^pow_b, prod(a[i]^expo[i] for i=1:length(a)))
+      if iszero(cur_b-one) || e*valuation(cur_b-one) >= k
         break
       end
+#      @show e*valuation(cur_b-one), 2l-1, last_val, k
+      @assert e*valuation(cur_b-one) >= min(2*l-1, last_val)
       last_val = e*valuation(cur_b-one)
-      continue
-    end
 
-    expo += s.coeff * expo_mult
-    expo_mult = reduce(vcat, [_mk(x).coeff for x = gens(_k)])*expo_mult
-    cur_a = [prod(cur_a[i]^_mk(x)[i] for i=1:length(cur_a)) for x = gens(_k)]
-#    @show [e*valuation(x-1) for x = cur_a]
-
-    cur_b = divexact(b^pow_b, prod(a[i]^expo[i] for i=1:length(a)))
-    if iszero(cur_b-one) || e*valuation(cur_b-one) >= k
-      break
+      if l == k
+        break
+      end
+      l *= 2
+      l = min(l, k)
     end
-#    @show e*valuation(cur_b-one), 2l-1, last_val, k
-    @assert e*valuation(cur_b-one) >= min(2*l-1, last_val)
-    last_val = e*valuation(cur_b-one)
-
-    if l == k
-      break
-    end
-    l *= 2
-    l = min(l, k)
-  end
-  setprecision!(K, old)
-  return [expo[1, i] for i=1:length(cur_a)], pow_b
+    return [expo[1, i] for i=1:length(cur_a)], pow_b
+  end # with_precision
 end
 
 function is_norm(K::Hecke.LocalField, b::Union{QadicFieldElem,PadicFieldElem,Hecke.LocalFieldElem})
@@ -369,7 +367,7 @@ function _norm_equation(K:: Hecke.LocalField, b::Union{QadicFieldElem,PadicField
   # - if v(b-1) > 1/(p-1), then exp/log work and we can reduce
   #   to trace equation..
   bb = setprecision(b, ceil(Int, e//(p-1)))
-  g = setprecision(K, precision(bb)*ramification_index(K)) do
+  g = with_precision(K, precision(bb)*ramification_index(K)) do
     one_unit_group_gens(K)
   end
   ng = map(norm, g)
@@ -618,7 +616,7 @@ function frobenius_equation(c::Hecke.LocalFieldElem, F::Union{PadicField, QadicF
   end
 
   v_deg = valuation(absolute_degree(E), prime(E))
-  setprecision(E, precision(E) + v_deg) do
+  with_precision(E, precision(E) + v_deg) do
     c = setprecision(c, precision(E))
     cnt = 0
     while true
@@ -650,7 +648,7 @@ function frobenius_equation(c::Hecke.LocalFieldElem, F::Union{PadicField, QadicF
         return frobenius_equation2(c, F, frobenius = fr)
       end
     end
-  end #setprecision
+  end # with_precision
 end
 
 #solve the same as above, but pi-adic digit by pi-adic digit, thus

--- a/src/LocalField/neq.jl
+++ b/src/LocalField/neq.jl
@@ -215,7 +215,7 @@ function coordinates(a::Union{QadicFieldElem, LocalFieldElem}, k)
   return c
 end
 coordinates(a::PadicFieldElem, ::PadicField) = [a]
-lift(a::Hecke.QadicRingElem{PadicField, PadicFieldElem}) = lift(a.x)
+lift(R::Ring, a::Hecke.QadicRingElem{PadicField, PadicFieldElem}) = lift(R, a.x)
 
 function setprecision!(A::Generic.MatSpaceElem{Hecke.QadicRingElem{PadicField, PadicFieldElem}}, n::Int)
   for i=1:nrows(A)
@@ -256,7 +256,7 @@ function solve_1_units(a::Vector{T}, b::T) where T
   cur_a = copy(a)
   cur_b = b
 #  @assert degree(K) == e
-  Qp = prime_field(K)
+  Qp = absolute_base_field(K)
   Zp = ring_of_integers(Qp)
   expo_mult = identity_matrix(ZZ, length(cur_a))
   #transformation of cur_a to a
@@ -566,7 +566,7 @@ struct MapEvalCtx
   map::Generic.MatSpaceElem{PadicFieldElem}
 
   function MapEvalCtx(M::LocalFieldMor)
-    mat = matrix(prime_field(domain(M)),
+    mat = matrix(absolute_base_field(domain(M)),
                  absolute_degree(domain(M)),
                  absolute_degree(codomain(M)),
                  reduce(vcat, [absolute_coordinates(M(x))
@@ -779,7 +779,7 @@ function local_fundamental_class_serre(mKL::LocalFieldMor)
     #thus Gal(E/base_field(L)) = Gal(L/base_field(L)) x unram of base_field
     bL = base_field(L)
     E2, _ = unramified_extension(map_coefficients(x->bL(coeff(x, 0)), defining_polynomial(E), cached = false))
-    G2 = automorphism_list(E2, prime_field(E2))
+    G2 = automorphism_list(E2, absolute_base_field(E2))
     GG = morphism_type(E)[]
     for e = G2
       ime = e(gen(E2))
@@ -795,7 +795,7 @@ function local_fundamental_class_serre(mKL::LocalFieldMor)
     @assert length(GG) == divexact(absolute_degree(E), absolute_degree(K))
 #    @assert all(x->x in GG, automorphism_list(E, K))
   else
-    GG = automorphism_list(E, prime_field(E))
+    GG = automorphism_list(E, absolute_base_field(E))
     gK = map(E, gK)
     GG = [g for g = GG if map(g, gK) == gK]
   end
@@ -829,7 +829,7 @@ function local_fundamental_class_serre(mKL::LocalFieldMor)
   beta = []
   sigma_hat = []
   #need to map and compare all generators
-  gL = gens(L, prime_field(L))
+  gL = gens(L, absolute_base_field(L))
   imGG = map(x->map(x, map(E, gL)), GG)
   imG = map(x->map(x, gL), G)
 

--- a/src/LocalField/pAdic.jl
+++ b/src/LocalField/pAdic.jl
@@ -41,7 +41,7 @@ function my_log_one_minus(x::PadicFieldElem)
   pp = prime(parent(x), 2)
   X = 1-x
   while true
-    y = lift(1-X) % pp
+    y = lift(ZZ, 1-X) % pp
     lg += parent(x)(my_log_one_minus_inner(y, precision(x), le, prime(parent(x))))
     X = X*inv(parent(x)(1-y))
     pp *= pp
@@ -76,10 +76,10 @@ function my_log_one_minus(x::QadicFieldElem)
   pp = prime(parent(x))^2
   X = 1-x
   R, _ = polynomial_ring(QQ, cached = false)
-  S, _ = residue_ring(R, map_coefficients(x->QQ(lift(x)), defining_polynomial(parent(x)), parent = R))
+  S, _ = residue_ring(R, map_coefficients(x->QQ(lift(ZZ, x)), defining_polynomial(parent(x)), parent = R))
   while true
     Y = 1-X
-    y = S(R([lift(coeff(Y, i)) % pp for i=0:length(Y)]))
+    y = S(R([lift(ZZ, coeff(Y, i)) % pp for i=0:length(Y)]))
     lg += parent(x)(my_log_one_minus_inner(y, precision(x), le, prime(parent(x))).data)
     X = X*inv(parent(x)(1-y.data))
     pp *= pp

--- a/src/LocalField/qAdic.jl
+++ b/src/LocalField/qAdic.jl
@@ -79,7 +79,7 @@ function lift_reco(::QQField, a::PadicFieldElem; reco::Bool = false)
       return x*prime(R, v)
     end
   else
-    return lift(FlintQQ, a)
+    return lift(QQ, a)
   end
 end
 

--- a/src/LocalField/qAdic.jl
+++ b/src/LocalField/qAdic.jl
@@ -57,7 +57,7 @@ function residue_field(Q::PadicField)
   return k, mp
 end
 
-coefficient_field(Q::QadicField) = coefficient_ring(Q)
+coefficient_field(Q::QadicField) = base_field(Q)
 
 function getUnit(a::PadicFieldElem)
   u = ZZRingElem()
@@ -83,19 +83,23 @@ function lift_reco(::QQField, a::PadicFieldElem; reco::Bool = false)
   end
 end
 
-
 uniformizer(Q::QadicField) = Q(prime(Q))
 
 uniformizer(Q::PadicField) = Q(prime(Q))
 
-function defining_polynomial(Q::QadicField, P::Ring = coefficient_ring(Q))
+function defining_polynomial(Q::QadicField, P::Ring = base_field(Q))
   Pt, t = polynomial_ring(P, cached = false)
   f = Pt()
-  for i=0:Q.len-1
+  for i in 0:Q.len-1
     j = unsafe_load(reinterpret(Ptr{Int}, Q.j), i+1)
     a = ZZRingElem()
-    ccall((:fmpz_set, libflint), Nothing, (Ref{ZZRingElem}, Int64), a, Q.a+i*sizeof(Ptr))
+    ccall((:fmpz_set, libflint), Nothing, (Ref{ZZRingElem}, Int64), a, Q.a + i*sizeof(Ptr))
     setcoeff!(f, j, P(a))
   end
   return f
+end
+
+# TODO: this should be in Nemo
+@attr PadicField function base_field(K::QadicField)
+  return PadicField(prime(K), precision(K), cached = false)
 end

--- a/src/LocalField/qAdic.jl
+++ b/src/LocalField/qAdic.jl
@@ -101,5 +101,5 @@ end
 
 # TODO: this should be in Nemo
 @attr PadicField function base_field(K::QadicField)
-  return PadicField(prime(K), precision(K), cached = false)
+  return padic_field(prime(K), precision = precision(K), cached = false)
 end

--- a/src/Misc/UnitsModM.jl
+++ b/src/Misc/UnitsModM.jl
@@ -280,7 +280,7 @@ function disc_log_mod(a::ZZRingElem, b::ZZRingElem, M::ZZRingElem)
       @assert (b-1) % 8 == 0
       @assert (a^2-1) % 8 == 0
       if fM[p] > 3
-        F = PadicField(p, fM[p], cached = false)
+        F = padic_field(p, precision = fM[p], cached = false)
         g += 2*lift(divexact(log(F(b)), log(F(a^2))))
       end
       return g

--- a/src/NumField/NfAbs/MPolyAbsFact.jl
+++ b/src/NumField/NfAbs/MPolyAbsFact.jl
@@ -865,7 +865,7 @@ function field(RC::RootCtx, m::MatElem)
 
   @vprintln :AbsFact 1 "target field has (local) degree $k"
 
-  Qq = QadicField(characteristic(F), k, 1, cached = false)[1]
+  Qq = qadic_field(characteristic(F), k, precision = 1, cached = false)[1]
   Qqt = polynomial_ring(Qq, cached = false)[1]
   k, mk = residue_field(Qq)
 

--- a/src/NumField/NfAbs/MPolyAbsFact.jl
+++ b/src/NumField/NfAbs/MPolyAbsFact.jl
@@ -333,61 +333,61 @@ function lift_q(C::HenselCtxFqRelSeries{<:SeriesElem{QadicFieldElem}})
   pr = precision(coeff(coeff(C.lf[1], 0), 0))
   N2 = 2*pr
 
-  setprecision!(Q, N2)
+  return with_precision(Q, N2) do
+    i = length(C.lf)
+    @assert i > 1
+    @assert all(is_monic, C.lf[1:end-1])
+    j = i-1
+    while j > 0
+      if i==length(C.lf)
+        f = evaluate(map_coefficients(Q, C.f, cached = false), [gen(St), St(gen(S))])
+        f *= inv(leading_coefficient(f))
+      else
+#        f = _set_precision(C.lf[i], N2)
+        f = C.lf[i]
+        @assert precision(coeff(coeff(f, 0), 0)) >= N2
+        @assert is_monic(C.lf[i])
+      end
+      @assert is_monic(f)
+      #formulae and names from the Flint doc
+      h = C.lf[j]
+      g = C.lf[j-1]
+      b = C.cf[j]
+      a = C.cf[j-1]
+      h = _set_precision(h, N2)
+      g = _set_precision(g, N2)
+      a = _set_precision(a, N2)
+      b = _set_precision(b, N2)
 
-  i = length(C.lf)
-  @assert i > 1
-  @assert all(is_monic, C.lf[1:end-1])
-  j = i-1
-  while j > 0
-    if i==length(C.lf)
-      f = evaluate(map_coefficients(Q, C.f, cached = false), [gen(St), St(gen(S))])
-      f *= inv(leading_coefficient(f))
-    else
-#      f = _set_precision(C.lf[i], N2)
-      f = C.lf[i]
-      @assert precision(coeff(coeff(f, 0), 0)) >= N2
-      @assert is_monic(C.lf[i])
+      fgh = _shift_coeff_right(f-g*h, pr)
+
+      @assert is_monic(g)
+      @assert !iszero(constant_coefficient(g))
+      @assert is_monic(h)
+      @assert !iszero(constant_coefficient(h))
+      gi = preinv(g)
+      hi = preinv(h)
+
+      G = _shift_coeff_left(rem(fgh*b, gi), pr)+g
+      @assert is_monic(G)
+      H = _shift_coeff_left(rem(fgh*a, hi), pr)+h
+      @assert is_monic(H)
+
+      t = _shift_coeff_right(1-a*G-b*H, pr)
+
+      B = _shift_coeff_left(rem(t*b, gi), pr)+b
+      A = _shift_coeff_left(rem(t*a, hi), pr)+a
+#      check_data(A)
+#      check_data(B)
+
+      C.lf[j-1] = G
+      C.lf[j] = H
+      C.cf[j-1] = A
+      C.cf[j] = B
+      i -= 1
+      j -= 2
     end
-    @assert is_monic(f)
-    #formulae and names from the Flint doc
-    h = C.lf[j]
-    g = C.lf[j-1]
-    b = C.cf[j]
-    a = C.cf[j-1]
-    h = _set_precision(h, N2)
-    g = _set_precision(g, N2)
-    a = _set_precision(a, N2)
-    b = _set_precision(b, N2)
-
-    fgh = _shift_coeff_right(f-g*h, pr)
-
-    @assert is_monic(g)
-    @assert !iszero(constant_coefficient(g))
-    @assert is_monic(h)
-    @assert !iszero(constant_coefficient(h))
-    gi = preinv(g)
-    hi = preinv(h)
-
-    G = _shift_coeff_left(rem(fgh*b, gi), pr)+g
-    @assert is_monic(G)
-    H = _shift_coeff_left(rem(fgh*a, hi), pr)+h
-    @assert is_monic(H)
-
-    t = _shift_coeff_right(1-a*G-b*H, pr)
-
-    B = _shift_coeff_left(rem(t*b, gi), pr)+b
-    A = _shift_coeff_left(rem(t*a, hi), pr)+a
-#    check_data(A)
-#    check_data(B)
-
-    C.lf[j-1] = G
-    C.lf[j] = H
-    C.cf[j-1] = A
-    C.cf[j] = B
-    i -= 1
-    j -= 2
-  end
+  end # with_precision
 end
 
 mutable struct RootCtxSingle{T}
@@ -1025,42 +1025,43 @@ function field(RC::RootCtx, m::MatElem)
     end
     @vprintln :AbsFact 1  "using p-adic precision of $pr"
 
-    setprecision!(Qq, pr+1)
-    if length(fa) > 0
-      H.f = map_coefficients(Qq, _lc, parent = Qqt)
-      @vprintln :AbsFact 2 "lifting leading coeff factorisation"
-      @vtime :AbsFact 2 Hecke.lift(H, pr+1)
-      fH = factor(H)
-      lc = [prod(fH[i]^t[i] for i=1:length(t)) for t = fa]
-    end
+    p, el, fl = with_precision(Qq, pr + 1) do
+      if length(fa) > 0
+        H.f = map_coefficients(Qq, _lc, parent = Qqt)
+        @vprintln :AbsFact 2 "lifting leading coeff factorisation"
+        @vtime :AbsFact 2 Hecke.lift(H, pr+1)
+        fH = factor(H)
+        lc = [prod(fH[i]^t[i] for i=1:length(t)) for t = fa]
+      end
 
-    @vprintln :AbsFact 1 "lifting factors"
-    @vtime :AbsFact 2 while precision(coeff(coeff(HQ.lf[1], 0), 0)) < pr+1
-      lift_q(HQ)
-    end
+      @vprintln :AbsFact 1 "lifting factors"
+      @vtime :AbsFact 2 while precision(coeff(coeff(HQ.lf[1], 0), 0)) < pr+1
+        lift_q(HQ)
+      end
 
-    if length(fa) > 0
-      z = [lc[i](gen(SQq)) * HQ.lf[i] for i=1:HQ.n]
-    else
-      z = HQ.lf[1:HQ.n]
-    end
+      if length(fa) > 0
+        z = [lc[i](gen(SQq)) * HQ.lf[i] for i=1:HQ.n]
+      else
+        z = HQ.lf[1:HQ.n]
+      end
 
-    setprecision!(coeff(X, 1), pr+2)
-    setprecision!(coeff(Y, 1), pr+2)
-    el = [map_coefficients(q -> lift(Qqt, q)(Y), f, cached = false)(X) for f = z]
+      setprecision!(coeff(X, 1), pr+2)
+      setprecision!(coeff(Y, 1), pr+2)
+      el = [map_coefficients(q -> lift(Qqt, q)(Y), f, cached = false)(X) for f = z]
 
-#    # lift mod p^1 -> p^pr x^2+y^2+px+1 was bad I think
-#    @vtime :AbsFact 1 ok, el = lift_prime_power(P*inv(coeff(P, 1)), el, [0], 1, pr)
-#    ok || @vprintln :AbsFact 1 "bad prime found, q-adic lifting failed"
-#    ok || return nothing
-#    @assert ok  # can fail but should fail for only finitely many p
+#      # lift mod p^1 -> p^pr x^2+y^2+px+1 was bad I think
+#      @vtime :AbsFact 1 ok, el = lift_prime_power(P*inv(coeff(P, 1)), el, [0], 1, pr)
+#      ok || @vprintln :AbsFact 1 "bad prime found, q-adic lifting failed"
+#      ok || return nothing
+#      @assert ok  # can fail but should fail for only finitely many p
 
 
-    #to make things integral...
-    fl = Qq(llc) .* el
+      #to make things integral...
+      fl = Qq(llc) .* el
 
-    p = [coeff(sum(pe(x)^l for x = fl), 0) for l=1:length(el)]
-    p = map(rational_reconstruction, p)
+      p = [coeff(sum(pe(x)^l for x = fl), 0) for l=1:length(el)]
+      return map(rational_reconstruction, p), el, fl
+    end # with_precision
 
     if !all(x->x[1], p)
       @vprintln :AbsFact 2 "reco failed (for poly), increasing p-adic precision"
@@ -1083,25 +1084,27 @@ function field(RC::RootCtx, m::MatElem)
 
     @vprintln :AbsFact 1  "using as number field: $k"
 
-    m = transpose(matrix([[pe(x)^l for x = fl] for l=0:degree(k)-1]))
-    kx, x = polynomial_ring(k, "x", cached = false)
-    kX, _ = polynomial_ring(k, ["X", "Y"], cached = false)
-    B = MPolyBuildCtx(kX)
-    for j=1:length(el[1])
-      n = transpose(matrix([[coeff(x, j)] for x = fl]))
-      s = Hecke.solve(m, transpose(n); side = :right)
-      @assert all(x->iszero(coeff(s[x, 1], 1)), 1:degree(k))
-      s = [rational_reconstruction(coeff(s[i, 1], 0)) for i=1:degree(k)]
-      if !all(x->x[1], s)
-        break
+    q = with_precision(Qq, pr+1) do
+      m = transpose(matrix([[pe(x)^l for x = fl] for l=0:degree(k)-1]))
+      kx, x = polynomial_ring(k, "x", cached = false)
+      kX, _ = polynomial_ring(k, ["X", "Y"], cached = false)
+      B = MPolyBuildCtx(kX)
+      for j=1:length(el[1])
+        n = transpose(matrix([[coeff(x, j)] for x = fl]))
+        s = Hecke.solve(m, transpose(n); side = :right)
+        @assert all(x->iszero(coeff(s[x, 1], 1)), 1:degree(k))
+        s = [rational_reconstruction(coeff(s[i, 1], 0)) for i=1:degree(k)]
+        if !all(x->x[1], s)
+          break
+        end
+        push_term!(B, k([x[2]//x[3] for x = s]), exponent_vector(el[1], j))
       end
-      push_term!(B, k([x[2]//x[3] for x = s]), exponent_vector(el[1], j))
-    end
-    q = finish(B)
+      return finish(B)
+    end # with_precision
     if length(q) < length(el[1])
       continue
     end
-    b, r = divrem(map_coefficients(k, P, parent = kX), [q])
+    b, r = divrem(map_coefficients(k, P, parent = parent(q)), [q])
     if iszero(r)
       return q, b[1]
     end

--- a/src/QuadForm/Quad/NormalForm.jl
+++ b/src/QuadForm/Quad/NormalForm.jl
@@ -208,7 +208,7 @@ function _padic_normal_form(G::QQMatrix, p::ZZRingElem; prec::Int = -1, partial:
 
   n = ncols(Gmod)
 
-  Qp = PadicField(p, prec, cached = false)
+  Qp = padic_field(p, precision = prec, cached = false)
 
   if n == 0
     return (zero_matrix(FlintQQ, n, n), zero_matrix(FlintQQ, n, n))::Tuple{QQMatrix, QQMatrix}

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -130,6 +130,7 @@ export abs2
 export abs_upper_bound
 export absolute_automorphism_group
 export absolute_automorphism_list
+export absolute_base_field
 export absolute_basis
 export absolute_basis_matrix
 export absolute_coordinates

--- a/test/LocalField/LocalField.jl
+++ b/test/LocalField/LocalField.jl
@@ -203,7 +203,7 @@
     Qp = PadicField(2, 100)
     Qpx, x = polynomial_ring(Qp)
     K, a = unramified_extension(x^2+x+1)
-    Qq, gQq = QadicField(2, 2, 100)
+    Qq, gQq = unramified_extension(Qp, 2, precision = 100)
     rt = roots(map_coefficients(Qq, defining_polynomial(K)))
 
     f = @inferred hom(K, Qq, rt[1])

--- a/test/LocalField/LocalField.jl
+++ b/test/LocalField/LocalField.jl
@@ -17,7 +17,7 @@
     @test absolute_degree(L) == 4
     @test prime(L) == 2
 
-    Q2 = PadicField(2, 10)
+    Q2 = padic_field(2, precision = 10)
     Q2s, s = polynomial_ring(Q2, "s")
     f = s^2+s+1
     Ku, c = local_field(f, "s", Hecke.UnramifiedLocalField, check = false)
@@ -39,7 +39,7 @@
   end
 
   @testset "Norm" begin
-    K = QadicField(3, 4, 10)[1]
+    K = qadic_field(3, 4, precision = 10)[1]
     Kx, x = polynomial_ring(K, "x")
     L = eisenstein_extension(x^20+3)[1]
     b = @inferred basis(L)
@@ -125,7 +125,7 @@
 
 
   @testset "Exp and Log" begin
-    K = PadicField(2, 100)
+    K = padic_field(2, precision = 100)
     Kx, x = polynomial_ring(K, "x", cached = false)
     L, b = eisenstein_extension(x^7+2, :a)
     pi = uniformizer(L)
@@ -140,7 +140,7 @@
       @test iszero(logexp - el) || valuation(logexp - el) > 80 #need improving
     end
 
-    KK, a = QadicField(2, 2, 16)
+    KK, a = qadic_field(2, 2, precision = 16)
     KKx, x = KK["x"]
     f = x + 2^1 + 2^2 + 2^3 + 2^4 + 2^5 + 2^6 + 2^7 + 2^8 + 2^9 + 2^10 + 2^11 + 2^12 + 2^13 + 2^14 + 2^15
     L, b = eisenstein_extension(f, "b");
@@ -150,7 +150,7 @@
 
   @testset "Maps" begin
     # QadicField -> QadicField
-    Qq, a = QadicField(2, 3, 100)
+    Qq, a = qadic_field(2, 3, precision = 100)
     rt = roots(map_coefficients(Qq, defining_polynomial(Qq)))
 
     i = findfirst(x -> x == a, rt)
@@ -200,7 +200,7 @@
     @test f(z) == L(-2)
 
     # LocalField -> QadicField
-    Qp = PadicField(2, 100)
+    Qp = padic_field(2, precision = 100)
     Qpx, x = polynomial_ring(Qp)
     K, a = unramified_extension(x^2+x+1)
     Qq, gQq = unramified_extension(Qp, 2, precision = 100)
@@ -216,11 +216,11 @@
   end
 
   @testset "Automorphisms" begin
-    K = PadicField(2, 200)
+    K = padic_field(2, precision = 200)
     Kt, t = polynomial_ring(K)
     L, b = eisenstein_extension(t^2+2, "a")
     @test length(automorphism_list(L)) == 2
-    Qq, a = QadicField(2, 2, 100)
+    Qq, a = qadic_field(2, 2, precision = 100)
     @test length(automorphism_list(Qq)) == 2
     Qqx, x = polynomial_ring(Qq)
     L, b = eisenstein_extension(x^3+2, "a")
@@ -260,7 +260,7 @@
   end
 
   @testset "extend extend extend" begin
-    K, = QadicField(5, 2, 10)
+    K, = qadic_field(5, 2, precision = 10)
     L, = unramified_extension(K, 3)
     M, = unramified_extension(L, 3)
   end
@@ -274,7 +274,7 @@
   @test length(automorphism_list(k3)) == 3
 
   @testset "image of one units under log" begin
-    Qp = PadicField(3, 10)
+    Qp = padic_field(3, precision = 10)
     Qpt, t = Qp["t"]
     E, a = eisenstein_extension(t^2 - 3)
     n, x = Hecke.image_of_logarithm_one_units(E)

--- a/test/LocalField/Poly.jl
+++ b/test/LocalField/Poly.jl
@@ -1,6 +1,6 @@
 @testset "Poly" begin
 
-  K = PadicField(2, 100)
+  K = padic_field(2, precision = 100)
   Kx, x = polynomial_ring(K, "x")
   L, gL = eisenstein_extension(x^2+2, "a")
 
@@ -80,7 +80,7 @@
   end
 
   @testset "Roots" begin
-    _, t = PadicField(3, 10)["t"]
+    _, t = padic_field(3, precision = 10)["t"]
     f = ((t-1+81)*(t-1+2*81))
     rt = roots(f)
     @test length(rt) == 2
@@ -89,7 +89,7 @@
   end
 
   @testset "Resultant" begin
-    R, x = polynomial_ring(PadicField(853, 2), "x")
+    R, x = polynomial_ring(padic_field(853, precision = 2), "x")
     a = 4*x^5 + x^4 + 256*x^3 + 192*x^2 + 48*x + 4
     b = derivative(a)
     rab = @inferred resultant(a, b)

--- a/test/LocalField/neq.jl
+++ b/test/LocalField/neq.jl
@@ -36,7 +36,7 @@ end
   l2 = prime_decomposition(maximal_order(k), 2)
   k2, _ = Hecke.completion(k, l2[1][1], 120)
 
-  G, mG = automorphism_group(k2, prime_field(k2))
+  G, mG = automorphism_group(k2, absolute_base_field(k2))
   @test all([mG(x*y) == mG(x) * mG(y) for x = G for y = G])
 
 end
@@ -50,9 +50,9 @@ end
   G, mG = automorphism_group(k2, Hecke.absolute_base_field((k2)))
 
   z = Hecke.local_fundamental_class_serre(k2, Hecke.absolute_base_field((k2)))
-  for g = G 
-    for h = G 
-      for k = G 
+  for g = G
+    for h = G
+      for k = G
         a = z(mG(g), mG(h*k))*z(mG(h), mG(k)) - mG(k)(z(mG(g), mG(h)))*z(mG(g*h), mG(k))
          @test iszero(a) || valuation(a) > 20
        end
@@ -70,8 +70,8 @@ end
 
   for i=1:10
     #numerical problems with gen[1] : there is valuation...
-    u = sum(rand(-10:10)*x for x = gens(U)[2:end]) 
-    @test u == preimage(mU, mU(u))  
+    u = sum(rand(-10:10)*x for x = gens(U)[2:end])
+    @test u == preimage(mU, mU(u))
   end
 end
 


### PR DESCRIPTION
This replaces many `setprecision!(::ParentObject)` calls by `with_precision` blocks.
Also removes `prime_field` in the context of local fields.
