### PR TITLE
Remove unused to_array and to_fmpz_mat methods

### DIFF
--- a/src/LinearAlgebra/FakeFmpqMat.jl
+++ b/src/LinearAlgebra/FakeFmpqMat.jl
@@ -202,13 +202,6 @@ isequal(x::FakeFmpqMat, y::FakeFmpqMat) = (x.num == y.num) && (x.den == y.den)
 #
 ################################################################################
 
-to_array(x::FakeFmpqMat) = (x.num, x.den)
-
-function to_fmpz_mat(x::FakeFmpqMat)
-  !isone(x.den) && error("Denominator has to be 1")
-  return numerator(x)
-end
-
 function FakeFmpqMat(x::Vector{QQFieldElem})
   dens = ZZRingElem[denominator(x[i]) for i=1:length(x)]
   den = lcm(dens)


### PR DESCRIPTION
Nothing uses them and the names are suboptimal (so if someone
needs this functionality we'd be better of implementing these
as `convert` methods or constructors or something like that).
