### PR TITLE
Change `eltype` methods for objects to types

### DIFF
--- a/src/Misc/Cartesian.jl
+++ b/src/Misc/Cartesian.jl
@@ -84,9 +84,9 @@ function Base.length(F::CartesianProductIt)
   return prod(length(x) for x in F.ranges)
 end
 
-Base.IteratorSize(::Type{CartesianProductIt{T}}) where T = Base.HasLength()
+Base.IteratorSize(::Type{<:CartesianProductIt{T}}) where T = Base.HasLength()
 
-Base.eltype(::CartesianProductIt{T}) where T = Vector{eltype(T)}
+Base.eltype(::Type{<:CartesianProductIt{T}}) where T = Vector{eltype(T)}
 
 function Base.getindex(F::CartesianProductIt{T}, i::Int) where T
   v = Vector{eltype{T}}(undef, length(F.ranges))

--- a/src/Misc/Integer.jl
+++ b/src/Misc/Integer.jl
@@ -281,7 +281,7 @@ mutable struct Divisors{T}
   end
 end
 
-Base.IteratorSize(::Divisors) = Base.HasLength()
+Base.IteratorSize(::Type{Divisors{T}}) where {T} = Base.HasLength()
 Base.length(D::Divisors) = length(D.s)
 Base.eltype(::Type{Divisors{T}}) where {T} = T
 

--- a/src/Misc/Poly.jl
+++ b/src/Misc/Poly.jl
@@ -992,5 +992,5 @@ function Base.iterate(
   return (f, (p, exp))
 end
 
-Base.IteratorSize(::FactorsOfSquarefree) = Base.SizeUnknown()
-Base.eltype(::FactorsOfSquarefree{T}) where T = T
+Base.IteratorSize(::Type{FactorsOfSquarefree{T}}) where T = Base.SizeUnknown()
+Base.eltype(::Type{FactorsOfSquarefree{T}}) where T = T

--- a/src/Misc/Primes.jl
+++ b/src/Misc/Primes.jl
@@ -398,7 +398,7 @@ end
 #  return A.to != -1 && st > A.to
 #end
 
-Base.eltype(::PrimesSet{T}) where {T <: IntegerUnion} = T
+Base.eltype(::Type{PrimesSet{T}}) where {T <: IntegerUnion} = T
 
 Base.length(A::PrimesSet) = length(collect(A))
 

--- a/src/Sparse/Matrix.jl
+++ b/src/Sparse/Matrix.jl
@@ -521,7 +521,7 @@ function length(A::SMat)
   return nrows(A)
 end
 
-Base.eltype(A::SMat{T}) where {T} = SRow{T}
+Base.eltype(::Type{<:SMat{T}}) where {T} = SRow{T}
 
 ################################################################################
 #

--- a/src/Sparse/Row.jl
+++ b/src/Sparse/Row.jl
@@ -358,9 +358,9 @@ function Base.iterate(A::SRow, st::Int = 1)
   return (A.pos[st], A.values[st]), st + 1
 end
 
-Base.eltype(::Type{SRow{T}}) where T = Tuple{Int, T}
+Base.eltype(::Type{<:SRow{T}}) where T = Tuple{Int, T}
 
-Base.IteratorSize(::SRow{T}) where T = Base.HasLength()
+Base.IteratorSize(::Type{<:SRow{T}}) where T = Base.HasLength()
 
 ################################################################################
 #


### PR DESCRIPTION
The docstring of `eltype` states
> However the form that accepts a type argument should be defined for new types. 

Chaning this should help julia infer types of iterator constructions like `Iterators.reverse(...)` for these types.


Furthermore, there were some methods installed that never triggered, e.g. `eltype(::Type{SMat{T}}) where T` does not get used as `SMat` has two type params. Changing this to  `eltype(::Type{<:SMat{T}}) where T` fixes this