### PR TITLE
Clean up `LocalFieldValuationRing` a bit

### DIFF
--- a/src/LocalField/Elem.jl
+++ b/src/LocalField/Elem.jl
@@ -244,7 +244,7 @@ function zero(K::LocalField; precision=precision(K))
   return setprecision(K(a), precision)
 end
 
-(K::LocalField)() = zero(K)
+(K::LocalField)(; precision=precision(K)) = zero(K, precision = precision)
 
 function one(K::LocalField; precision=precision(K))
   a = one(parent(defining_polynomial(K)))

--- a/src/LocalField/LocalField.jl
+++ b/src/LocalField/LocalField.jl
@@ -5,18 +5,21 @@
 ################################################################################
 
 function show(io::IO, a::LocalField{S, EisensteinLocalField}) where S
-  print(io, "Eisenstein extension with defining polynomial ", defining_polynomial(a))
-  print(io, " over ", base_field(a))
+  io = pretty(io)
+  print(io, LowercaseOff(), "Eisenstein extension with defining polynomial ", defining_polynomial(a))
+  print(io, " over ", Lowercase(), base_field(a))
 end
 
 function show(io::IO, a::LocalField{S, UnramifiedLocalField}) where S
+  io = pretty(io)
   print(io, "Unramified extension with defining polynomial ", defining_polynomial(a))
-  print(io, " over ", base_field(a))
+  print(io, " over ", Lowercase(), base_field(a))
 end
 
 function show(io::IO, a::LocalField{S, GenericLocalField}) where S
+  io = pretty(io)
   print(io, "Extension with defining polynomial ", defining_polynomial(a))
-  print(io, " over ", base_field(a))
+  print(io, " over ", Lowercase(), base_field(a))
 end
 
 ################################################################################

--- a/src/LocalField/Types.jl
+++ b/src/LocalField/Types.jl
@@ -93,7 +93,7 @@ end
 #
 ################################################################################
 
-mutable struct LocalFieldValuationRing{S, T} <: Generic.Ring
+@attributes mutable struct LocalFieldValuationRing{S, T} <: Generic.Ring
   Q::S #The corresponding local field
   basis::Vector{T} #The OK-basis of the ring, where OK is
                    #the maximal order of the base field of Q

--- a/test/LocalField.jl
+++ b/test/LocalField.jl
@@ -4,5 +4,6 @@
   include("LocalField/LocalField.jl")
   include("LocalField/neq.jl")
   include("LocalField/Completions.jl")
+  include("LocalField/Ring.jl")
   include("LocalField/ResidueRing.jl")
 end

--- a/test/LocalField/Ring.jl
+++ b/test/LocalField/Ring.jl
@@ -1,0 +1,49 @@
+function _integral_test_elem(R::PadicField)
+  p = prime(R)
+  prec = rand(1:R.prec_max)
+  r = ZZRingElem(0):p-1
+  return R(sum(rand(r)*p^i for i in 0:prec))
+end
+
+function _integral_test_elem(R::NonArchLocalField)
+  d = degree(R)
+  a = gen(R)
+  x = R()
+  for i in 0:d - 1
+    x += _integral_test_elem(base_field(R))*a^i
+  end
+  return x
+end
+
+function test_elem(R::Hecke.LocalFieldValuationRing)
+  return R(_integral_test_elem(Hecke._field(R)))
+end
+
+@testset "Conformance tests" begin
+  # PadicField
+  K = padic_field(17)
+  R = valuation_ring(K)
+  @test is_domain_type(typeof(R))
+  @test !is_exact_type(typeof(R))
+  test_Ring_interface(R)
+  test_EuclideanRing_interface(R)
+
+  # QadicField
+  K, a = qadic_field(17, 2)
+  R = valuation_ring(K)
+  @test is_domain_type(typeof(R))
+  @test !is_exact_type(typeof(R))
+  test_Ring_interface(R)
+  test_EuclideanRing_interface(R)
+
+  # LocalField
+  F, _ = cyclotomic_field(20)
+  OF = maximal_order(F)
+  P = prime_decomposition(OF, 2)[1][1]
+  K, toK = completion(F, P)
+  R = valuation_ring(K)
+  @test is_domain_type(typeof(R))
+  @test !is_exact_type(typeof(R))
+  test_Ring_interface(R)
+  test_EuclideanRing_interface(R)
+end


### PR DESCRIPTION
Mostly moves around code in `src/LocalField/Ring.jl` and adds conformance tests.

Also adds a bit nicer printing, makes `valuation_ring` an attribute of the field and fixes `canonical_unit`.
