### PR TITLE
feat: swap type parameter order for orders in algebras

### DIFF
--- a/src/AlgAss/StructureConstantAlgebra.jl
+++ b/src/AlgAss/StructureConstantAlgebra.jl
@@ -7,7 +7,7 @@
 elem_type(::Type{StructureConstantAlgebra{T}}) where {T} = AssociativeAlgebraElem{T, StructureConstantAlgebra{T}}
 
 # Definitions for orders
-order_type(::Type{StructureConstantAlgebra{QQFieldElem}}) = AlgAssAbsOrd{ZZRing, StructureConstantAlgebra{QQFieldElem}}
+order_type(::Type{StructureConstantAlgebra{QQFieldElem}}) = AlgAssAbsOrd{StructureConstantAlgebra{QQFieldElem}, ZZRing}
 
 #order_type(::Type{T}, ::Type{ZZRing}) where {T} = AlgAssAbsOrd{ZZRing, T}
 #

--- a/src/AlgAssAbsOrd/Ideal.jl
+++ b/src/AlgAssAbsOrd/Ideal.jl
@@ -81,7 +81,7 @@ function ideal(A::AbstractAssociativeAlgebra{QQFieldElem}, M::QQMatrix; M_in_hnf
     end
   end
   k = something(findfirst(i -> !is_zero_row(M, i), 1:nrows(M)), nrows(M) + 1)
-  return AlgAssAbsOrdIdl{ZZRing, typeof(A)}(A, ZZ, sub(M, k:nrows(M), 1:ncols(M)))
+  return AlgAssAbsOrdIdl{typeof(A), ZZRing}(A, ZZ, sub(M, k:nrows(M), 1:ncols(M)))
 end
 
 function ideal(A::AbstractAssociativeAlgebra, R::Ring, M::MatElem; M_in_hnf::Bool=false)
@@ -93,7 +93,7 @@ function ideal(A::AbstractAssociativeAlgebra, R::Ring, M::MatElem; M_in_hnf::Boo
     end
   end
   k = something(findfirst(i -> !is_zero_row(M, i), 1:nrows(M)), nrows(M) + 1)
-  return AlgAssAbsOrdIdl{typeof(R), typeof(A)}(A, R, sub(M, k:nrows(M), 1:ncols(M)))
+  return AlgAssAbsOrdIdl{typeof(A), typeof(R)}(A, R, sub(M, k:nrows(M), 1:ncols(M)))
 end
 
 @doc raw"""
@@ -2113,7 +2113,7 @@ end
 #
 ################################################################################
 
-function swan_module(R::AlgAssAbsOrd{<: Any, <: GroupAlgebra}, r::IntegerUnion)
+function swan_module(R::AlgAssAbsOrd{<: GroupAlgebra, <: Any}, r::IntegerUnion)
   A = algebra(R)
   n = order(group(A))
   @req is_coprime(n, r) "Argument must be coprime to group order"

--- a/src/AlgAssAbsOrd/Order.jl
+++ b/src/AlgAssAbsOrd/Order.jl
@@ -6,17 +6,17 @@
 
 algebra_type(x) = algebra_type(typeof(x))
 
-algebra_type(::Type{AlgAssAbsOrd{S, T}}) where {S, T} = T
+algebra_type(::Type{AlgAssAbsOrd{T, S}}) where {S, T} = T
 
-order_type(::Type{T}) where {T <: AbstractAssociativeAlgebra{QQFieldElem}} = AlgAssAbsOrd{ZZRing, T}
+order_type(::Type{T}) where {T <: AbstractAssociativeAlgebra{QQFieldElem}} = AlgAssAbsOrd{T, ZZRing}
 
 order_type(::Type{T}) where {S <: NumFieldElem, T <: AbstractAssociativeAlgebra{S}} = AlgAssRelOrd{S, fractional_ideal_type(order_type(parent_type(S))), T}
 
-order_type(::Type{T}, ::Type{ZZRing}) where {T <: AbstractAssociativeAlgebra{QQFieldElem}} = AlgAssAbsOrd{ZZRing, T}
+order_type(::Type{T}, ::Type{ZZRing}) where {T <: AbstractAssociativeAlgebra{QQFieldElem}} = AlgAssAbsOrd{T, ZZRing}
 
-order_type(::Type{T}, ::Type{S}) where {T, U <: FieldElem, S <: PolyRing{U}} = AlgAssAbsOrd{S, T}
+order_type(::Type{T}, ::Type{S}) where {T, U <: FieldElem, S <: PolyRing{U}} = AlgAssAbsOrd{T, S}
 
-order_type(::Type{T}, ::Type{S}) where {T, U <: FieldElem, S <: KInftyRing{U}} = AlgAssAbsOrd{S, T}
+order_type(::Type{T}, ::Type{S}) where {T, U <: FieldElem, S <: KInftyRing{U}} = AlgAssAbsOrd{T, S}
 
 elem_type(::Type{T}) where {T <: AlgAssAbsOrd} = AlgAssAbsOrdElem{T, elem_type(algebra_type(T))}
 
@@ -36,7 +36,7 @@ _algebra(O::AlgAssAbsOrd) = algebra(O)
 
 base_ring(O::AlgAssAbsOrd) = O.base_ring
 
-base_ring_type(::Type{AlgAssAbsOrd{S, T}}) where {S, T} = S
+base_ring_type(::Type{AlgAssAbsOrd{T, S}}) where {S, T} = S
 
 @doc raw"""
     is_commutative(O::AlgAssAbsOrd) -> Bool
@@ -204,10 +204,10 @@ function Order(A::AbstractAssociativeAlgebra, R::Ring, M::MatElem; check::Bool =
     if !b
       error("The basis matrix does not define an order")
     else
-      return AlgAssAbsOrd{typeof(R), typeof(A)}(A, R, deepcopy(M), Minv, v, cached)
+      return AlgAssAbsOrd{typeof(A), typeof(R)}(A, R, deepcopy(M), Minv, v, cached)
     end
   else
-    return AlgAssAbsOrd{typeof(R), typeof(A)}(A, R, deepcopy(M), cached)
+    return AlgAssAbsOrd{typeof(A), typeof(R)}(A, R, deepcopy(M), cached)
   end
 end
 
@@ -327,7 +327,7 @@ end
 
 absolute_basis(O::AlgAssAbsOrd) = basis(O)
 
-function basis_alg(O::AlgAssAbsOrd{S, T}; copy::Bool = true) where {S, T}
+function basis_alg(O::AlgAssAbsOrd{T, S}; copy::Bool = true) where {S, T}
   assure_basis_alg(O)
   if copy
     return deepcopy(O.basis_alg)::Vector{elem_type(T)}
@@ -336,7 +336,7 @@ function basis_alg(O::AlgAssAbsOrd{S, T}; copy::Bool = true) where {S, T}
   end
 end
 
-function basis(O::AlgAssAbsOrd{S, T}, A::T; copy::Bool = true) where {S, T}
+function basis(O::AlgAssAbsOrd{T, S}, A::T; copy::Bool = true) where {S, T}
   @req algebra(O) === A "Algebras do not match"
   return basis_alg(O, copy = copy)
 end
@@ -862,7 +862,7 @@ function new_maximal_order(O::AlgAssAbsOrd{S, T}, cache_in_substructures::Bool =
   return OO
 end
 
-function MaximalOrder(O::AlgAssAbsOrd{S, T}) where { S <: GroupAlgebra, T <: GroupAlgebraElem }
+function MaximalOrder(O::AlgAssAbsOrd{T, S}) where { S <: GroupAlgebra, T <: GroupAlgebraElem }
   A = algebra(O)
 
   if isdefined(A, :maximal_order)
@@ -1038,7 +1038,7 @@ end
 # for an ideal a of O.
 # See Bley, Johnston "Computing generators of free modules over orders in group
 # algebras", Prop. 5.1.
-function _simple_maximal_order(O::AlgAssAbsOrd{ZZRing, S1}, ::Val{with_transform} = Val(false)) where { S1 <: MatAlgebra, with_transform }
+function _simple_maximal_order(O::AlgAssAbsOrd{S1, ZZRing}, ::Val{with_transform} = Val(false)) where { S1 <: MatAlgebra, with_transform }
   A = algebra(O)
 
   if !(A isa MatAlgebra)

--- a/src/AlgAssAbsOrd/Types.jl
+++ b/src/AlgAssAbsOrd/Types.jl
@@ -5,7 +5,7 @@
 ################################################################################
 
 # Orders in algebras over the rationals
-@attributes mutable struct AlgAssAbsOrd{BRingType, AlgType} <: NCRing
+@attributes mutable struct AlgAssAbsOrd{AlgType, BRingType} <: NCRing
   algebra::AlgType                       # Algebra containing the order
   dim::Int
   base_ring::BRingType #= parent_type(elem_type) =#
@@ -35,28 +35,28 @@
   nice_order#Tuple{AlgAssAbsOrd, T}
   nice_order_ideal#::ZZRingElem
 
-  function AlgAssAbsOrd{BRingType, AlgType}(A::AlgType, R::BRingType) where {BRingType, AlgType}
+  function AlgAssAbsOrd{AlgType, BRingType}(A::AlgType, R::BRingType) where {AlgType, BRingType}
     # "Default" constructor with default values.
-    O = new{BRingType, AlgType}(A, dim(A), R)
+    O = new{AlgType, BRingType}(A, dim(A), R)
     O.is_maximal = 0
     O.isnice = false
     O.tcontain = zero_matrix(base_ring(A), 1, dim(A))
     return O
   end
 
-  function AlgAssAbsOrd{BRingType, AlgType}(A::AlgType, R::BRingType, M::MatElem, Minv::MatElem, B::Vector, cached::Bool = false) where {BRingType, AlgType}
+  function AlgAssAbsOrd{AlgType, BRingType}(A::AlgType, R::BRingType, M::MatElem, Minv::MatElem, B::Vector, cached::Bool = false) where {AlgType, BRingType}
     return get_cached!(AlgAssAbsOrdID, (A, R, M), cached) do
-      O = AlgAssAbsOrd{BRingType, AlgType}(A, R)
+      O = AlgAssAbsOrd{AlgType, BRingType}(A, R)
       O.basis_alg = B
       O.basis_matrix = M
       O.basis_mat_inv = Minv
       return O
-    end::AlgAssAbsOrd{BRingType, AlgType}
+    end::AlgAssAbsOrd{AlgType, BRingType}
   end
 
-  function AlgAssAbsOrd{BRingType, AlgType}(A::AlgType, R::BRingType, M::MatElem, cached::Bool = false) where {BRingType, AlgType}
+  function AlgAssAbsOrd{AlgType, BRingType}(A::AlgType, R::BRingType, M::MatElem, cached::Bool = false) where {AlgType, BRingType}
     return get_cached!(AlgAssAbsOrdID, (A, M), cached) do
-      O = AlgAssAbsOrd{BRingType, AlgType}(A, R)
+      O = AlgAssAbsOrd{AlgType, BRingType}(A, R)
       d = dim(A)
       O.basis_matrix = M
       O.basis_alg = Vector{elem_type(A)}(undef, d)
@@ -64,17 +64,17 @@
         O.basis_alg[i] = elem_from_mat_row(A, M, i)
       end
       return O
-    end::AlgAssAbsOrd{BRingType, AlgType}
+    end::AlgAssAbsOrd{AlgType, BRingType}
   end
 
-  function AlgAssAbsOrd{BRingType, AlgType}(A::AlgType, R::BRingType, B::Vector, cached::Bool = false) where {AlgType, BRingType}
+  function AlgAssAbsOrd{AlgType, BRingType}(A::AlgType, R::BRingType, B::Vector, cached::Bool = false) where {AlgType, BRingType}
     M = basis_matrix(B)
     return get_cached!(AlgAssAbsOrdID, (A, R, M), cached) do
-      O = AlgAssAbsOrd{BRingType, AlgType}(A, R)
+      O = AlgAssAbsOrd{AlgType, BRingType}(A, R)
       O.basis_alg = B
       O.basis_matrix = M
       return O
-    end::AlgAssAbsOrd{BRingType, AlgType}
+    end::AlgAssAbsOrd{AlgType, BRingType}
   end
 end
 
@@ -131,7 +131,7 @@ end
 #
 ################################################################################
 
-@attributes mutable struct AlgAssAbsOrdIdl{BRingType, AlgType}
+@attributes mutable struct AlgAssAbsOrdIdl{AlgType, BRingType}
   algebra::AlgType
   base_ring::BRingType
 
@@ -176,8 +176,8 @@ end
                                        # to different orders
   normred#::Dict{AlgAssAbsOrd{S, T}, QQFieldElem}
 
-  function AlgAssAbsOrdIdl{BRingType, AlgType}(A::AlgType, R::BRingType) where {BRingType, AlgType}
-    r = new{BRingType, AlgType}()
+  function AlgAssAbsOrdIdl{AlgType, BRingType}(A::AlgType, R::BRingType) where {AlgType, BRingType}
+    r = new{AlgType, BRingType}()
     r.algebra = A
     r.base_ring = R
     r.isleft = 0
@@ -191,8 +191,8 @@ end
     return r
   end
 
-  function AlgAssAbsOrdIdl{BRingType, AlgType}(A::AlgType, R::BRingType, M::MatElem) where {BRingType, AlgType}
-    r = AlgAssAbsOrdIdl{BRingType, AlgType}(A, R)
+  function AlgAssAbsOrdIdl{AlgType, BRingType}(A::AlgType, R::BRingType, M::MatElem) where {AlgType, BRingType}
+    r = AlgAssAbsOrdIdl{AlgType, BRingType}(A, R)
     r.basis_matrix = M
     n = nrows(M)
     if is_square(M)

--- a/src/ModAlgAss/Lattices/Basics.jl
+++ b/src/ModAlgAss/Lattices/Basics.jl
@@ -91,7 +91,7 @@ end
 Given a $\mathbf{Z}$-order $O$ of a rational matrix algebra contained in
 $\mathrm{M}_n(\mathbf{Z})$, return $\mathbf{Z}^n$ as an $O$-lattice.
 """
-function natural_lattice(O::AlgAssAbsOrd{ZZRing, <: MatAlgebra{QQFieldElem}})
+function natural_lattice(O::AlgAssAbsOrd{<: MatAlgebra{QQFieldElem}, ZZRing})
   A = algebra(O)
   if all(x -> isone(denominator(matrix(elem_in_algebra(x)))),
          basis(O, copy = false))


### PR DESCRIPTION
@fieker now it is the same as for `GenOrd`. First the field/algebra, then the "base ring".