### PR TITLE
Skip doc preview for dependabot PRs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,9 +6,15 @@ include(normpath(joinpath(Hecke.pkgdir, "docs", "Build.jl")))
 
 Build.make(Hecke; strict = Documenter.except(:missing_docs), local_build=true, doctest=false, format = :vitepress, warnonly = false)
 
+should_push_preview = true
+if get(ENV, "GITHUB_ACTOR", "") == "dependabot[bot]"
+  # skip preview for dependabot PRs as they fail due to lack of permissions
+  should_push_preview = false
+end
+
 deploydocs(
   repo = "github.com/thofma/Hecke.jl.git",
   target = "build",
-  push_preview = true,
+  push_preview = should_push_preview,
   forcepush = true
 )


### PR DESCRIPTION
If https://github.com/thofma/Hecke.jl/pull/1735 is merged, this needs to be merged as well. Otherwise, the "Build docs" CI job will fail for dependabot PRs. See https://github.com/oscar-system/Oscar.jl/pull/4554 for more details.