### PR TITLE
Allow GAP.jl 0.13

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Hecke"
 uuid = "3e1990a7-5d81-5526-99ce-9ba3ff248f21"
-version = "0.35.7"
+version = "0.35.8"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
@@ -31,7 +31,7 @@ PolymakeExt = "Polymake"
 AbstractAlgebra = "^0.44.0"
 Dates = "1.6"
 Distributed = "1.6"
-GAP = "0.9.6, 0.10, 0.11, 0.12"
+GAP = "0.9.6, 0.10, 0.11, 0.12, 0.13"
 InteractiveUtils = "1.6"
 LazyArtifacts = "1.6"
 Libdl = "1.6"


### PR DESCRIPTION
Draft as GAP.jl 0.13.0 is not released yet.