### PR TITLE
Small fix of is_divisible (and divexact) + tests

### DIFF
--- a/src/AlgAss/Elem.jl
+++ b/src/AlgAss/Elem.jl
@@ -463,7 +463,7 @@ function is_divisible(a::AbstractAssociativeAlgebraElem, b::AbstractAssociativeA
   Ma = hcat(M, va)
   r = rref!(Ma)
 
-  if all(iszero, [ Ma[r, i] for i = 1:dim(A) ])
+  if r == 0 || all(iszero, [ Ma[r, i] for i = 1:dim(A) ])
     return false, A()
   end
 

--- a/test/AlgAss/Elem.jl
+++ b/test/AlgAss/Elem.jl
@@ -3,6 +3,11 @@
   f = x^2 + 1
   A = StructureConstantAlgebra(f)
 
+  @testset "divexact" begin
+    @test divexact(A([1,1]), A([1,1])) == one(A)
+    @test_throws ErrorException divexact(zero(A), zero(A))
+  end
+
   @testset "Is integral" begin
     @test Hecke.is_integral(A[1]) == true
     @test Hecke.is_integral(QQFieldElem(1, 2)*A[1]) == false


### PR DESCRIPTION
Given an instance `A` of a subtype of `Hecke.AbstractAssociativeAlgebra{T}`, trying

```julia

divexact(zero(A), zero(A))

```
would result in a `BoundsError` instead of the usual `ErrorException`, due to `r == 0` in the Elem.jl.

This commit fixes this an also adds two small tests.