### PR TITLE
Add some ring / field conformance tests

### DIFF
--- a/src/LocalField/LocalField.jl
+++ b/src/LocalField/LocalField.jl
@@ -37,6 +37,8 @@ prime(K::LocalField) = prime(base_field(K))
 #
 ################################################################################
 
+base_ring_type(::Type{LocalField{S, T}}) where {S <: FieldElem, T <: LocalFieldParameter} = parent_type(S)
+
 base_field_type(::Type{LocalField{S, T}}) where {S <: FieldElem, T <: LocalFieldParameter} = parent_type(S)
 
 elem_type(::Type{LocalField{S, T}}) where {S <: FieldElem, T <: LocalFieldParameter} = LocalFieldElem{S, T}
@@ -47,8 +49,8 @@ elem_type(::Type{LocalField{S, T}}) where {S <: FieldElem, T <: LocalFieldParame
 #
 ################################################################################
 
-is_domain_type(::Type{S}) where S <: LocalField = true
-is_exact_type(::Type{S}) where S <: LocalField = false
+is_domain_type(::Type{<: LocalFieldElem}) = true
+is_exact_type(::Type{<: LocalFieldElem}) = false
 isfinite(K::LocalField) = isfinite(base_field(K))
 
 ################################################################################
@@ -129,6 +131,10 @@ end
 #  Subfields
 #
 ################################################################################
+
+function base_ring(L::LocalField)
+  return base_ring(defining_polynomial(L))
+end
 
 function base_field(L::LocalField)
   return base_ring(defining_polynomial(L))

--- a/src/LocalField/LocalField.jl
+++ b/src/LocalField/LocalField.jl
@@ -37,8 +37,6 @@ prime(K::LocalField) = prime(base_field(K))
 #
 ################################################################################
 
-base_ring_type(::Type{LocalField{S, T}}) where {S <: FieldElem, T <: LocalFieldParameter} = parent_type(S)
-
 base_field_type(::Type{LocalField{S, T}}) where {S <: FieldElem, T <: LocalFieldParameter} = parent_type(S)
 
 elem_type(::Type{LocalField{S, T}}) where {S <: FieldElem, T <: LocalFieldParameter} = LocalFieldElem{S, T}
@@ -131,10 +129,6 @@ end
 #  Subfields
 #
 ################################################################################
-
-function base_ring(L::LocalField)
-  return base_ring(defining_polynomial(L))
-end
 
 function base_field(L::LocalField)
   return base_ring(defining_polynomial(L))

--- a/src/Misc/RelFiniteField.jl
+++ b/src/Misc/RelFiniteField.jl
@@ -58,7 +58,11 @@ end
 
 base_field_type(::Type{RelFinField{S}}) where S = parent_type(S)
 
-base_field(F::RelFinField{S}) where S= base_ring(F.defining_polynomial)::parent_type(S)
+base_field(F::RelFinField{S}) where S = base_ring(F.defining_polynomial)::parent_type(S)
+
+base_ring_type(::Type{RelFinField{S}}) where S = parent_type(S)
+
+base_ring(F::RelFinField{S}) where S = base_ring(F.defining_polynomial)::parent_type(S)
 
 characteristic(F::RelFinField) = characteristic(base_field(F))
 
@@ -140,6 +144,8 @@ data(a::RelFinFieldElem) = a.data
 iszero(x::RelFinFieldElem) = iszero(x.data)
 isone(x::RelFinFieldElem) = isone(x.data)
 is_unit(x::RelFinFieldElem) = !iszero(x)
+
+hash(x::RelFinFieldElem, h::UInt) = hash(x.data, h)
 
 ==(x::RelFinFieldElem{S, T}, y::RelFinFieldElem{S, T}) where {S, T} = x.data == y.data
 

--- a/src/Misc/RelFiniteField.jl
+++ b/src/Misc/RelFiniteField.jl
@@ -60,10 +60,6 @@ base_field_type(::Type{RelFinField{S}}) where S = parent_type(S)
 
 base_field(F::RelFinField{S}) where S = base_ring(F.defining_polynomial)::parent_type(S)
 
-base_ring_type(::Type{RelFinField{S}}) where S = parent_type(S)
-
-base_ring(F::RelFinField{S}) where S = base_ring(F.defining_polynomial)::parent_type(S)
-
 characteristic(F::RelFinField) = characteristic(base_field(F))
 
 order(F::RelFinField) = order(base_field(F))^degree(F)

--- a/src/NumField/Embedded.jl
+++ b/src/NumField/Embedded.jl
@@ -65,6 +65,8 @@ base_ring_type(::Type{<:EmbeddedNumField}) = QQField
 
 data(x::EmbeddedNumFieldElem) = x.element
 
+characteristic(::EmbeddedNumField) = 0
+
 function embedded_field(K::SimpleNumField, i::NumFieldEmb)
   @assert number_field(i) === K
   E = EmbeddedNumField(K, i)

--- a/src/NumField/NfRel/NfRel.jl
+++ b/src/NumField/NfRel/NfRel.jl
@@ -57,10 +57,6 @@ order_type(::Type{RelSimpleNumField{T}}) where {T} = RelNumFieldOrder{T, fractio
 
 @inline base_field(a::RelSimpleNumField{T}) where {T} = a.base_ring::parent_type(T)
 
-base_ring(a::RelSimpleNumField{T}) where {T} = a.base_ring::parent_type(T)
-
-base_ring_type(::Type{RelSimpleNumField{T}}) where {T} = parent_type(T)
-
 @inline data(a::RelSimpleNumFieldElem) = a.data
 
 @inline parent(a::RelSimpleNumFieldElem{T}) where {T} = a.parent::RelSimpleNumField{T}

--- a/src/NumField/NfRel/NfRel.jl
+++ b/src/NumField/NfRel/NfRel.jl
@@ -57,6 +57,10 @@ order_type(::Type{RelSimpleNumField{T}}) where {T} = RelNumFieldOrder{T, fractio
 
 @inline base_field(a::RelSimpleNumField{T}) where {T} = a.base_ring::parent_type(T)
 
+base_ring(a::RelSimpleNumField{T}) where {T} = a.base_ring::parent_type(T)
+
+base_ring_type(::Type{RelSimpleNumField{T}}) where {T} = parent_type(T)
+
 @inline data(a::RelSimpleNumFieldElem) = a.data
 
 @inline parent(a::RelSimpleNumFieldElem{T}) where {T} = a.parent::RelSimpleNumField{T}

--- a/test/LocalField/LocalField.jl
+++ b/test/LocalField/LocalField.jl
@@ -1,3 +1,16 @@
+# the following is copied from the `random_elem` function
+function test_elem(L::Union{QadicField, Hecke.LocalField})
+  b = basis(L)
+  n = degree(L)
+  r = [rand(1:5*n) for i in 1:n]   # Choose small coordinates
+  return sum( [r[i]*b[i] for i in 1:n])
+end
+
+# TODO/FIXME: implement isapprox so we can get rid of the following HACK:
+function equality(a::T, b::T) where {T <: Union{QadicFieldElem, Hecke.LocalFieldElem}}
+  return a == b
+end
+
 @testset "LocalField" begin
 
   @testset "Creation" begin
@@ -7,6 +20,9 @@
     @test precision(K) == 20
     @test characteristic(K) == 0
     @test prime(K) == 2
+
+    test_Field_interface(K)
+    #test_Field_interface_recursive(K)  # TODO/FIXME: does not work due to missing isapprox
 
     Kt, t = polynomial_ring(K, "t")
     g = t^2+2
@@ -40,8 +56,14 @@
 
   @testset "Norm" begin
     K = qadic_field(3, 4, precision = 10)[1]
+    test_Field_interface(K)
+    #test_Field_interface_recursive(K)  # TODO/FIXME: does not work due to missing isapprox
+
     Kx, x = polynomial_ring(K, "x")
     L = eisenstein_extension(x^20+3)[1]
+    test_Field_interface(L)
+    #test_Field_interface_recursive(L)  # TODO/FIXME: does not work due to missing isapprox
+
     b = @inferred basis(L)
     for i = 1:10
       r = 1+2*uniformizer(L)^i * sum([rand(1:10)*b[i] for i in 1:5])

--- a/test/Misc/RelFinField.jl
+++ b/test/Misc/RelFinField.jl
@@ -1,5 +1,12 @@
 @testset "RelFinField" begin
 
+  @testset "conformance" begin
+    F = Native.finite_field(3, 3, cached = false)[1]
+    x = polynomial_ring(F, "x", cached = false)[2]
+    K, gK = @inferred Native.finite_field(x^2+1, :a)
+    test_Field_interface_recursive(K)
+  end
+
   @testset "Basic properties" begin
     F = Native.finite_field(3, 3, cached = false)[1]
     x = polynomial_ring(F, "x", cached = false)[2]

--- a/test/NfRel/NfRel.jl
+++ b/test/NfRel/NfRel.jl
@@ -1,4 +1,20 @@
+function test_elem(K::RelSimpleNumField)
+  return rand(K, -10:10)
+end
+
 @testset "RelSimpleNumField" begin
+
+  @testset "conformance" begin
+    Qx, x = QQ["x"]
+    f = x^2 + 12x - 92
+    K, a = number_field(f, "a")
+    Ky, y = K["y"]
+
+    L, b = number_field(y^2 + y + 1, "b")
+
+    test_Field_interface_recursive(L)
+  end
+
   @testset "is_subfield" begin
     Qx, x = QQ["x"]
     f = x^2 + 12x - 92

--- a/test/NumField/Embedded.jl
+++ b/test/NumField/Embedded.jl
@@ -23,7 +23,7 @@ test_elem(E::Hecke.EmbeddedNumField) = E(rand(number_field(E), -10:10))
   @test sprint(show, a) isa String
   @test sprint(show, "text/plain", a) isa String
   @test E([1, 2]) == 1 + 2*a
-  test_Ring_interface(E)
+  test_Field_interface(E)
   # trigger expressify
   Et, t = E["t"]
   @test sprint(show, a * t) isa String


### PR DESCRIPTION
... and fix some issues this revealed. In particular "missing" `base_ring` methods
which the conformance tests kind of assume, but here in some cases "only" `base_field` methods were available.

Contains #1706 because of overlap.