### PR TITLE
Fix `_automorphisms` for degree 1 number field

### DIFF
--- a/src/Map/automorphisms.jl
+++ b/src/Map/automorphisms.jl
@@ -26,7 +26,7 @@ end
 
 function _automorphisms(K::AbsSimpleNumField; is_abelian::Bool = false)
   if degree(K) == 1
-    return automorphism_type(K)[hom(K, K, one(K))]
+    return automorphism_type(K)[hom(K, K, gen(K))]
   end
   if Nemo.is_cyclo_type(K)
     f = get_attribute(K, :cyclo)::Int

--- a/test/Map/NumberField.jl
+++ b/test/Map/NumberField.jl
@@ -77,6 +77,10 @@ end
   @test fl
   fl, tau = Hecke.is_cm_field(K)
   @test fl
+
+  Qt, t = QQ["t"]
+  K, _ = number_field(t+1; cached=false)
+  @test length(automorphism_list(K)) == 1
 end
 
 @testset "parents" begin


### PR DESCRIPTION
Before
```
julia> Qt, t = QQ["t"]
(Univariate polynomial ring in t over QQ, t)

julia> K, a = number_field(t+1)
(Number field of degree 1 over QQ, -1)

julia> automorphism_list(K)
ERROR: Data does not define a morphism
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:35
 [2] #map_data#323
   @ ~/.julia/packages/Hecke/CoyAD/src/Map/NumField.jl:281 [inlined]
 [3] map_data
   @ ~/.julia/packages/Hecke/CoyAD/src/Map/NumField.jl:272 [inlined]
 [4] #hom#322
   @ ~/.julia/packages/Hecke/CoyAD/src/Map/NumField.jl:150 [inlined]
 [5] hom
   @ ~/.julia/packages/Hecke/CoyAD/src/Map/NumField.jl:137 [inlined]
 [6] _automorphisms(K::AbsSimpleNumField; is_abelian::Bool)
   @ Hecke ~/.julia/packages/Hecke/CoyAD/src/Map/automorphisms.jl:29
 [7] automorphism_list(K::AbsSimpleNumField; copy::Bool, is_abelian::Bool)
   @ Hecke ~/.julia/packages/Hecke/CoyAD/src/Map/automorphisms.jl:141
 [8] automorphism_list(K::AbsSimpleNumField)
   @ Hecke ~/.julia/packages/Hecke/CoyAD/src/Map/automorphisms.jl:127
 [9] top-level scope
   @ REPL[3]:1
```
caused by the code of `_automorphisms` to create the identity morphism for degree 1 number fields by calling `hom(K, K, one(K))`. But in the case `gen(K) != one(K)` this does not work (I guess the code was initially intended to work for `QQ` defined as a number field by the polynomial `t-1`). Now with the change, even "exotic" degree 1 polynomials work

```
julia> Qt, t = QQ["t"]
(Univariate polynomial ring in t over QQ, t)

julia> K, a = number_field(t-984762)
(Number field of degree 1 over QQ, 984762)

julia> automorphism_list(K)
1-element Vector{NumFieldHom{AbsSimpleNumField, AbsSimpleNumField, Hecke.MapDataFromAnticNumberField{AbsSimpleNumFieldElem}, Hecke.MapDataFromAnticNumberField{AbsSimpleNumFieldElem}, AbsSimpleNumFieldElem}}:
 Map: K -> K

julia> s = ans[1]
Map
  from number field of degree 1 over QQ
  to number field of degree 1 over QQ

julia> s(one(K))
1
```