### PR TITLE
Introduce `assure_reduced!(A::FinGenAbGroup, a::ZZMatrix)`

### DIFF
--- a/src/GrpAb/Elem.jl
+++ b/src/GrpAb/Elem.jl
@@ -47,16 +47,7 @@ end
 # This destroy's the input. If you don't want this, use A(::ZZMatrix)
 
 function FinGenAbGroupElem(A::FinGenAbGroup, a::ZZMatrix)
-  if is_snf(A)
-    return elem_snf(A, a)
-  else
-    return elem_gen(A, a)
-  end
-end
-
-function elem_gen(A::FinGenAbGroup, a::ZZMatrix)
-  assure_has_hnf(A)
-  reduce_mod_hnf_ur!(a, A.hnf)
+  assure_reduced!(A, a)
   z = FinGenAbGroupElem()
   z.parent = A
   z.coeff = a
@@ -78,12 +69,13 @@ function reduce_mod_snf!(a::ZZMatrix, v::Vector{ZZRingElem})
   end
 end
 
-function elem_snf(A::FinGenAbGroup, a::ZZMatrix)
-  reduce_mod_snf!(a, A.snf)
-  z = FinGenAbGroupElem()
-  z.parent = A
-  z.coeff = a
-  return z
+function assure_reduced!(A::FinGenAbGroup, a::ZZMatrix)
+  if is_snf(A)
+    reduce_mod_snf!(a, A.snf)
+  else
+    assure_has_hnf(A)
+    reduce_mod_hnf_ur!(a, A.hnf)
+  end
 end
 
 ################################################################################

--- a/src/GrpAb/Map.jl
+++ b/src/GrpAb/Map.jl
@@ -442,12 +442,7 @@ function compose(f::FinGenAbGroupHom, g::FinGenAbGroupHom)
   else
     M = f.map*g.map
   end
-  if is_snf(C)
-    reduce_mod_snf!(M, C.snf)
-  else
-    assure_has_hnf(C)
-    reduce_mod_hnf_ur!(M, C.hnf)
-  end
+  assure_reduced!(C, M)
   return hom(domain(f), codomain(g), M, check = false)
 end
 
@@ -456,12 +451,7 @@ function +(f::FinGenAbGroupHom, g::FinGenAbGroupHom)
   @assert codomain(f) == codomain(g)
   M = f.map + g.map
   C = codomain(f)
-  if is_snf(C)
-    reduce_mod_snf!(M, C.snf)
-  else
-    assure_has_hnf(C)
-    reduce_mod_hnf_ur!(M, C.hnf)
-  end
+  assure_reduced!(C, M)
 
   return hom(domain(f), codomain(f), M, check = false)
 end
@@ -471,12 +461,7 @@ function -(f::FinGenAbGroupHom, g::FinGenAbGroupHom)
   @assert codomain(f) == codomain(g)
   M = f.map - g.map
   C = codomain(f)
-  if is_snf(C)
-    reduce_mod_snf!(M, C.snf)
-  else
-    assure_has_hnf(C)
-    reduce_mod_hnf_ur!(M, C.hnf)
-  end
+  assure_reduced!(C, M)
 
   return hom(domain(f), codomain(f), M, check = false)
 end
@@ -484,12 +469,7 @@ end
 function -(f::FinGenAbGroupHom)
   M = -f.map
   C = codomain(f)
-  if is_snf(C)
-    reduce_mod_snf!(M, C.snf)
-  else
-    assure_has_hnf(C)
-    reduce_mod_hnf_ur!(M, C.hnf)
-  end
+  assure_reduced!(C, M)
 
   return hom(domain(f), codomain(f), M, check = false)
 end
@@ -497,12 +477,7 @@ end
 function Base.:(*)(a::IntegerUnion, f::FinGenAbGroupHom)
   M = a*f.map
   C = codomain(f)
-  if is_snf(C)
-    reduce_mod_snf!(M, C.snf)
-  else
-    assure_has_hnf(C)
-    reduce_mod_hnf_ur!(M, C.snf)
-  end
+  assure_reduced!(C, M)
   return hom(domain(f), codomain(f), M, check = false)
 end
 
@@ -527,12 +502,7 @@ function Base.:^(f::FinGenAbGroupHom, n::Integer)
   else
     M = f.map^n
   end
-  if is_snf(C)
-    reduce_mod_snf!(M, C.snf)
-  else
-    assure_has_hnf(C)
-    reduce_mod_hnf_ur!(M, C.snf)
-  end
+  assure_reduced!(C, M)
   return hom(domain(f), codomain(f), M, check = false)
 end
 
@@ -540,12 +510,7 @@ function evaluate(p::ZZPolyRingElem, f::FinGenAbGroupHom)
   @assert domain(f) === codomain(f)
   M = p(f.map)
   C = codomain(f)
-  if is_snf(C)
-    reduce_mod_snf!(M, C.snf)
-  else
-    assure_has_hnf(C)
-    reduce_mod_hnf_ur!(M, C.snf)
-  end
+  assure_reduced!(C, M)
   return hom(domain(f), codomain(f), M, check = false)
 end
 


### PR DESCRIPTION
Note that some of the replaced code was potentially wrong: it passed `A.snf` instead of `A.hnf` to `reduce_mod_hnf_ur!`. But I did not bother to see if this actually leads to problems.