### PR TITLE
Add `components` method to Abelian group

### DIFF
--- a/docs/src/manual/abelian/elements.md
+++ b/docs/src/manual/abelian/elements.md
@@ -19,7 +19,7 @@ parent(x::FinGenAbGroupElem)
 ### Access
 
 ```@docs
-components(x::FinGenAbGroupElem)
+getindex(x::FinGenAbGroupElem, v::AbstractVector{Int})
 getindex(x::FinGenAbGroupElem, i::Int)
 ```
 

--- a/docs/src/manual/abelian/elements.md
+++ b/docs/src/manual/abelian/elements.md
@@ -19,6 +19,7 @@ parent(x::FinGenAbGroupElem)
 ### Access
 
 ```@docs
+components(x::FinGenAbGroupElem)
 getindex(x::FinGenAbGroupElem, i::Int)
 ```
 

--- a/src/GrpAb/Elem.jl
+++ b/src/GrpAb/Elem.jl
@@ -158,20 +158,10 @@ function getindex(x::FinGenAbGroupElem, v::AbstractVector{Int})
   return [x.coeff[1, i] for i in v]
 end
 
-@doc raw"""
-    firstindex(x::FinGenAbGroupElem) -> Int64
-
-Returns the first component of the element $x$.
-"""
 function Base.firstindex(x::FinGenAbGroupElem)
-  return Int64(1)
+  return Int(1)
 end
 
-@doc raw"""
-    lastindex(x::FinGenAbGroupElem) -> Int64
-
-Returns the last component of the element $x$.
-"""
 function Base.lastindex(x::FinGenAbGroupElem)
   return ngens(parent(x))
 end

--- a/src/GrpAb/Elem.jl
+++ b/src/GrpAb/Elem.jl
@@ -138,6 +138,15 @@ end
 ################################################################################
 
 @doc raw"""
+    components(x::FinGenAbGroupElem) -> Vector{ZZRingElem}
+
+Returns the components of the element $x$.
+"""
+function components(x::FinGenAbGroupElem)
+  return x.coeff
+end
+
+@doc raw"""
     getindex(x::FinGenAbGroupElem, i::Int) -> ZZRingElem
 
 Returns the $i$-th component of the element $x$.

--- a/src/GrpAb/Elem.jl
+++ b/src/GrpAb/Elem.jl
@@ -138,21 +138,42 @@ end
 ################################################################################
 
 @doc raw"""
-    components(x::FinGenAbGroupElem) -> Vector{ZZRingElem}
-
-Returns the components of the element $x$.
-"""
-function components(x::FinGenAbGroupElem)
-  return x.coeff
-end
-
-@doc raw"""
     getindex(x::FinGenAbGroupElem, i::Int) -> ZZRingElem
 
 Returns the $i$-th component of the element $x$.
 """
 function getindex(x::FinGenAbGroupElem, i::Int)
   return x.coeff[1, i]
+end
+
+@doc raw"""
+    getindex(x::FinGenAbGroupElem, v::AbstractVector{Int}) -> Vector{ZZRingElem}
+
+Returns the $i$-th components of the element $x$ where $i \in v$.
+
+!!! note
+    This function is inefficient since the elements are internally stored using ZZMatrix but this function outputs a vector.
+"""
+function getindex(x::FinGenAbGroupElem, v::AbstractVector{Int})
+  return [x.coeff[1, i] for i in v]
+end
+
+@doc raw"""
+    firstindex(x::FinGenAbGroupElem) -> Int64
+
+Returns the first component of the element $x$.
+"""
+function Base.firstindex(x::FinGenAbGroupElem)
+  return Int64(1)
+end
+
+@doc raw"""
+    lastindex(x::FinGenAbGroupElem) -> Int64
+
+Returns the last component of the element $x$.
+"""
+function Base.lastindex(x::FinGenAbGroupElem)
+  return ngens(parent(x))
 end
 
 ################################################################################

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -206,7 +206,6 @@ export codifferent
 export codomain
 export coefficient_ideals
 export coefficients
-export components
 export coinvariant_lattice
 export cokernel
 export collapse_top_layer

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -206,6 +206,7 @@ export codifferent
 export codomain
 export coefficient_ideals
 export coefficients
+export components
 export coinvariant_lattice
 export cokernel
 export collapse_top_layer

--- a/test/GrpAb/Elem.jl
+++ b/test/GrpAb/Elem.jl
@@ -6,12 +6,14 @@
     a = @inferred FinGenAbGroupElem(G, N)
     @test parent(a) == G
     @test a.coeff == N
+    @test a[begin:end] == [0, 0, 0]
 
     G = @inferred abelian_group([3, 0])
     N = FlintZZ[1 1]
     a = @inferred FinGenAbGroupElem(G, N)
     @test @inferred parent(a) == G
     @test a.coeff == N
+    @test a[begin:end] == [1, 1]
 
     N = matrix(FlintZZ, 1, 2, [ 1, 1 ])
     a = @inferred G(N)
@@ -21,6 +23,7 @@
     a = @inferred G(N)
     @test @inferred parent(a) == G
     @test a.coeff == transpose(N)
+    @test a[begin:end] == [1, 1]
   end
 
   @testset "Generators" begin


### PR DESCRIPTION
@simonbrandhorst suggested that instead of accessing the property using the dot notation, a proper getter would be useful. I named the method `components` since this is how it is referred to in the docs.