### PR TITLE
Make `kernel(::SMat)` better infereable

### DIFF
--- a/src/Sparse/Rref.jl
+++ b/src/Sparse/Rref.jl
@@ -205,8 +205,6 @@ function kernel(M::SMat{T}; side::Symbol = :left) where T <: FieldElement
   Solve.check_option(side, [:right, :left], "side")
   if side == :right
     return _right_kernel(M)[2]
-  elseif side == :left
-    return _left_kernel(M)[2]
   end
-  error("unreachable")
+  return _left_kernel(M)[2]
 end

--- a/src/Sparse/Rref.jl
+++ b/src/Sparse/Rref.jl
@@ -208,4 +208,5 @@ function kernel(M::SMat{T}; side::Symbol = :left) where T <: FieldElement
   elseif side == :left
     return _left_kernel(M)[2]
   end
+  error("unreachable")
 end


### PR DESCRIPTION
Without this change, the compiler only infers `Union{dense_matrix_type(C), Nothing}`, as it does not know that the if/elseif clause get always taken due to the check in the beginning. Adding this explicit error  removes `Nothing` from the possible return types.