### PR TITLE
fix: minor space typo in the `AbsAlgAssMor` output after decomposition of `group_algebra`

### DIFF
--- a/src/AlgAss/AlgGrp.jl
+++ b/src/AlgAss/AlgGrp.jl
@@ -178,11 +178,11 @@ function show(io::IO, A::GroupAlgebra)
   else
     print(io, "Group algebra of group ")
     if is_finite(group(A))
-      print(io, "of order ", order(group(A)))
+      print(io, "of order ", order(group(A)), " ")
     else
       print(io, "of infinite order ")
     end
-    print(io, " over ")
+    print(io, "over ")
     print(terse(io), base_ring(A))
   end
 end

--- a/src/AlgAss/AlgGrp.jl
+++ b/src/AlgAss/AlgGrp.jl
@@ -182,7 +182,7 @@ function show(io::IO, A::GroupAlgebra)
     else
       print(io, "of infinite order ")
     end
-    print(io, "over ")
+    print(io, " over ")
     print(terse(io), base_ring(A))
   end
 end


### PR DESCRIPTION
It seems there is a minor space typo as there is no space after order 5 in the output below:
```
julia> C = abelian_group(5);

julia> GA = group_algebra(GF(3), C);

julia> d = decompose(GA);

julia> d[1][2]
Map
  from structure constant algebra of dimension 1 over GF(3)
  to group algebra of group of order 5over GF(3)
```

I think the first output line is printed correctly from: https://github.com/thofma/Hecke.jl/blob/3f9f55b0c1e1c2c013f3ecd60d0000aba86d121a/src/AlgAss/StructureConstantAlgebra.jl#L362-L363

It seems the typo is due to this line, no space before over, it should be `" over " `as in the earlier clause

https://github.com/thofma/Hecke.jl/blob/3f9f55b0c1e1c2c013f3ecd60d0000aba86d121a/src/AlgAss/AlgGrp.jl#L185

Please help review this PR, thank you!
