### PR TITLE
bump version number, in order to allow for GAP.jl 0.12

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Hecke"
 uuid = "3e1990a7-5d81-5526-99ce-9ba3ff248f21"
-version = "0.34.3"
+version = "0.34.4"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
@@ -31,7 +31,7 @@ PolymakeExt = "Polymake"
 AbstractAlgebra = "^0.43.1"
 Dates = "1.6"
 Distributed = "1.6"
-GAP = "0.9.6, 0.10, 0.11"
+GAP = "0.9.6, 0.10, 0.11, 0.12"
 InteractiveUtils = "1.6"
 LazyArtifacts = "1.6"
 Libdl = "1.6"

--- a/ext/GAPExt/abelian_layer.jl
+++ b/ext/GAPExt/abelian_layer.jl
@@ -16,7 +16,7 @@ function _real_level(L::GAP.GapObj)
       push!(lElem, g)
     end
   end
-  S = GAP.Globals.Subgroup(G, GAP.julia_to_gap(lElem))
+  S = GAP.Globals.Subgroup(G, GAP.GapObj(lElem))
   #Now, I check containment.
   k = 0
   for i = 2:length(L)
@@ -175,7 +175,7 @@ function _construct_grp(IdH::GAP.GapObj, uncom::Int)
     ex = ppio(o, uncom)[1]
     push!(new_gens, gens[i]^ex)
   end
-  S = GAP.Globals.Subgroup(G, GAP.julia_to_gap(new_gens))
+  S = GAP.Globals.Subgroup(G, GAP.GapObj(new_gens))
   Q = GAP.Globals.FactorGroup(G, S)
   IdCheck = GAP.Globals.IdGroup(Q)
   return IdCheck

--- a/ext/GAPExt/brauer.jl
+++ b/ext/GAPExt/brauer.jl
@@ -158,7 +158,7 @@ function find_subgroup(L::GAP.GapObj, level::Int)
     end
   end
   if !found
-    return found, GAP.julia_to_gap([candidate])
+    return found, GAP.GapObj([candidate])
   end
   #I need to change the series...
   L1 = GAP.GapObj[]
@@ -168,7 +168,7 @@ function find_subgroup(L::GAP.GapObj, level::Int)
   for i = level:length(L)
     push!(L1, GAP.Globals.Image(proj_comp, L[i]))
   end
-  return found, GAP.julia_to_gap(L1)
+  return found, GAP.GapObj(L1)
 end
 
 ################################################################################
@@ -227,7 +227,7 @@ function _to_prime_power_groups(cocycle::cocycle_ctx, p::Int)
   for i = 1:length(gensEp)
     push!(imgs_new_proj, GAP.Globals.Image(proj, gensEp[i]))
   end
-  imgs_proj = GAP.julia_to_gap(imgs_new_proj)
+  imgs_proj = GAP.GapObj(imgs_new_proj)
   Gp = GAP.Globals.Subgroup(G, imgs_proj)
   #I need the inclusion of Gp into G for strange (GAP) reasons.
   gensGp = GAP.Globals.GeneratorsOfGroup(Gp)
@@ -241,7 +241,7 @@ function _to_prime_power_groups(cocycle::cocycle_ctx, p::Int)
     prel = GAP.Globals.PreImagesRepresentative(inj_Ep, el)
     push!(images_inclusion, prel)
   end
-  imgs_inclusion = GAP.julia_to_gap(images_inclusion)
+  imgs_inclusion = GAP.GapObj(images_inclusion)
   new_incl = GAP.Globals.GroupHomomorphismByImages(A, Ep, gensA, imgs_inclusion)
   res =  cocycle_ctx(new_proj, new_incl, cocycle.cocycle)
   res.inclusion_of_pSylow = inclusion_Gp
@@ -318,14 +318,14 @@ function _to_subgroup_of_kernel(cocycle::cocycle_ctx, S)
     el_E = GAP.Globals.Image(cocycle.inclusion, el_A)
     push!(images_inclusion, GAP.Globals.Image(pr1, el_E))
   end
-  inclusion = GAP.Globals.GroupHomomorphismByImages(A_new, E_new, gensA_new, GAP.julia_to_gap(images_inclusion))
+  inclusion = GAP.Globals.GroupHomomorphismByImages(A_new, E_new, gensA_new, GAP.GapObj(images_inclusion))
   gensE_new = GAP.Globals.GeneratorsOfGroup(E_new)
   images_proj = []
   for i = 1:length(gensE_new)
     el = GAP.Globals.PreImagesRepresentative(pr1, gensE_new[i])
     push!(images_proj, GAP.Globals.Image(cocycle.projection, el))
   end
-  projection = GAP.Globals.GroupHomomorphismByImages(E_new, G, gensE_new, GAP.julia_to_gap(images_proj))
+  projection = GAP.Globals.GroupHomomorphismByImages(E_new, G, gensE_new, GAP.GapObj(images_proj))
   local new_coc
   let cocycle = cocycle, pr = pr
     function new_coc(x::GAP.GapObj, y::GAP.GapObj)
@@ -355,7 +355,7 @@ function _to_prime_power_kernel(cocycle::cocycle_ctx, p::Int)
   E = GAP.Globals.Source(cocycle.projection)
   G = GAP.Globals.ImagesSource(cocycle.projection)
   sizeG = GAP.Globals.Size(G)
-  S = GAP.Globals.Subgroup(A, GAP.julia_to_gap(gens_sub))
+  S = GAP.Globals.Subgroup(A, GAP.GapObj(gens_sub))
   pr = GAP.Globals.NaturalHomomorphismByNormalSubgroup(A, S)
   #I still need to create the maps.
   S1 = GAP.Globals.Image(cocycle.inclusion, S)
@@ -369,14 +369,14 @@ function _to_prime_power_kernel(cocycle::cocycle_ctx, p::Int)
     el_E = GAP.Globals.Image(cocycle.inclusion, el_A)
     push!(images_inclusion, GAP.Globals.Image(pr1, el_E))
   end
-  inclusion = GAP.Globals.GroupHomomorphismByImages(A_new, E_new, gensA_new, GAP.julia_to_gap(images_inclusion))
+  inclusion = GAP.Globals.GroupHomomorphismByImages(A_new, E_new, gensA_new, GAP.GapObj(images_inclusion))
   gensE_new = GAP.Globals.GeneratorsOfGroup(E_new)
   images_proj = []
   for i = 1:length(gensE_new)
     el = GAP.Globals.PreImagesRepresentative(pr1, gensE_new[i])
     push!(images_proj, GAP.Globals.Image(cocycle.projection, el))
   end
-  projection = GAP.Globals.GroupHomomorphismByImages(E_new, G, gensE_new, GAP.julia_to_gap(images_proj))
+  projection = GAP.Globals.GroupHomomorphismByImages(E_new, G, gensE_new, GAP.GapObj(images_proj))
   local new_coc
   let cocycle = cocycle, pr = pr
     function new_coc(x::GAP.GapObj, y::GAP.GapObj)
@@ -432,7 +432,7 @@ function _autos_to_check(G::GAP.GapObj, K::GAP.GapObj, E::GAP.GapObj, mG::GAP.Ga
   gK = GAP.Globals.GeneratorsOfGroup(K)
   for s = 1:length(gens)
     ind_auts_quo[s] = GAP.Globals.Image(isoAutG, GAP.Globals.InducedAutomorphism(mG, gens[s]))
-    igK = GAP.julia_to_gap([GAP.Globals.Image(gens[s], gK[i]) for i = 1:length(gK)])
+    igK = GAP.GapObj([GAP.Globals.Image(gens[s], gK[i]) for i = 1:length(gK)])
     h = GAP.Globals.GroupHomomorphismByImages(K, K, gK, igK)
     ind_auts_sub[s] = GAP.Globals.Image(isoAutK, h)
   end
@@ -443,7 +443,7 @@ function _autos_to_check(G::GAP.GapObj, K::GAP.GapObj, E::GAP.GapObj, mG::GAP.Ga
   for s = 1:length(gens)
     gensubs[s] = GAP.Globals.Image(EmbAutG, ind_auts_quo[s]) * GAP.Globals.Image(EmbAutK, ind_auts_sub[s])
   end
-  S = GAP.Globals.Subgroup(GProd, GAP.julia_to_gap(gensubs))
+  S = GAP.Globals.Subgroup(GProd, GAP.GapObj(gensubs))
   @vprintln :BrauerObst 1 "Map constructed. Enumerating cosets..."
   Transv = GAP.Globals.RightTransversal(GProd, S)
   Tperm = GAP.Globals.List(Transv)
@@ -472,7 +472,7 @@ function projections(mG::GAP.GapObj)
   for s = 1:length(gens)
     gens_img[s] = GAP.Globals.Image(isoAutG, GAP.Globals.InducedAutomorphism(mG, gens[s]))
   end
-  S = GAP.Globals.Subgroup(permAutG, GAP.julia_to_gap(gens_img))
+  S = GAP.Globals.Subgroup(permAutG, GAP.GapObj(gens_img))
   @vprintln :BrauerObst 1 "Map constructed. Enumerating cosets..."
   Transv = GAP.Globals.RightTransversal(permAutG, S)
   Tperm = GAP.Globals.List(Transv)

--- a/ext/GAPExt/conductors.jl
+++ b/ext/GAPExt/conductors.jl
@@ -95,7 +95,7 @@ function _conductors_using_cocycles(F::FieldsTower, st::Vector{Int}, l_cond::Vec
     for p in lp
       gHp = inertia_subgroups[p]
       els = [D[g] for g in gHp]
-      sub = GAP.Globals.Subgroup(G, GAP.julia_to_gap(els))
+      sub = GAP.Globals.Subgroup(G, GAP.GapObj(els))
       ord = GAP.Globals.Size(sub)
       subgs = Vector{GAP.GapObj}()
       preimages = Vector{Vector{GAP.GapObj}}(undef, length(els))
@@ -106,7 +106,7 @@ function _conductors_using_cocycles(F::FieldsTower, st::Vector{Int}, l_cond::Vec
       it = cartesian_product_iterator(UnitRange{Int}[1:n for i = 1:length(els)], inplace = true)
       sizes_preimages = Int[]
       for I in it
-        sub = GAP.Globals.Subgroup(E, GAP.julia_to_gap([preimages[i][I[i]] for i = 1:length(els)]))
+        sub = GAP.Globals.Subgroup(E, GAP.GapObj([preimages[i][I[i]] for i = 1:length(els)]))
         push!(sizes_preimages, GAP.Globals.Size(sub))
         if maximum(sizes_preimages) != ord && minimum(sizes_preimages) == ord
           break

--- a/ext/GAPExt/fields.jl
+++ b/ext/GAPExt/fields.jl
@@ -296,12 +296,12 @@ function _perm_to_gap_grp(perm::Vector{Vector{Int}})
     z = _perm_to_gap_perm(x)
     push!(g, z)
   end
-  g1 = GAP.julia_to_gap(g)
+  g1 = GAP.GapObj(g)
   return GAP.Globals.Group(g1)
 end
 
 function _perm_to_gap_perm(x::Vector{Int})
-  x1 = GAP.julia_to_gap(x)
+  x1 = GAP.GapObj(x)
   z = GAP.Globals.PermList(x1)
   return z
 end
@@ -322,7 +322,7 @@ function _split_extension(G::Vector{<: NumFieldHom{AbsSimpleNumField, AbsSimpleN
   gtype = map(Int, domain(mats[1]).snf)
   G1 = permutation_group(G)
   gensG1 = GAP.Globals.GeneratorsOfGroup(G1)
-  A = GAP.Globals.AbelianGroup(GAP.julia_to_gap(gtype))
+  A = GAP.Globals.AbelianGroup(GAP.GapObj(gtype))
   gens = GAP.Globals.GeneratorsOfGroup(A)
   auts = Vector{GAP.GapObj}(undef, length(mats))
   for i = 1:length(mats)
@@ -336,10 +336,10 @@ function _split_extension(G::Vector{<: NumFieldHom{AbsSimpleNumField, AbsSimpleN
       end
       images[j] = g
     end
-    auts[i] = GAP.Globals.GroupHomomorphismByImages(A, A, gens, GAP.julia_to_gap(images))
+    auts[i] = GAP.Globals.GroupHomomorphismByImages(A, A, gens, GAP.GapObj(images))
   end
-  AutGrp = GAP.Globals.Group(GAP.julia_to_gap(auts))
-  mp = GAP.Globals.GroupHomomorphismByImages(G1, AutGrp, gensG1, GAP.julia_to_gap(auts))
+  AutGrp = GAP.Globals.Group(GAP.GapObj(auts))
+  mp = GAP.Globals.GroupHomomorphismByImages(G1, AutGrp, gensG1, GAP.GapObj(auts))
   return GAP.Globals.SplitExtension(G1, mp, A)
 
 end

--- a/ext/GAPExt/maximal_abelian_subextension.jl
+++ b/ext/GAPExt/maximal_abelian_subextension.jl
@@ -17,7 +17,7 @@ function check_abelian_extensions(class_fields::Vector{Tuple{ClassField{MapRayCl
   #I need to compute the degree of the maximal abelian subextension over this subfield.
   deg_mas = Set{Int}()
   if degree(domain(F.subfields[i])) == 1
-    idH = GAP.julia_to_gap([1, 1])
+    idH = GAP.GapObj([1, 1])
   else
     idH = IdGroup(automorphism_list(domain(F.subfields[i])))
   end

--- a/ext/GAPExt/meataxe.jl
+++ b/ext/GAPExt/meataxe.jl
@@ -1,6 +1,6 @@
 ## `ZZRingElem` to GAP integer
-function _julia_to_gap(obj::ZZRingElem)
-  Nemo._fmpz_is_small(obj) && return GAP.julia_to_gap(Int(obj))
+function _GapObj(obj::ZZRingElem)
+  Nemo._fmpz_is_small(obj) && return GAP.GapObj(Int(obj))
   GC.@preserve obj begin
     x = Nemo._as_bigint(obj)
     return ccall((:MakeObjInt, GAP.libgap), GAP.GapObj, (Ptr{UInt64}, Cint), x.d, x.size)
@@ -42,10 +42,10 @@ end
 # computes the isomorphism between the Oscar field F and the corresponding GAP field
 function _ring_iso_oscar_gap(F::T) where T <: Union{Nemo.fpField, Nemo.FpField}
    p = characteristic(F)
-   G = GAP.Globals.GF(_julia_to_gap(p))
+   G = GAP.Globals.GF(_GapObj(p))
    e = GAP.Globals.One(G)
 
-   f(x::Union{Nemo.fpFieldElem, Nemo.FpFieldElem}) = _julia_to_gap(lift(x))*e
+   f(x::Union{Nemo.fpFieldElem, Nemo.FpFieldElem}) = _GapObj(lift(x))*e
    finv(x) = F(ZZRingElem(GAP.Globals.IntFFE(x)))
 
    return MapFromFunc(F, G, f, finv)
@@ -118,7 +118,7 @@ function _ring_iso_oscar_gap(F::T) where T <: Union{Nemo.fqPolyRepField, Nemo.Fq
 end
 
 function __to_gap(h, x::Vector)
-  return GAP.Globals.GModuleByMats(GAP.julia_to_gap([GAP.julia_to_gap(map(x -> _image(h, x), Matrix(y))) for y in x]), codomain(h))
+  return GAP.Globals.GModuleByMats(GAP.GapObj([GAP.GapObj(map(x -> _image(h, x), Matrix(y))) for y in x]), codomain(h))
 end
 
 function __gap_matrix_to_julia(h, g)

--- a/src/FieldFactory/CM_recognition.jl
+++ b/src/FieldFactory/CM_recognition.jl
@@ -4,7 +4,7 @@ function defines_CM_field(F::FieldsTower)
     return false, id_hom(K)
   end
   autsK = F.generators_of_automorphisms
-  permGC = GAP.julia_to_gap([_perm_to_gap_perm(x) for x in permutations(autsK)])
+  permGC = GAP.GapObj([_perm_to_gap_perm(x) for x in permutations(autsK)])
   perm_group = GAP.Globals.GroupByGenerators(permGC)
   Z = GAP.Globals.Center(perm_group)
   if isodd(GAP.Globals.Size(Z))


### PR DESCRIPTION
If Oscar.jl wants to use GAP.jl 0.12.0 then the Hecke.jl dependencies must allow GAP.jl 0.12 (see oscar-system/Oscar.jl/pull/4086).