### PR TITLE
is_empty for pseudo-matrices

### DIFF
--- a/src/NumFieldOrd/NfOrd/LinearAlgebra.jl
+++ b/src/NumFieldOrd/NfOrd/LinearAlgebra.jl
@@ -2052,3 +2052,12 @@ function inv(x::Generic.MatSpaceElem{AbsSimpleNumFieldOrderElem})
   K = nf(R)
   return change_base_ring(R, inv(change_base_ring(K, x)))
 end
+
+################################################################################
+#
+#  Emptiness check
+#
+################################################################################
+
+is_empty(P::PMat) = is_empty(matrix(P))
+

--- a/src/NumFieldOrd/NfOrd/LinearAlgebra.jl
+++ b/src/NumFieldOrd/NfOrd/LinearAlgebra.jl
@@ -214,7 +214,9 @@ end
 
 function show(io::IO, P::PMat)
   compact = get(io, :compact, false)
-  if compact
+  if nrows(P.matrix) == 0
+    print(io, "empty $(0) x $(ncols(P)) pseudo-matrix")
+  elseif compact
     for i in 1:nrows(P.matrix)
       i == 1 || print(io, "\n")
       print(io, "(")

--- a/test/NfOrd/LinearAlgebra.jl
+++ b/test/NfOrd/LinearAlgebra.jl
@@ -156,6 +156,11 @@
       @test isempty(pmat20)
       @test !is_empty(pmat11)
       @test !is_empty(pmat23)
+      
+      @test sprint(show, pmat00) isa String
+      @test sprint(show, pmat02) isa String
+      @test sprint(show, pmat20) isa String
+
     end
   end
 

--- a/test/NfOrd/LinearAlgebra.jl
+++ b/test/NfOrd/LinearAlgebra.jl
@@ -137,6 +137,26 @@
       @test Hecke._in_span(map(K, [1, 2, 3, 4]), A)[1]
       @test Hecke._in_span(map(K, [5, 6, 7, 8]), A)[1] == false
     end
+    @testset "emptiness" begin
+      K, a = quadratic_field(-5)
+      O = maximal_order(K)
+      ide = fractional_ideal(O, one(O))
+      pmat00 = pseudo_matrix(identity_matrix(K, 0), [])
+      pmat02 = pseudo_matrix(matrix(K, 0, 2, []), [])
+      pmat20 = pseudo_matrix(matrix(K, 2, 0, []), [ide, ide])
+      pmat11 = pseudo_matrix(identity_matrix(K, 1), [ide])
+      pmat23 = pseudo_matrix(matrix(K, 2, 3, [1, 2, 3, a, 2*a, 3*a]), [ide, ide])
+      @test is_empty(pmat00)
+      @test is_empty(pmat02)
+      @test is_empty(pmat20)
+      @test !is_empty(pmat11)
+      @test !is_empty(pmat23)
+      @test isempty(pmat00)
+      @test isempty(pmat02)
+      @test isempty(pmat20)
+      @test !is_empty(pmat11)
+      @test !is_empty(pmat23)
+    end
   end
 
   @testset "rand" begin


### PR DESCRIPTION
It seems natural to have an 'is_empty'-method for pseudo-matrices, so this commit adds one. I also added a couple of tests.