### PR TITLE
Reduce default for max_precision in newton_iteration

### DIFF
--- a/src/EllCrv/NewtonLift.jl
+++ b/src/EllCrv/NewtonLift.jl
@@ -39,7 +39,7 @@ function _singular_points_weierstrass_model(E::EllipticCurve{<:AbstractAlgebra.G
 end
 
 @doc raw"""
-    newton_lift(E::EllipticCurve, P::EllipticCurvePoint, reduction_map; max_iterations=16) -> Bool, EllipticCurvePoint
+    newton_lift(E::EllipticCurve, P::EllipticCurvePoint, reduction_map; max_iterations=7) -> Bool, EllipticCurvePoint
 
 Return a point `Q` of `E` which reduces by `reduction_map` to `P` and whether it exists.
 
@@ -57,9 +57,9 @@ Input:
 - `E` -- the elliptic curve ``E/F(t)``
 - `p` -- a point of ``E/k(t)``
 - `reduction map` -- the canonical homomorphism $O_F \rightarrow k$
-- max_iterations -- the maximal number of Newton iteration steps
+- max_iterations -- the maximal number of Newton iteration steps, setting to a high value slows down computations a lot.
 """
-function newton_lift(E::EllipticCurve{<:Generic.FracFieldElem{<:PolyRingElem}}, P::EllipticCurvePoint{<:Generic.FracFieldElem{<:PolyRingElem}}, reduction_map::Map; max_iterations::Int=16)
+function newton_lift(E::EllipticCurve{<:Generic.FracFieldElem{<:PolyRingElem}}, P::EllipticCurvePoint{<:Generic.FracFieldElem{<:PolyRingElem}}, reduction_map::Map; max_iterations::Int=7)
   # O_F -> O_F/m =: k
   # K the completion of F at m
   sing = _singular_points_weierstrass_model(E)

--- a/src/EllCrv/NewtonLift.jl
+++ b/src/EllCrv/NewtonLift.jl
@@ -283,7 +283,7 @@ function can_solve_with_solution_mod(A::T, b::T, n::Int; side) where {T<: MatEle
   pi = uniformizer(OK)
   R, OK_to_R = residue_ring(OK, pi^n)
 
-  @show minimum(precision.(A))
+  #@show minimum(precision.(A))
   @assert minimum(precision.(A))>=n
   @assert minimum(precision.(b))>=n
 


### PR DESCRIPTION
Reduces the default value since otherwise computations take too long. 
An early abort will have to wait until #1509 and the likes are resolved.