### PR TITLE
Turn `FinGenAbGroupElem` into a non-mutable struct

### DIFF
--- a/src/GrpAb/Elem.jl
+++ b/src/GrpAb/Elem.jl
@@ -44,16 +44,6 @@ end
 #
 ################################################################################
 
-# This destroy's the input. If you don't want this, use A(::ZZMatrix)
-
-function FinGenAbGroupElem(A::FinGenAbGroup, a::ZZMatrix)
-  assure_reduced!(A, a)
-  z = FinGenAbGroupElem()
-  z.parent = A
-  z.coeff = a
-  return z
-end
-
 function reduce_mod_snf!(a::ZZMatrix, v::Vector{ZZRingElem})
   GC.@preserve a begin
     for i = 1:length(v)

--- a/src/HeckeTypes.jl
+++ b/src/HeckeTypes.jl
@@ -1828,11 +1828,16 @@ abstract type GrpAbElem <: AbstractAlgebra.AdditiveGroupElem end
 
 end
 
-mutable struct FinGenAbGroupElem <: GrpAbElem
+struct FinGenAbGroupElem <: GrpAbElem
   parent::FinGenAbGroup
   coeff::ZZMatrix
 
-  FinGenAbGroupElem() = new()
+  # This destroy's the input. If you don't want this, use A(::ZZMatrix)
+  function FinGenAbGroupElem(A::FinGenAbGroup, a::ZZMatrix)
+    assure_reduced!(A, a)
+    return new(A, a)
+  end
+
 end
 
 ################################################################################


### PR DESCRIPTION
This reduce allocations and increases speed of code using these elements.

Using the same example as in https://github.com/oscar-system/Oscar.jl/pull/4119, we get the following.

Before this PR here:

    julia> @btime is_homogeneous(f);
      1.533 μs (62 allocations: 2.28 KiB)

    julia> @btime is_homogeneous(F);
      3.932 μs (152 allocations: 5.53 KiB)

With just this PR:

    julia> @btime is_homogeneous(f);
      1.404 μs (48 allocations: 2.00 KiB)

    julia> @btime is_homogeneous(F);
      3.688 μs (116 allocations: 4.56 KiB)

With just https://github.com/oscar-system/Oscar.jl/pull/4119:

    julia> @btime is_homogeneous(f);
      334.071 ns (10 allocations: 416 bytes)

    julia> @btime is_homogeneous(F);
      556.150 ns (12 allocations: 656 bytes)

With this PR and https://github.com/oscar-system/Oscar.jl/pull/4119:

    julia> @btime is_homogeneous(f);
      330.772 ns (8 allocations: 352 bytes)
    
    julia> @btime is_homogeneous(F);
      564.865 ns (10 allocations: 592 bytes)

So allocations are further reduced but performance stays the same. But that's OK because in that example only relatively few `FinGenAbGroupElem` are used after https://github.com/oscar-system/Oscar.jl/pull/4119 ; but many other places still use them extensively, so it still seems quite useful to me to have this.