### PR TITLE
feat: make has_preimage_with_preimage faster for abelian groups

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Hecke"
 uuid = "3e1990a7-5d81-5526-99ce-9ba3ff248f21"
-version = "0.32.0"
+version = "0.32.1"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"

--- a/src/GrpAb/Map.jl
+++ b/src/GrpAb/Map.jl
@@ -51,7 +51,7 @@ function has_preimage_with_preimage(M::FinGenAbGroupHom, a::FinGenAbGroupElem)
     return true, preimage(M, a)
   end
 
-  m = vcat(M.map, rels(codomain(M)))
+  m = _preimage_ctx(M)
   fl, p = can_solve_with_solution(m, a.coeff, side = :left)
 
   if fl
@@ -59,6 +59,10 @@ function has_preimage_with_preimage(M::FinGenAbGroupHom, a::FinGenAbGroupElem)
   else
     return false, id(domain(M))
   end
+end
+
+@attr AbstractAlgebra.Solve.SolveCtx{ZZRingElem, ZZMatrix, ZZMatrix, ZZMatrix} function _preimage_ctx(M::FinGenAbGroupHom)
+  return solve_init(vcat(M.map, rels(codomain(M))))
 end
 
 function has_preimage_with_preimage(M::FinGenAbGroupHom, a::Vector{FinGenAbGroupElem})


### PR DESCRIPTION
- Use to a SolveContext to cache the implicit normal form
  computations