### PR TITLE
Add missing parentheses in complex printing and fix `free_resolution(::FinGenAbGrp)`

### DIFF
--- a/src/GrpAb/ChainComplex.jl
+++ b/src/GrpAb/ChainComplex.jl
@@ -337,7 +337,7 @@ function pres_show(io::IO, C::ComplexOfMorphisms)
   R = Nemo.base_ring(C[first(rng)])
   R_name = get_name(R)
   if isnothing(R_name)
-    R_name = "$R"
+    R_name = "($R)"
   end
 
   for i=reverse(rng)
@@ -403,7 +403,7 @@ function free_show(io::IO, C::ComplexOfMorphisms)
   R = Nemo.base_ring(C[first(rng)])
   R_name = get_name(R)
   if R_name === nothing
-    R_name = "$R"
+    R_name = "($R)"
   end
 
   for i=reverse(rng)

--- a/test/GrpAb/GrpAbFinGen.jl
+++ b/test/GrpAb/GrpAbFinGen.jl
@@ -351,6 +351,9 @@
       Th = hom_tensor(T, T, map(mH, [rand(H) for x = 1:2])) #induced map in tensor product
       Dh = hom_direct_sum(D, D, map(mH, rand(H, (2,2)))) #induced map on direct prod
     end
+
+    C, mC = free_resolution(G)
+    sprint(show, C)
     #=
 
     C, mC = free_resolution(G)


### PR DESCRIPTION
The first commit is part of https://github.com/oscar-system/Oscar.jl/pull/3815.

The second commit makes `free_resolution(::FinGenAbGrp)` work again, and also the printing of its return value. This seems to be some fallout from the `rank` -> `torsion_free_rank` thing. And I added a dummy test to keep this working in the future (but without real test).