### PR TITLE
Optimize local fields a bit

### DIFF
--- a/src/LocalField/Completions.jl
+++ b/src/LocalField/Completions.jl
@@ -461,7 +461,7 @@ function setprecision!(f::CompletionMap{LocalField{PadicFieldElem, EisensteinLoc
     coeffs_eisenstein[e+1] = one(Qp)
     pol_gen = Qpx(coeffs_eisenstein)
     Kp.def_poly_cache[new_prec] = pol_gen
-    Kp.precision = new_prec
+    setprecision!(Kp, new_prec * ramification_index(Kp))
     #Should I update the traces too?
     img_prim_elem = Vector{PadicFieldElem}(undef, e)
     for i = 1:e

--- a/src/LocalField/Elem.jl
+++ b/src/LocalField/Elem.jl
@@ -566,7 +566,7 @@ end
 function Base.:+(a::LocalFieldElem{S, T}, b::LocalFieldElem{S, T}) where {S <: FieldElem, T <: LocalFieldParameter}
   check_parent(a, b)
   K = parent(a)
-  c = setprecision(base_ring(a.data), ceil(Int, precision(K)/ramification_index(K))) do
+  c = setprecision(base_ring(a.data), _precision_base(K)) do
     a.data + b.data
   end
   return LocalFieldElem{S, T}(parent(a), c, min(precision(a), precision(b)))
@@ -575,7 +575,7 @@ end
 function Base.:-(a::LocalFieldElem{S, T}, b::LocalFieldElem{S, T}) where {S <: FieldElem, T <: LocalFieldParameter}
   check_parent(a, b)
   K = parent(a)
-  c = setprecision(base_ring(a.data), ceil(Int, precision(K)/ramification_index(K))) do
+  c = setprecision(base_ring(a.data), _precision_base(K)) do
     a.data - b.data
   end
   return LocalFieldElem{S, T}(parent(a), c, min(precision(a), precision(b)))
@@ -627,12 +627,12 @@ end
 
 function mul!(c::LocalFieldElem{S, T}, a::LocalFieldElem{S, T}, b::LocalFieldElem{S, T}) where {S <: FieldElem, T <: LocalFieldParameter}
   check_parent(a, b)
-  K = c.parent = a.parent
-  e = ramification_index(parent(a))
+  K = parent(a)
+  e = ramification_index(K)
   c.data = mul!(c.data, a.data, b.data)
-  c.data = mod(c.data, defining_polynomial(parent(a), max(precision(c.data), ceil(Int, precision(K)/e))))
+  c.data = mod(c.data, defining_polynomial(K, max(precision(c.data), _precision_base(K))))
 #  c.precision = compute_precision(a.parent, c.data)
-  e = absolute_ramification_index(parent(a))
+  e = absolute_ramification_index(K)
   if iszero(a)
     va = 0
   else
@@ -644,8 +644,8 @@ function mul!(c::LocalFieldElem{S, T}, a::LocalFieldElem{S, T}, b::LocalFieldEle
     vb = Int(e*valuation(b))
   end
   pr = min(precision(a) - va, precision(b) - vb) + va+vb
-  c.precision = min(compute_precision(a.parent, c.data), pr)
-#  c.precision = compute_precision(a.parent, c.data)
+  c.precision = min(compute_precision(K, c.data), pr)
+#  c.precision = compute_precision(K, c.data)
   return c
 end
 
@@ -814,7 +814,6 @@ function log(a::LocalFieldElem)
   end
   return logy + va*logeps
 end
-
 
 function _log_one_units(a::LocalFieldElem)
   K = parent(a)

--- a/src/LocalField/Elem.jl
+++ b/src/LocalField/Elem.jl
@@ -39,8 +39,8 @@ function compute_precision(K::LocalField, a::Generic.Poly)
   prec = precision(coeff(a, 0))*ramification_index(K)
   degree(a) == 0 && return prec
   f = defining_polynomial(K)
-  v = Int(numerator(valuation(coeff(f, 0))))
-  # Note: v == Int(numerator(QQ(valuation(coeff(f, 0)), degree(K))*ramification_index(K)))
+  v = Int(numerator(valuation(coeff(f, 0))//degree(K) * ramification_index(K)))
+  # TODO: Presumably, v is supposed to be the valuation of gen(K). Is this correct?
   vi = 0
   for i = 1:degree(a)
     vi += v

--- a/src/LocalField/Elem.jl
+++ b/src/LocalField/Elem.jl
@@ -35,21 +35,12 @@ end
 #
 ################################################################################
 
-function _generator_valuation(K::LocalField{S, T}) where {S <: Union{PadicFieldElem, QadicFieldElem}, T <: LocalFieldParameter}
-  f = defining_polynomial(K)
-#  @show K, f
-  return QQFieldElem(valuation(coeff(f, 0)), degree(f))
-end
-
-function _generator_valuation(K::LocalField)
-  f = defining_polynomial(K)
-  return divexact(valuation(coeff(f, 0)), degree(K))
-end
-
 function compute_precision(K::LocalField, a::Generic.Poly)
   prec = precision(coeff(a, 0))*ramification_index(K)
   degree(a) == 0 && return prec
-  v = Int(numerator(_generator_valuation(K)*ramification_index(K)))
+  f = defining_polynomial(K)
+  v = Int(numerator(valuation(coeff(f, 0))))
+  # Note: v == Int(numerator(QQ(valuation(coeff(f, 0)), degree(K))*ramification_index(K)))
   vi = 0
   for i = 1:degree(a)
     vi += v
@@ -641,14 +632,12 @@ function mul!(c::LocalFieldElem{S, T}, a::LocalFieldElem{S, T}, b::LocalFieldEle
   check_parent(a, b)
   K = parent(a)
   e = ramification_index(K)
-  c.data = mul!(c.data, a.data, b.data)
-  c.data = mod(c.data, defining_polynomial(K, max(precision(c.data), _precision_base(K))))
-#  c.precision = compute_precision(a.parent, c.data)
+  c.data = mul!(c.data, data(a), data(b))
+  c.data = mod(c.data, defining_polynomial(K, max(precision(data(c)), _precision_base(K))))
   va = (iszero(a) ? 0 : Int(_valuation_integral(a)))
   vb = (iszero(b) ? 0 : Int(_valuation_integral(b)))
   pr = min(precision(a) + vb, precision(b) + va)
-  c.precision = min(compute_precision(K, c.data), pr)
-#  c.precision = compute_precision(K, c.data)
+  c.precision = min(compute_precision(K, data(c)), pr)
   return c
 end
 

--- a/src/LocalField/Elem.jl
+++ b/src/LocalField/Elem.jl
@@ -790,16 +790,17 @@ function log(a::LocalFieldElem)
   e = absolute_ramification_index(K)
   f = absolute_inertia_degree(K)
   p = prime(K)
+  pf1 = p^f - 1
   pi = uniformizer(K)
   y = a*pi^(-Int(numerator(va*e)))
   #Now, y has valuation 0
-  z = y^(p^f-1)
+  z = y^pf1
   #Now, z is a 1-unit
-  logy = _log_one_units(z)//(p^f-1)
+  logy = _log_one_units(z)//pf1
   eps = ((pi^e)//p)
   #Same trick to make eps is now a 1-unit.
   if !isone(eps) && iszero(valuation(eps-1))
-    logeps = divexact(_log_one_units(eps^(p^f-1)), p^f-1)
+    logeps = divexact(_log_one_units(eps^pf1), pf1)
   else
     logeps = _log_one_units(eps)
   end

--- a/src/LocalField/Elem.jl
+++ b/src/LocalField/Elem.jl
@@ -735,7 +735,7 @@ function _underlying_base_field(K::T) where T <: Union{PadicField, QadicField}
 end
 
 @doc raw"""
-    log(a::LocalFieldElem) -> LocalFieldElem
+    exp(a::LocalFieldElem) -> LocalFieldElem
 
 Computes the $p$-adic exponential of $a$.
 """

--- a/src/LocalField/Elem.jl
+++ b/src/LocalField/Elem.jl
@@ -47,11 +47,14 @@ function _generator_valuation(K::LocalField)
 end
 
 function compute_precision(K::LocalField, a::Generic.Poly)
-  v = numerator(_generator_valuation(K)*ramification_index(K))
   prec = precision(coeff(a, 0))*ramification_index(K)
+  degree(a) == 0 && return prec
+  v = Int(numerator(_generator_valuation(K)*ramification_index(K)))
+  vi = 0
   for i = 1:degree(a)
+    vi += v
     c = coeff(a, i)
-    prec = min(prec, precision(c)*ramification_index(K)+Int(numerator(ceil(i*v))))
+    prec = min(prec, precision(c)*ramification_index(K) + vi)
   end
   return prec
 end

--- a/src/LocalField/LocalField.jl
+++ b/src/LocalField/LocalField.jl
@@ -222,7 +222,10 @@ absolute_ramification_index(K::PadicField) = 1
 absolute_ramification_index(K::QadicField) = 1
 
 function absolute_ramification_index(K::LocalField{S, T}) where {S <: FieldElem, T <: LocalFieldParameter}
-  return ramification_index(K)*absolute_ramification_index(base_field(K))
+  if K.absolute_ramification_index < 0
+    K.absolute_ramification_index = ramification_index(K)*absolute_ramification_index(base_field(K))
+  end
+  return K.absolute_ramification_index
 end
 
 function ramification_index(L::LocalField, K::Union{PadicField, QadicField, LocalField})

--- a/src/LocalField/LocalField.jl
+++ b/src/LocalField/LocalField.jl
@@ -368,19 +368,27 @@ function local_field(f::QQPolyRingElem, p::Int, precision::Int, s::VarName, ::Ty
   return local_field(fK, s, T, cached = cached, check = check)
 end
 
-function defining_polynomial(K::LocalField, n::Int = ceil(Int, precision(K)/ramification_index(K)))
+function defining_polynomial(K::LocalField, n::Int = _precision_base(K))
   if !haskey(K.def_poly_cache, n)
     K.def_poly_cache[n] = K.def_poly(n)
   end
   return K.def_poly_cache[n]
 end
 
+function _precision_base(K::LocalField)
+  return K.precision_base
+end
+
 function precision(K::LocalField)
-  return K.precision*ramification_index(K)
+  if K.precision_times_ramification_index < 0
+    K.precision_times_ramification_index = K.precision_base * ramification_index(K)
+  end
+  return K.precision_times_ramification_index
 end
 
 function setprecision!(K::LocalField, n::Int)
-  K.precision = ceil(Int, n/ramification_index(K))
+  K.precision_base = ceil(Int, n/ramification_index(K))
+  K.precision_times_ramification_index = n
   return nothing
 end
 
@@ -395,7 +403,6 @@ function setprecision(f::Function, K::Union{LocalField, PadicField, QadicField},
       end
   return v
 end
-
 
 ################################################################################
 #

--- a/src/LocalField/Types.jl
+++ b/src/LocalField/Types.jl
@@ -17,6 +17,7 @@ abstract type GenericLocalField <: LocalFieldParameter end
   precision_times_ramification_index::Int #only used for exact to ring
   traces_basis::Dict{Int, Vector{S}}
   ramification_index::Int
+  absolute_ramification_index::Int
   inertia_degree::Int
   uniformizer::Generic.Poly{S}
   residue_field_map
@@ -30,6 +31,7 @@ abstract type GenericLocalField <: LocalFieldParameter end
     z.precision_base = precision(f)
     z.precision_times_ramification_index = -1
     z.ramification_index = -1
+    z.absolute_ramification_index = -1
     z.inertia_degree = -1
     return z
   end

--- a/src/LocalField/Types.jl
+++ b/src/LocalField/Types.jl
@@ -13,8 +13,10 @@ abstract type GenericLocalField <: LocalFieldParameter end
   def_poly::Function #Int -> Poly at prec n
   def_poly_cache::Dict{Int, Generic.Poly{S}}
   S::Symbol
-  precision_base::Int #only used for exact to ring
-  precision_times_ramification_index::Int #only used for exact to ring
+  precision_base::Int # precision of the defining polynomial
+  precision_times_ramification_index::Int # precision_base * ramification index,
+                                          # this is the precision that is used
+                                          # for "exact input"
   traces_basis::Dict{Int, Vector{S}}
   ramification_index::Int
   absolute_ramification_index::Int

--- a/src/LocalField/Types.jl
+++ b/src/LocalField/Types.jl
@@ -13,7 +13,8 @@ abstract type GenericLocalField <: LocalFieldParameter end
   def_poly::Function #Int -> Poly at prec n
   def_poly_cache::Dict{Int, Generic.Poly{S}}
   S::Symbol
-  precision::Int #only used for exact to ring
+  precision_base::Int #only used for exact to ring
+  precision_times_ramification_index::Int #only used for exact to ring
   traces_basis::Dict{Int, Vector{S}}
   ramification_index::Int
   inertia_degree::Int
@@ -26,7 +27,8 @@ abstract type GenericLocalField <: LocalFieldParameter end
     z.def_poly_cache = Dict{Int, Generic.Poly{S}}(precision(f) => f)
     z.traces_basis = Dict{Int, Vector{S}}()
     z.S = s
-    z.precision = precision(f)
+    z.precision_base = precision(f)
+    z.precision_times_ramification_index = -1
     z.ramification_index = -1
     z.inertia_degree = -1
     return z


### PR DESCRIPTION
This should make some things a bit faster in the local fields.
I had timings where `_p_adic_regulator` was twice as fast as before, but the timings differ largely accross julia sessions.
This closes #1537 as far as I am concerned.

Not all changes here are "trivial", so someone should have a look (once the CI is green).
