### PR TITLE
Use `Lowercase` in some `show` methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ julia> K, a = number_field(f, "a");
 julia> O = maximal_order(K);
 
 julia> O
-Maximal order of Number field of degree 3 over QQ
-with basis AbsSimpleNumFieldElem[1, a, a^2]
+Maximal order of number field of degree 3 over QQ
+with basis [1, a, a^2]
 ```
 
 ## Documentation

--- a/src/AlgAss/AlgGrp.jl
+++ b/src/AlgAss/AlgGrp.jl
@@ -167,14 +167,14 @@ function show(io::IO, ::MIME"text/plain", A::GroupAlgebra)
 end
 
 function show(io::IO, A::GroupAlgebra)
+  io = pretty(io)
   if is_terse(io)
     print(io, "Group algebra of ")
     if is_finite(group(A))
-      print(io, "dimension ", order(group(A)))
+      print(io, "dimension ", order(group(A)), " ")
     else
       print(io, "infinite dimension ")
     end
-    print(io, " over ", base_ring(A))
   else
     print(io, "Group algebra of group ")
     if is_finite(group(A))
@@ -182,9 +182,9 @@ function show(io::IO, A::GroupAlgebra)
     else
       print(io, "of infinite order ")
     end
-    print(io, "over ")
-    print(terse(io), base_ring(A))
+    io = terse(io)
   end
+  print(io, "over ", Lowercase(), base_ring(A))
 end
 
 ################################################################################

--- a/src/GenOrd/GenOrd.jl
+++ b/src/GenOrd/GenOrd.jl
@@ -630,7 +630,7 @@ julia> k, a = quadratic_field(12);
 
 julia> integral_closure(ZZ, k)
 
-Maximal order of Real quadratic field defined by x^2 - 12
+Maximal order of real quadratic field defined by x^2 - 12
 with basis AbsSimpleNumFieldElem[1, 1//2*sqrt(12)]
 ```
 """

--- a/src/NumFieldOrd/NfOrd/NfOrd.jl
+++ b/src/NumFieldOrd/NfOrd/NfOrd.jl
@@ -194,8 +194,9 @@ end
 ################################################################################
 
 function show(io::IO, S::AbsNumFieldOrderSet)
+  io = pretty(io)
   print(io, "Set of orders of the number field ")
-  print(io, S.nf)
+  print(io, Lowercase(), S.nf)
 end
 
 function extra_name(O::AbsNumFieldOrder)
@@ -217,14 +218,21 @@ function show(io::IO, O::AbsNumFieldOrder)
 end
 
 function show_gen(io::IO, O::AbsNumFieldOrder)
+  io = pretty(io)
   print(io, "Order of ")
-  println(io, nf(O))
+  println(io, Lowercase(), nf(O))
   print(io, "with Z-basis ")
-  print(io, basis(O, copy = false))
+  b = basis(O, copy = false)
+  print(IOContext(terse(io), :typeinfo=>typeof(b)), b)
 end
 
 function show_maximal(io::IO, O::AbsNumFieldOrder)
-  print(io, "Maximal order of $(nf(O)) \nwith basis $(O.basis_nf)")
+  io = pretty(io)
+  print(io, "Maximal order of ")
+  println(io, Lowercase(), nf(O))
+  print(io, "with basis ")
+  b = O.basis_nf
+  print(IOContext(terse(io), :typeinfo=>typeof(b)), b)
 end
 
 ################################################################################

--- a/src/NumFieldOrd/NfOrd/NfOrd.jl
+++ b/src/NumFieldOrd/NfOrd/NfOrd.jl
@@ -223,6 +223,8 @@ function show_gen(io::IO, O::AbsNumFieldOrder)
   println(io, Lowercase(), nf(O))
   print(io, "with Z-basis ")
   b = basis(O, copy = false)
+  # use `typeinfo` in IOContext to change e.g. `AbsSimpleNumFieldElem[1, a, a^2]`
+  # to `[1, a, a^2]` when printing the base
   print(IOContext(terse(io), :typeinfo=>typeof(b)), b)
 end
 
@@ -232,7 +234,9 @@ function show_maximal(io::IO, O::AbsNumFieldOrder)
   println(io, Lowercase(), nf(O))
   print(io, "with basis ")
   b = O.basis_nf
-  print(IOContext(terse(io), :typeinfo=>typeof(b)), b)
+    # use `typeinfo` in IOContext to change e.g. `AbsSimpleNumFieldElem[1, a, a^2]`
+    # to `[1, a, a^2]` when printing the base
+    print(IOContext(terse(io), :typeinfo=>typeof(b)), b)
 end
 
 ################################################################################

--- a/src/NumFieldOrd/NfOrd/ResidueRing.jl
+++ b/src/NumFieldOrd/NfOrd/ResidueRing.jl
@@ -77,7 +77,8 @@ Base.deepcopy_internal(x::AbsOrdQuoRingElem, dict::IdDict) =
 ################################################################################
 
 function show(io::IO, Q::AbsOrdQuoRing)
-  print(io, "Quotient of $(Q.base_ring)")
+  io = pretty(io)
+  print(io, "Quotient of ", Lowercase(), Q.base_ring)
 end
 
 function AbstractAlgebra.expressify(x::AbsOrdQuoRingElem; context = nothing)


### PR DESCRIPTION
Also tweak how the bases are printed (print basis vector as `[x, y]` instead of `T[x,y]`)
