### PR TITLE
Update show for GroupAlgebraElem with sparse rep

### DIFF
--- a/src/AlgAss/Elem.jl
+++ b/src/AlgAss/Elem.jl
@@ -752,7 +752,7 @@ function show(io::IO, a::AbstractAssociativeAlgebraElem)
         for (i, ci) in a.coeffs_sparse
           push!(sum.args,
                 Expr(:call, :*, AbstractAlgebra.expressify(ci, context = io),
-                                AbstractAlgebra.expressify(parent(a).base_to_group[i], context = IOContext(io, :compact => true))))
+                                Expr(:call, :e, AbstractAlgebra.expressify(parent(a).base_to_group[i], context = IOContext(io, :compact => true)))))
         end
       end
       print(io, AbstractAlgebra.expr_to_string(AbstractAlgebra.canonicalize(sum)))

--- a/src/AlgAss/Elem.jl
+++ b/src/AlgAss/Elem.jl
@@ -263,10 +263,10 @@ function getindex(a::GroupAlgebraElem{S, GroupAlgebra{S, T, U}}, g::U) where {S,
     if !haskey(parent(a).group_to_base, g)
       return zero(base_ring(parent(a)))
     else
-      return a.coeffs_sparse[parent(a).group_to_base[g]]
+      return a.coeffs_sparse[parent(a).group_to_base[g]]::S
     end
   else
-    return a.coeffs[parent(a).group_to_base[g]]
+    return a.coeffs[parent(a).group_to_base[g]]::S
   end
 end
 


### PR DESCRIPTION
Let me show the current issue with an example. To reproduce, you need the branch https://github.com/oscar-system/Oscar.jl/tree/lg/character-ring together with a dev'ed Hecke that includes https://github.com/thofma/Hecke.jl/pull/1685.

```julia
julia> R = root_system(:A, 2);

julia> P = weight_lattice(R); # this is basically ZZ^2, but with nice printing

julia> ZP = group_algebra(ZZ, P);

julia> z = zero(ZP)
0

julia> o = one(ZP)
0

julia> z == o # but they print the same
false

julia> 42 * one(ZP) # that should be something like `42 * 0` or `42 * e(0)`
0

julia> a = ZP(gen(P, 1)) + ZP(gen(P, 2))
w_1 + w_2

julia> b = ZP(gen(P, 1) + gen(P, 2))
w_1 + w_2

julia> a == b # but they print the same
false
```
Thus I propose to instead of just writing the group elem as the basis elem, to do something like `e(g)` as often done in the literature. With this change enabled, the problematic lines from above change to the following, which IMO is a clear readability and disambiguation improvement.
```julia
julia> z = zero(ZP)
0

julia> o = one(ZP)
e(0)

julia> 42 * one(ZP) # that should be something like `42 * 0` or `42 * e(0)`
42*e(0)

julia> a = ZP(gen(P, 1)) + ZP(gen(P, 2))
e(w_1) + e(w_2)

julia> b = ZP(gen(P, 1) + gen(P, 2))
e(w_1 + w_2)
```