### PR TITLE
Fix show method for pseudo-matrices

### DIFF
--- a/src/NumFieldOrd/NfOrd/LinearAlgebra.jl
+++ b/src/NumFieldOrd/NfOrd/LinearAlgebra.jl
@@ -214,7 +214,9 @@ end
 
 function show(io::IO, P::PMat)
   compact = get(io, :compact, false)
-  if compact
+  if nrows(P.matrix) == 0
+    print(io, "empty $(0) x $(ncols(P)) pseudo-matrix")
+  elseif compact
     for i in 1:nrows(P.matrix)
       i == 1 || print(io, "\n")
       print(io, "(")


### PR DESCRIPTION
Previously, generating a pseudo-matrix over an algebraic number field with zero rows was possible, e.g.,

`K, _ = quadratic_field(-5)`
`P = pseudo_matrix(identity_matrix(K, 0), [])`

and the pseudo-matrix P was created correctly. However, an error was raised, due to an undefined reference and this P could not be printed. This commit just adds an extra output for pseudo-matrices with zero rows.
