### PR TITLE
Linear solving for p-adic residue rings

### DIFF
--- a/src/LocalField/ResidueRing.jl
+++ b/src/LocalField/ResidueRing.jl
@@ -299,7 +299,8 @@ function annihilator(a::LocalFieldValuationRingResidueRingElem)
     return one(parent(a))
   end
   pi = uniformizer(_valuation_ring(parent(a)))
-  return parent(a)(pi)^(_exponent(parent(a)) - valuation(data(a)))
+  va = absolute_ramification_index(_field(parent(a)))*valuation(data(a))
+  return parent(a)(pi)^ZZ(_exponent(parent(a)) - va)
 end
 
 ################################################################################
@@ -327,18 +328,21 @@ end
 function mul!(c::LocalFieldValuationRingResidueRingElem, a::LocalFieldValuationRingResidueRingElem, b::LocalFieldValuationRingResidueRingElem)
   @req parent(a) === parent(b) === parent(c) "Parents do not match"
   c.a = mul!(data(c), data(a), data(b))
+  c.a = setprecision!(c.a, _exponent(parent(a)))
   return c
 end
 
 function add!(c::LocalFieldValuationRingResidueRingElem, a::LocalFieldValuationRingResidueRingElem, b::LocalFieldValuationRingResidueRingElem)
   @req parent(a) === parent(b) === parent(c) "Parents do not match"
   c.a = add!(data(c), data(a), data(b))
+  c.a = setprecision!(c.a, _exponent(parent(a)))
   return c
 end
 
 function addeq!(a::LocalFieldValuationRingResidueRingElem, b::LocalFieldValuationRingResidueRingElem)
   @req parent(a) === parent(b) "Parents do not match"
   a.a = addeq!(data(a), data(b))
+  a.a = setprecision!(a.a, _exponent(parent(a)))
   return a
 end
 
@@ -362,7 +366,7 @@ end
 
 function residue_ring(R::LocalFieldValuationRing, a::LocalFieldValuationRingElem)
   @req parent(a) === R "Rings do not match"
-  k = Int(valuation(a))
+  k = Int(absolute_ramification_index(R.Q)*valuation(a))
   S = LocalFieldValuationRingResidueRing(R, k)
   return S, Generic.EuclideanRingResidueMap(R, S)
 end

--- a/src/LocalField/ResidueRing.jl
+++ b/src/LocalField/ResidueRing.jl
@@ -265,22 +265,33 @@ function Base.divrem(a::LocalFieldValuationRingResidueRingElem, b::LocalFieldVal
   return zero(parent(a)), a
 end
 
+function _canonicalize_xxgcd(g::T, u::T, v::T, s::T, t::T) where {T <: LocalFieldValuationRingResidueRingElem}
+  e = canonical_unit(g)
+  is_one(e) && return g, u, v, s, t
+  g = divexact(g, e)
+  u = divexact(u, e)
+  v = divexact(v, e)
+  s *= e
+  t *= e
+  return g, u, v, s, t
+end
+
 # Return g, u, v, s, t with g = gcd(a, b), g = u*a + v*b, 0 = s*a + t*b and u*t - v*s = 1
 function xxgcd(a::LocalFieldValuationRingResidueRingElem, b::LocalFieldValuationRingResidueRingElem)
   @req parent(a) === parent(b) "Parents do not match"
 
   R = parent(a)
   if is_zero(b)
-    return a, one(R), zero(R), zero(R), one(R)
+    return _canonicalize_xxgcd(a, one(R), zero(R), zero(R), one(R))
   end
   if is_zero(a)
-    return b, zero(R), one(R), -one(R), zero(R)
+    return _canonicalize_xxgcd(b, zero(R), one(R), -one(R), zero(R))
   end
 
   if valuation(data(a)) > valuation(data(b))
-    return b, zero(R), one(R), -one(R), divexact(a, b)
+    return _canonicalize_xxgcd(b, zero(R), one(R), -one(R), divexact(a, b))
   end
-  return a, one(R), zero(R), -divexact(b, a), one(R)
+  return _canonicalize_xxgcd(a, one(R), zero(R), -divexact(b, a), one(R))
 end
 
 function annihilator(a::LocalFieldValuationRingResidueRingElem)

--- a/src/LocalField/Ring.jl
+++ b/src/LocalField/Ring.jl
@@ -190,6 +190,7 @@ end
 
 function setprecision!(a::LocalFieldValuationRingElem, n::Int)
   a.x = setprecision!(a.x, n)
+  return a
 end
 
 function Base.setprecision(a::Generic.MatSpaceElem{LocalFieldValuationRingElem{QadicFieldElem}}, n::Int)

--- a/src/NumFieldOrd/NfOrd/StrongEchelonForm.jl
+++ b/src/NumFieldOrd/NfOrd/StrongEchelonForm.jl
@@ -237,6 +237,36 @@ function howell_form(A::MatElem{T}) where {T <: Union{AbsSimpleNumFieldOrderQuoR
   return B
 end
 
+function howell_form_with_transformation(A::MatElem{T}) where {T <: Union{AbsSimpleNumFieldOrderQuoRingElem, LocalFieldValuationRingResidueRingElem}}
+  B = hcat(A, identity_matrix(A, nrows(A)))
+  if nrows(B) < ncols(B)
+    B = vcat(B, zero(A, ncols(B) - nrows(B), ncols(B)))
+  end
+
+  howell_form!(B)
+
+  m = max(nrows(A), ncols(A))
+  H = sub(B, 1:m, 1:ncols(A))
+  U = sub(B, 1:m, ncols(A) + 1:ncols(B))
+
+  @hassert :AbsOrdQuoRing 1 H == U*A
+
+  return H, U
+end
+
+################################################################################
+#
+#  Inverse
+#
+################################################################################
+
+function inv(A::MatElem{T}) where {T <: Union{AbsSimpleNumFieldOrderQuoRingElem, LocalFieldValuationRingResidueRingElem}}
+  !is_square(A) && error("Matrix not invertible")
+  H, U = howell_form_with_transformation(A)
+  !is_one(H) && error("Matrix not invertible")
+  return U
+end
+
 ################################################################################
 #
 #  Linear solving

--- a/test/LocalField/ResidueRing.jl
+++ b/test/LocalField/ResidueRing.jl
@@ -296,3 +296,23 @@ end
   K = @inferred kernel(C, side = :right)
   @test K == identity_matrix(S, 2) || K == swap_cols!(identity_matrix(S, 2), 1, 2)
 end
+
+@testset "Matrix inversion" begin
+  F, _ = cyclotomic_field(20)
+  OF = maximal_order(F)
+  P = prime_decomposition(OF, 2)[1][1]
+  K, toK = completion(F, P)
+  R = valuation_ring(K)
+  pi = uniformizer(R)
+  S, RtoS = residue_ring(R, pi^8)
+
+  M = matrix(S, [1 2 3 4 5; 0 0 8 9 10; 0 0 0 14 15])
+  @test_throws ErrorException inv(M)
+
+  M = matrix(S, [2 0; 0 1])
+  @test_throws ErrorException inv(M)
+  M = matrix(S, [1 4; 0 1])
+  N = inv(M)
+  @test M * N == identity_matrix(S, 2)
+  @test N * M == identity_matrix(S, 2)
+end

--- a/test/LocalField/ResidueRing.jl
+++ b/test/LocalField/ResidueRing.jl
@@ -135,3 +135,98 @@ end
   K = @inferred kernel(N, side = :right)
   @test K == matrix(S, 1, 1, [8])
 end
+
+@testset "Linear solving context" begin
+  K, _ = qadic_field(2, 2)
+  R = valuation_ring(K)
+  pi = uniformizer(R)
+  S, RtoS = residue_ring(R, pi^4)
+
+  M = matrix(S, [1 2 3 4 5; 0 0 8 9 10; 0 0 0 14 15])
+  C = solve_init(M)
+
+  @test C isa AbstractAlgebra.solve_context_type(elem_type(S))
+  @test C isa AbstractAlgebra.solve_context_type(zero(S))
+  @test C isa AbstractAlgebra.solve_context_type(typeof(S))
+  @test C isa AbstractAlgebra.solve_context_type(S)
+  @test C isa AbstractAlgebra.solve_context_type(typeof(M))
+  @test C isa AbstractAlgebra.solve_context_type(M)
+
+  @test_throws ErrorException solve(C, [ S(1) ])
+  @test_throws ErrorException solve(C, [ S(1) ], side = :right)
+  @test_throws ErrorException solve(C, matrix(S, 1, 1, [ S(1) ]))
+  @test_throws ErrorException solve(C, matrix(S, 1, 1, [ S(1) ]), side = :right)
+  @test_throws ArgumentError solve(C, [ S(1), S(2), S(3) ], side = :test)
+  @test_throws ArgumentError solve(C, matrix(S, 3, 1, [ S(1), S(2), S(3) ]), side = :test)
+
+  for b in [ [ S(1), S(2), S(3) ],
+            matrix(S, 3, 1, [ S(1), S(2), S(3) ]),
+            matrix(S, 3, 2, [ S(1), S(2), S(3), S(4), S(5), S(6) ]) ]
+    @test @inferred can_solve(C, b, side = :right)
+    x = @inferred solve(C, b, side = :right)
+    @test M*x == b
+    fl, x = @inferred can_solve_with_solution(C, b, side = :right)
+    @test fl
+    @test M*x == b
+    fl, x, K = @inferred can_solve_with_solution_and_kernel(C, b, side = :right)
+    @test fl
+    @test M*x == b
+    @test is_zero(M*K)
+    @test ncols(K) == 2
+    K = @inferred kernel(C, side = :right)
+    @test is_zero(M*K)
+    @test ncols(K) == 2
+  end
+
+  for b in [ [ S(1), S(1), S(1), S(1), S(1) ],
+            matrix(S, 1, 5, [ S(1), S(1), S(1), S(1), S(1) ]),
+            matrix(S, 2, 5, [ S(1), S(1), S(1), S(1), S(1),
+                             S(1), S(1), S(1), S(1), S(1) ]) ]
+    @test_throws ArgumentError solve(C, b)
+    @test @inferred !can_solve(C, b)
+    fl, x = @inferred can_solve_with_solution(C, b)
+    @test !fl
+    fl, x, K = @inferred can_solve_with_solution_and_kernel(C, b)
+    @test !fl
+  end
+
+  for b in [ [ S(1), S(2), S(3), S(4), S(5) ],
+            matrix(S, 1, 5, [ S(1), S(2), S(3), S(4), S(5)]),
+            matrix(S, 2, 5, [ S(1), S(2), S(3), S(4), S(5),
+                             S(0), S(0), S(8), S(9), S(10) ]) ]
+    @test @inferred can_solve(C, b)
+    x = @inferred solve(C, b)
+    @test x*M == b
+    fl, x = @inferred can_solve_with_solution(C, b)
+    @test fl
+    @test x*M == b
+    fl, x, K = @inferred can_solve_with_solution_and_kernel(C, b)
+    @test fl
+    @test x*M == b
+    @test is_zero(K*M)
+    @test nrows(K) == 0
+    K = @inferred kernel(C)
+    @test is_zero(K*M)
+    @test nrows(K) == 0
+  end
+
+  N = zero_matrix(S, 2, 1)
+  C = solve_init(N)
+  b = zeros(S, 2)
+  fl, x, K = @inferred can_solve_with_solution_and_kernel(C, b, side = :right)
+  @test fl
+  @test N*x == b
+  @test K == identity_matrix(S, 1)
+  K = @inferred kernel(C, side = :right)
+  @test K == identity_matrix(S, 1)
+
+  N = zero_matrix(S, 1, 2)
+  C = solve_init(N)
+  b = zeros(S, 1)
+  fl, x, K = @inferred can_solve_with_solution_and_kernel(C, b, side = :right)
+  @test fl
+  @test N*x == b
+  @test K == identity_matrix(S, 2) || K == swap_cols!(identity_matrix(S, 2), 1, 2)
+  K = @inferred kernel(C, side = :right)
+  @test K == identity_matrix(S, 2) || K == swap_cols!(identity_matrix(S, 2), 1, 2)
+end


### PR DESCRIPTION
Use the Howell form for linear solving over the new `LocalFieldValuationRingResidueRing`s.

The `kernel` method is copied from the `zzModMatrix` version in Nemo. I have no idea whether this is correct; it seems to work.
