### PR TITLE
fix: saturation at large primes

### DIFF
--- a/src/NumFieldOrd/NfOrd/ResidueRingMultGrp.jl
+++ b/src/NumFieldOrd/NfOrd/ResidueRingMultGrp.jl
@@ -714,6 +714,8 @@ of the first step. This allows to speed up subsequent calls with
 the same $g$ and $n$.
 """
 function baby_step_giant_step(g, n, h, cache::Dict)
+  # if cache is given, it must be empty or contain
+  # *all* big steps
   @assert typeof(g) == typeof(h)
   m = ZZRingElem(isqrt(n) + 1)
   if isempty(cache)

--- a/test/NfOrd/Clgp.jl
+++ b/test/NfOrd/Clgp.jl
@@ -285,4 +285,11 @@ end
       @test order(c) == 892
     end
   end
+
+  # saturation at large primes
+  
+  # the cyclotomic units are saturated at any prime l, since the class number h_149^+ is one.
+  K, = cyclotomic_real_subfield(149, "a")
+  u = Hecke._cyclotomic_units_totally_real_prime_conductor(K, 149)
+  @test nrows(Hecke.RelSaturate.compute_candidates_for_saturate(FacElem.(u[2:end]), next_prime(2^25))) == 0
 end


### PR DESCRIPTION
Use baby-step-giant-step algorithm for large primes to make
the complexity not linear in the order.

Before (saturating at ~2^25):
```julia
96.520001 seconds (56.86 k allocations: 120.018 GiB, 17.87% gc time)
```
With this PR:
```julia
2.726522 seconds (70.38 M allocations: 1.101 GiB, 30.02% gc time)
```