### PR TITLE
Refactor FOO_type functions

### DIFF
--- a/src/AlgAss/AlgGrp.jl
+++ b/src/AlgAss/AlgGrp.jl
@@ -16,11 +16,8 @@ Generic.dim(A::GroupAlgebra) = order(Int, group(A))
 
 elem_type(::Type{GroupAlgebra{T, S, R}}) where {T, S, R} = GroupAlgebraElem{T, GroupAlgebra{T, S, R}}
 
-order_type(::GroupAlgebra{QQFieldElem, S, R}) where { S, R } = AlgAssAbsOrd{GroupAlgebra{QQFieldElem, S, R}, elem_type(GroupAlgebra{QQFieldElem, S, R})}
-
 order_type(::Type{GroupAlgebra{QQFieldElem, S, R}}) where { S, R } = AlgAssAbsOrd{GroupAlgebra{QQFieldElem, S, R}, elem_type(GroupAlgebra{QQFieldElem, S, R})}
 
-order_type(::GroupAlgebra{T, S, R}) where { T <: NumFieldElem, S, R } = AlgAssRelOrd{T, fractional_ideal_type(order_type(parent_type(T))), GroupAlgebra{T, S, R}}
 order_type(::Type{GroupAlgebra{T, S, R}}) where { T <: NumFieldElem, S, R } = AlgAssRelOrd{T, fractional_ideal_type(order_type(parent_type(T))), GroupAlgebra{T, S, R}}
 
 @doc raw"""

--- a/src/AlgAss/AlgMat.jl
+++ b/src/AlgAss/AlgMat.jl
@@ -26,10 +26,8 @@ has_one(A::MatAlgebra) = true
 
 elem_type(::Type{MatAlgebra{T, S}}) where { T, S } = MatAlgebraElem{T, S}
 
-order_type(::MatAlgebra{QQFieldElem, S}) where { S } = AlgAssAbsOrd{MatAlgebra{QQFieldElem, S}, elem_type(MatAlgebra{QQFieldElem, S})}
 order_type(::Type{MatAlgebra{QQFieldElem, S}}) where { S } = AlgAssAbsOrd{MatAlgebra{QQFieldElem, S}, elem_type(MatAlgebra{QQFieldElem, S})}
 
-order_type(::MatAlgebra{T, S}) where { T <: NumFieldElem, S } = AlgAssRelOrd{T, fractional_ideal_type(order_type(parent_type(T))), MatAlgebra{T, S}}
 order_type(::Type{MatAlgebra{T, S}}) where { T <: NumFieldElem, S } = AlgAssRelOrd{T, fractional_ideal_type(order_type(parent_type(T))), MatAlgebra{T, S}}
 
 matrix_algebra_type(K::Field) = matrix_algebra_type(typeof(K))

--- a/src/AlgAss/AlgQuat.jl
+++ b/src/AlgAss/AlgQuat.jl
@@ -71,11 +71,7 @@ dimension_of_center(A::QuaternionAlgebra) = 1
 
 (A::QuaternionAlgebra{T})(a::QQFieldElem) where {T} = A(map(base_ring(A), [a, 0, 0, 0]))
 
-order_type(::QuaternionAlgebra{QQFieldElem}) = order_type(QuaternionAlgebra{QQFieldElem})
-
 order_type(::Type{QuaternionAlgebra{QQFieldElem}}) = AlgAssAbsOrd{QuaternionAlgebra{QQFieldElem}, elem_type(QuaternionAlgebra{QQFieldElem})}
-
-order_type(::QuaternionAlgebra{T}) where { T <: NumFieldElem} = order_type(QuaternionAlgebra{T})
 
 order_type(::Type{QuaternionAlgebra{T}}) where {T <: NumFieldElem} = AlgAssRelOrd{T, fractional_ideal_type(order_type(parent_type(T))), QuaternionAlgebra{T}}
 

--- a/src/AlgAss/StructureConstantAlgebra.jl
+++ b/src/AlgAss/StructureConstantAlgebra.jl
@@ -9,7 +9,6 @@ elem_type(::Type{StructureConstantAlgebra{T}}) where {T} = AssociativeAlgebraEle
 # Definitions for orders
 order_type(::Type{StructureConstantAlgebra{QQFieldElem}}) = AlgAssAbsOrd{StructureConstantAlgebra{QQFieldElem}, elem_type(StructureConstantAlgebra{QQFieldElem})}
 order_type(::Type{StructureConstantAlgebra{T}}) where {T <: NumFieldElem} = AlgAssRelOrd{T, fractional_ideal_type(order_type(parent_type(T)))}
-order_type(A::StructureConstantAlgebra) = order_type(typeof(A))
 
 ################################################################################
 #

--- a/src/AlgAssAbsOrd/Order.jl
+++ b/src/AlgAssAbsOrd/Order.jl
@@ -1,12 +1,8 @@
 elem_type(::Type{AlgAssAbsOrd{S, T}}) where {S, T} = AlgAssAbsOrdElem{S, T}
 
-ideal_type(::AlgAssAbsOrd{S, T}) where {S, T} = AlgAssAbsOrdIdl{S, T}
-
 ideal_type(::Type{AlgAssAbsOrd{S, T}}) where {S, T} = AlgAssAbsOrdIdl{S, T}
 
 # There is no dedicated type for fractional ideals
-fractional_ideal_type(::AlgAssAbsOrd{S, T}) where {S, T} = AlgAssAbsOrdIdl{S, T}
-
 fractional_ideal_type(::Type{AlgAssAbsOrd{S, T}}) where {S, T} = AlgAssAbsOrdIdl{S, T}
 
 @doc raw"""

--- a/src/Hecke.jl
+++ b/src/Hecke.jl
@@ -547,6 +547,27 @@ Base.showerror(io::IO, ::NotImplemented) =
 function is_absolutely_irreducible end
 function multiplicative_group end
 
+
+# TODO: once https://github.com/Nemocas/AbstractAlgebra.jl/pull/1924 lands
+# and we require an AA version with it, remove the next four lines
+if !isdefined(AbstractAlgebra, :ideal_type)
+  ideal_type(x) = ideal_type(typeof(x))
+  ideal_type(T::DataType) = throw(MethodError(ideal_type, (T,)))
+end
+
+fractional_ideal_type(x) = fractional_ideal_type(typeof(x))
+fractional_ideal_type(T::DataType) = throw(MethodError(fractional_ideal_type, (T,)))
+
+place_type(x) = place_type(typeof(x))
+place_type(T::DataType) = throw(MethodError(place_type, (T,)))
+
+order_type(x) = order_type(typeof(x))
+order_type(T::DataType) = throw(MethodError(order_type, (T,)))
+
+embedding_type(x) = embedding_type(typeof(x))
+embedding_type(T::DataType) = throw(MethodError(embedding_type, (T,)))
+
+
 ################################################################################
 #
 #  "Submodules"

--- a/src/NumField/ComplexEmbeddings/NfAbs.jl
+++ b/src/NumField/ComplexEmbeddings/NfAbs.jl
@@ -6,8 +6,6 @@
 
 embedding_type(::Type{AbsSimpleNumField}) = AbsSimpleNumFieldEmbedding
 
-embedding_type(::AbsSimpleNumField) = embedding_type(AbsSimpleNumField)
-
 ################################################################################
 #
 #  Field access

--- a/src/NumField/ComplexEmbeddings/NfAbsNS.jl
+++ b/src/NumField/ComplexEmbeddings/NfAbsNS.jl
@@ -13,8 +13,6 @@ number_field(P::AbsNonSimpleNumFieldEmbedding) = P.field
 
 embedding_type(::Type{AbsNonSimpleNumField}) = AbsNonSimpleNumFieldEmbedding
 
-embedding_type(::AbsNonSimpleNumField) = AbsNonSimpleNumFieldEmbedding
-
 isreal(P::AbsNonSimpleNumFieldEmbedding) = P.isreal
 
 is_imaginary(P::AbsNonSimpleNumFieldEmbedding) = !P.isreal

--- a/src/NumField/ComplexEmbeddings/NfRel.jl
+++ b/src/NumField/ComplexEmbeddings/NfRel.jl
@@ -44,8 +44,6 @@ function embedding_type(::Type{RelSimpleNumField{T}}) where {T}
   return RelSimpleNumFieldEmbedding{embedding_type(parent_type(T)), RelSimpleNumField{T}}
 end
 
-embedding_type(K::RelSimpleNumField{T}) where {T} = embedding_type(RelSimpleNumField{T})
-
 _absolute_index(f::RelSimpleNumFieldEmbedding) = f.absolute_index
 
 number_field(f::RelSimpleNumFieldEmbedding) = f.field

--- a/src/NumField/NfAbs/NfAbs.jl
+++ b/src/NumField/NfAbs/NfAbs.jl
@@ -4,8 +4,6 @@
 #
 ################################################################################
 
-order_type(::AbsSimpleNumField) = AbsSimpleNumFieldOrder
-
 order_type(::Type{AbsSimpleNumField}) = AbsSimpleNumFieldOrder
 
 ################################################################################

--- a/src/NumField/NfAbs/NonSimple.jl
+++ b/src/NumField/NfAbs/NonSimple.jl
@@ -44,8 +44,6 @@ end
 #
 ################################################################################
 
-order_type(::AbsNonSimpleNumField) = AbsNumFieldOrder{AbsNonSimpleNumField, AbsNonSimpleNumFieldElem}
-
 order_type(::Type{AbsNonSimpleNumField}) = AbsNumFieldOrder{AbsNonSimpleNumField, AbsNonSimpleNumFieldElem}
 
 function iszero(a::AbsNonSimpleNumFieldElem)

--- a/src/NumField/NfRel/Conjugates.jl
+++ b/src/NumField/NfRel/Conjugates.jl
@@ -1,7 +1,5 @@
 place_type(::Type{T}) where {T <: NumField} = InfPlc{T, embedding_type(T)}
 
-place_type(K::NumField) = place_type(typeof(K))
-
 #function _signs(a)
 #  if iszero(a)
 #    error("element must not be zero")

--- a/src/NumField/NfRel/NfRel.jl
+++ b/src/NumField/NfRel/NfRel.jl
@@ -47,8 +47,6 @@ end
 #
 ################################################################################
 
-order_type(K::RelSimpleNumField{T}) where {T} = RelNumFieldOrder{T, fractional_ideal_type(order_type(base_field(K))), RelSimpleNumFieldElem{T}}
-
 order_type(::Type{RelSimpleNumField{T}}) where {T} = RelNumFieldOrder{T, fractional_ideal_type(order_type(parent_type(T))), RelSimpleNumFieldElem{T}}
 
 ################################################################################

--- a/src/NumField/NfRel/NfRelNS.jl
+++ b/src/NumField/NfRel/NfRelNS.jl
@@ -44,8 +44,6 @@ end
 #
 ################################################################################
 
-order_type(K::RelNonSimpleNumField{T}) where {T} = RelNumFieldOrder{T, fractional_ideal_type(order_type(base_field(K))), RelNonSimpleNumFieldElem{T}}
-
 order_type(::Type{RelNonSimpleNumField{T}}) where {T} = RelNumFieldOrder{T, fractional_ideal_type(order_type(parent_type(T))), RelNonSimpleNumFieldElem{T}}
 
 function Nemo.iszero(a::RelNonSimpleNumFieldElem)

--- a/src/NumField/QQ.jl
+++ b/src/NumField/QQ.jl
@@ -174,14 +174,10 @@ primary_decomposition(I::ZZIdl) = iszero(I) ? [ (I,I) ] :
 
 maximal_order(::QQField) = ZZ
 
-ideal_type(::ZZRing) = ZZIdl
-order_type(::QQField) = ZZRing
 ideal_type(::Type{ZZRing}) = ZZIdl
 order_type(::Type{QQField}) = ZZRing
-place_type(::QQField) = PosInf
 place_type(::Type{QQField}) = PosInf
-
-fractional_ideal_type(::QQField) = ZZFracIdl
+fractional_ideal_type(::Type{QQField}) = ZZFracIdl
 
 elem_in_nf(x::ZZRingElem) = QQ(x)
 

--- a/src/NumFieldOrd/NfOrd/NfOrd.jl
+++ b/src/NumFieldOrd/NfOrd/NfOrd.jl
@@ -10,15 +10,11 @@
 #
 ################################################################################
 
-Nemo.parent_type(::Type{AbsNumFieldOrderElem{S, T}}) where {S, T} = AbsNumFieldOrder{S, T}
+parent_type(::Type{AbsNumFieldOrderElem{S, T}}) where {S, T} = AbsNumFieldOrder{S, T}
 
-Nemo.elem_type(::Type{AbsNumFieldOrder{S, T}}) where {S, T} = AbsNumFieldOrderElem{S, T}
-
-ideal_type(::AbsNumFieldOrder{S, T}) where {S, T} = AbsNumFieldOrderIdeal{S, T}
+elem_type(::Type{AbsNumFieldOrder{S, T}}) where {S, T} = AbsNumFieldOrderElem{S, T}
 
 ideal_type(::Type{AbsNumFieldOrder{S, T}}) where {S, T} = AbsNumFieldOrderIdeal{S, T}
-
-fractional_ideal_type(::AbsNumFieldOrder{S, T}) where {S, T} = AbsSimpleNumFieldOrderFractionalIdeal
 
 fractional_ideal_type(::Type{AbsNumFieldOrder{S, T}}) where {S, T} = AbsSimpleNumFieldOrderFractionalIdeal
 

--- a/src/NumFieldOrd/NfRelOrd/NfRelOrd.jl
+++ b/src/NumFieldOrd/NfRelOrd/NfRelOrd.jl
@@ -22,11 +22,7 @@ base_ring_type(::Type{RelNumFieldOrder{T, S, U}}) where {T, S, U} = order_type(b
 
 elem_type(::Type{RelNumFieldOrder{T, S, U}}) where {T, S, U} = RelNumFieldOrderElem{T, U}
 
-ideal_type(::RelNumFieldOrder{T, S, U}) where {T, S, U} = RelNumFieldOrderIdeal{T, S, U}
-
 ideal_type(::Type{RelNumFieldOrder{T, S, U}}) where {T, S, U} = RelNumFieldOrderIdeal{T, S, U}
-
-fractional_ideal_type(::RelNumFieldOrder{T, S, U}) where {T, S, U} = RelNumFieldOrderFractionalIdeal{T, S, U}
 
 fractional_ideal_type(::Type{RelNumFieldOrder{T, S, U}}) where {T, S, U} = RelNumFieldOrderFractionalIdeal{T, S, U}
 


### PR DESCRIPTION
Provide generic methods which delegate from instances to types. Then delete many implementations for instances, and keep only those for types.

Also add missing `fractional_ideal_type(::Type{QQField})`.