### PR TITLE
Adapt to conformance test changes in AA

### DIFF
--- a/src/GenOrd/GenOrd.jl
+++ b/src/GenOrd/GenOrd.jl
@@ -916,3 +916,14 @@ function codifferent(O::GenOrd)
    end
   return fractional_ideal(O, inv(matrix(R, n, n, mat_entries)))
 end
+
+###############################################################################
+#
+#   Conformance test element generation
+#
+###############################################################################
+
+function ConformanceTests.generate_element(O::GenOrd{<:Any, ZZRing})
+  B = basis(O)
+  return sum(rand(-10:10) * B[i] for i in 1:degree(O))
+end

--- a/src/LocalField/PowerSeries.jl
+++ b/src/LocalField/PowerSeries.jl
@@ -317,6 +317,20 @@ function AbstractAlgebra.promote_rule(::Type{LaurentSeriesFieldValuationRingElem
   AbstractAlgebra.promote_rule(U, V) == U ? LaurentSeriesFieldValuationRingElem{S, T, U} : Union{}
 end
 
+###############################################################################
+#
+#   Conformance test element generation
+#
+###############################################################################
+
+function ConformanceTests.generate_element(R::LaurentSeriesFieldValuationRing; shift::Int = Int(characteristic(R)) - 1)
+  return R(rand(data(R), 0:shift))
+end
+
+function ConformanceTests.equality(a::T, b::T) where {T <: LaurentSeriesFieldValuationRingElem}
+  return a == b
+end
+
 ################################################################################
 #
 #  Construction

--- a/src/LocalField/ResidueRing.jl
+++ b/src/LocalField/ResidueRing.jl
@@ -393,6 +393,25 @@ function AbstractAlgebra.promote_rule(::Type{LocalFieldValuationRingResidueRingE
   AbstractAlgebra.promote_rule(T, U) == T ? LocalFieldValuationRingResidueRingElem{S, T} : Union{}
 end
 
+###############################################################################
+#
+#   Conformance test element generation
+#
+###############################################################################
+
+function ConformanceTests.generate_element(R::LocalFieldValuationRingResidueRing{<:LocalFieldValuationRing})
+  return R(ConformanceTests.generate_element(_valuation_ring(R)))
+end
+
+function ConformanceTests.generate_element(R::LocalFieldValuationRingResidueRing{<:LaurentSeriesFieldValuationRing})
+  O = _valuation_ring(R)
+  return R(ConformanceTests.generate_element(O; shift = _exponent(R)))
+end
+
+function ConformanceTests.equality(a::LocalFieldValuationRingElem{S, T}, b::LocalFieldValuationRingElem{S, T}) where {S, T}
+  return a == b
+end
+
 ################################################################################
 #
 #  Construction

--- a/src/LocalField/Ring.jl
+++ b/src/LocalField/Ring.jl
@@ -349,6 +349,37 @@ function AbstractAlgebra.promote_rule(::Type{LocalFieldValuationRingElem{S, T}},
   AbstractAlgebra.promote_rule(T, U) == T ? LocalFieldValuationRingElem{S, T} : Union{}
 end
 
+###############################################################################
+#
+#   Conformance test element generation
+#
+###############################################################################
+
+function _integral_test_elem(R::PadicField)
+  p = prime(R)
+  prec = rand(1:R.prec_max)
+  r = ZZRingElem(0):p-1
+  return R(sum(rand(r)*p^i for i in 0:prec))
+end
+
+function _integral_test_elem(R::NonArchLocalField)
+  d = degree(R)
+  a = gen(R)
+  x = R()
+  for i in 0:d - 1
+    if rand() < 0.5
+      # Only fill every second coefficient
+      continue
+    end
+    x += _integral_test_elem(base_field(R))*a^i
+  end
+  return x
+end
+
+function ConformanceTests.generate_element(R::LocalFieldValuationRing)
+  return R(_integral_test_elem(_field(R)))
+end
+
 ################################################################################
 #
 #  Construction

--- a/src/NumField/Embedded.jl
+++ b/src/NumField/Embedded.jl
@@ -429,3 +429,13 @@ end
 # default
 round(a::EmbeddedNumFieldElem) = round(a, RoundNearestTiesAway)
 round(::Type{ZZRingElem}, a::EmbeddedNumFieldElem) = round(ZZRingElem, a, RoundNearestTiesAway)
+
+###############################################################################
+#
+#   Conformance test element generation
+#
+###############################################################################
+
+function ConformanceTests.generate_element(E::EmbeddedNumField)
+  E(rand(number_field(E), -10:10))
+end

--- a/src/Sparse/Row.jl
+++ b/src/Sparse/Row.jl
@@ -57,6 +57,7 @@ sparse_row_type(::Type{T}) where {T <: NCRingElem} = SRow{T, sparse_inner_type(T
 
 
 ==(x::SRow{T}, y::SRow{T}) where {T} = (x.pos == y.pos) && (x.values == y.values)
+ConformanceTests.equality(A::SRow, B::SRow) = A == B
 
 ################################################################################
 #

--- a/test/GenOrd/GenOrd.jl
+++ b/test/GenOrd/GenOrd.jl
@@ -9,7 +9,7 @@ end
   K, _ = number_field(x^3 - 18, "a")
   O = @inferred Order(ZZ, K)
   @test O isa Hecke.GenOrd
-  test_Ring_interface(O)
+  ConformanceTests.test_Ring_interface(O)
 
   k = GF(5)
   kx, x = rational_function_field(k, "x")

--- a/test/GenOrd/GenOrd.jl
+++ b/test/GenOrd/GenOrd.jl
@@ -1,8 +1,3 @@
-function test_elem(O::Hecke.GenOrd{<: Any, ZZRing})
-  B = basis(O)
-  return sum(rand(-10:10) * B[i] for i in 1:degree(O))
-end
-
 @testset "GenOrd" begin
   # Test first the ring interface
   Qx, x = QQ["x"]

--- a/test/LocalField/PowerSeries.jl
+++ b/test/LocalField/PowerSeries.jl
@@ -11,8 +11,8 @@ end
   R = @inferred valuation_ring(K)
   @test is_domain_type(elem_type(R))
   @test !is_exact_type(elem_type(R))
-  test_Ring_interface(R)
-  #test_EuclideanRing_interface(R) # doesn't do anything for a non-exact ring
+  ConformanceTests.test_Ring_interface(R)
+  #ConformanceTests.test_EuclideanRing_interface(R) # doesn't do anything for a non-exact ring
 end
 
 @testset "Ring to field" begin

--- a/test/LocalField/PowerSeries.jl
+++ b/test/LocalField/PowerSeries.jl
@@ -1,11 +1,3 @@
-function test_elem(R::Hecke.LaurentSeriesFieldValuationRing)
-  return R(rand(data(R), 0:Int(characteristic(R)) - 1))
-end
-
-function Base.isapprox(a::T, b::T) where {T <: Hecke.LaurentSeriesFieldValuationRingElem}
-  return a == b
-end
-
 @testset "Conformance tests" begin
   K, x = laurent_series_field(GF(101), 30, "x", cached = false)
   R = @inferred valuation_ring(K)

--- a/test/LocalField/ResidueRing.jl
+++ b/test/LocalField/ResidueRing.jl
@@ -1,41 +1,3 @@
-function _integral_test_elem(R::PadicField)
-  p = prime(R)
-  prec = rand(1:R.prec_max)
-  r = ZZRingElem(0):p-1
-  return R(sum(rand(r)*p^i for i in 0:prec))
-end
-
-function _integral_test_elem(R::NonArchLocalField)
-  d = degree(R)
-  a = gen(R)
-  x = R()
-  for i in 0:d - 1
-    if rand() < 0.5
-      # Only fill every second coefficient
-      continue
-    end
-    x += _integral_test_elem(base_field(R))*a^i
-  end
-  return x
-end
-
-function test_elem(R::Hecke.LocalFieldValuationRing)
-  return R(_integral_test_elem(Hecke._field(R)))
-end
-
-function test_elem(R::Hecke.LocalFieldValuationRingResidueRing{<:Hecke.LocalFieldValuationRing})
-  return R(test_elem(Hecke._valuation_ring(R)))
-end
-
-function test_elem(R::Hecke.LaurentSeriesFieldValuationRing; shift::Int = 10)
-  return R(rand(data(R), 0:shift))
-end
-
-function test_elem(R::Hecke.LocalFieldValuationRingResidueRing{<:Hecke.LaurentSeriesFieldValuationRing})
-  O = Hecke._valuation_ring(R)
-  return R(test_elem(O, shift = Hecke._exponent(R)))
-end
-
 @testset "Conformance tests" begin
   F, _ = cyclotomic_field(20)
   OF = maximal_order(F)
@@ -82,9 +44,9 @@ end
   @test is_one(RtoS(R(1)))
   @test_throws ArgumentError RtoS(setprecision!(R(1), 1))
 
-  for a in [test_elem(R) for i in 1:10]
+  for a in [ConformanceTests.generate_element(R) for i in 1:10]
     @test RtoS\RtoS(a) == a
-    for b in [test_elem(R) for i in 1:10]
+    for b in [ConformanceTests.generate_element(R) for i in 1:10]
       @test RtoS\RtoS(b) == b
       @test RtoS(a + b) == RtoS(a) + RtoS(b)
       @test RtoS(a * b) == RtoS(a) * RtoS(b)

--- a/test/LocalField/ResidueRing.jl
+++ b/test/LocalField/ResidueRing.jl
@@ -57,7 +57,7 @@ end
     @test Hecke._exponent(R) == 3
     @test !is_domain_type(elem_type(R))
     @test is_exact_type(elem_type(R))
-    test_Ring_interface(R)
+    ConformanceTests.test_Ring_interface(R)
 
     p = uniformizer(R)
     @test p == R(pi)
@@ -69,7 +69,7 @@ end
 
     # the euclidean conformance test seems to assume that the ring is a domain
     R, _ = residue_ring(O, pi)
-    test_EuclideanRing_interface(R)
+    ConformanceTests.test_EuclideanRing_interface(R)
   end
 end
 

--- a/test/LocalField/Ring.jl
+++ b/test/LocalField/Ring.jl
@@ -29,16 +29,16 @@ end
   R = valuation_ring(K)
   @test is_domain_type(elem_type(R))
   @test !is_exact_type(elem_type(R))
-  test_Ring_interface(R)
-  #test_EuclideanRing_interface(R) # doesn't do anything for a non-exact ring
+  ConformanceTests.test_Ring_interface(R)
+  #ConformanceTests.test_EuclideanRing_interface(R) # doesn't do anything for a non-exact ring
 
   # QadicField
   K, a = qadic_field(17, 2)
   R = valuation_ring(K)
   @test is_domain_type(elem_type(R))
   @test !is_exact_type(elem_type(R))
-  test_Ring_interface(R)
-  #test_EuclideanRing_interface(R) # doesn't do anything for a non-exact ring
+  ConformanceTests.test_Ring_interface(R)
+  #ConformanceTests.test_EuclideanRing_interface(R) # doesn't do anything for a non-exact ring
 
   # LocalField
   F, _ = cyclotomic_field(20)
@@ -48,6 +48,6 @@ end
   R = valuation_ring(K)
   @test is_domain_type(elem_type(R))
   @test !is_exact_type(elem_type(R))
-  test_Ring_interface(R)
-  #test_EuclideanRing_interface(R) # doesn't do anything for a non-exact ring
+  ConformanceTests.test_Ring_interface(R)
+  #ConformanceTests.test_EuclideanRing_interface(R) # doesn't do anything for a non-exact ring
 end

--- a/test/LocalField/Ring.jl
+++ b/test/LocalField/Ring.jl
@@ -1,28 +1,3 @@
-function _integral_test_elem(R::PadicField)
-  p = prime(R)
-  prec = rand(1:R.prec_max)
-  r = ZZRingElem(0):p-1
-  return R(sum(rand(r)*p^i for i in 0:prec))
-end
-
-function _integral_test_elem(R::NonArchLocalField)
-  d = degree(R)
-  a = gen(R)
-  x = R()
-  for i in 0:d - 1
-    x += _integral_test_elem(base_field(R))*a^i
-  end
-  return x
-end
-
-function test_elem(R::Hecke.LocalFieldValuationRing)
-  return R(_integral_test_elem(Hecke._field(R)))
-end
-
-function Base.isapprox(a::Hecke.LocalFieldValuationRingElem{S, T}, b::Hecke.LocalFieldValuationRingElem{S, T}) where {S, T}
-  return a == b
-end
-
 @testset "Conformance tests" begin
   # PadicField
   K = padic_field(17)

--- a/test/NumField/Embedded.jl
+++ b/test/NumField/Embedded.jl
@@ -1,5 +1,3 @@
-test_elem(E::Hecke.EmbeddedNumField) = E(rand(number_field(E), -10:10))
-
 @testset "Embedded number field" begin
   Qx, x = QQ["x"]
   K, _a = number_field(x^2 - 2, "a")

--- a/test/NumField/Embedded.jl
+++ b/test/NumField/Embedded.jl
@@ -23,7 +23,7 @@ test_elem(E::Hecke.EmbeddedNumField) = E(rand(number_field(E), -10:10))
   @test sprint(show, a) isa String
   @test sprint(show, "text/plain", a) isa String
   @test E([1, 2]) == 1 + 2*a
-  test_Ring_interface(E)
+  ConformanceTests.test_Ring_interface(E)
   # trigger expressify
   Et, t = E["t"]
   @test sprint(show, a * t) isa String
@@ -47,7 +47,7 @@ test_elem(E::Hecke.EmbeddedNumField) = E(rand(number_field(E), -10:10))
   @test sprint(show, "text/plain", E) isa String
   @test sprint(show, a[1]) isa String
   @test sprint(show, "text/plain", a[1]) isa String
-  test_Ring_interface(E)
+  ConformanceTests.test_Ring_interface(E)
 
   # other constructors
   E, a = Hecke.embedded_number_field([x^2 - 2, x^2 - 3], [1.41, 1.6])

--- a/test/Sparse/Row.jl
+++ b/test/Sparse/Row.jl
@@ -210,7 +210,7 @@
     n = rand((1,1,1,2,5,7,15))
     return rand(-2^n:2^n)
   end
-  Main.equality(A::SRow, B::SRow) = A == B
+
   @testset "mutating arithmetic; R = $R" for R in (ZZ, QQ)
     for _ in 1:10
       maxind_A = rand(0:10)
@@ -223,21 +223,21 @@
       vals_B = elem_type(R)[R(rand((-1, 1)) * rand(1:10)) for _ in 1:length(inds_B)]
       B = sparse_row(R, inds_B, vals_B)
 
-      test_mutating_op_like_zero(zero, zero!, A)
+      ConformanceTests.test_mutating_op_like_zero(zero, zero!, A)
 
-      test_mutating_op_like_neg(-, neg!, A)
+      ConformanceTests.test_mutating_op_like_neg(-, neg!, A)
 
-      test_mutating_op_like_add(+, add!, A, B)
-      test_mutating_op_like_add(-, sub!, A, B)
-      test_mutating_op_like_add(*, mul!, A, randcoeff(), SRow)
-      test_mutating_op_like_add(*, mul!, randcoeff(), A, SRow)
-      test_mutating_op_like_add(*, mul!, A, ZZ(randcoeff()), SRow)
-      test_mutating_op_like_add(*, mul!, ZZ(randcoeff()), A, SRow)
+      ConformanceTests.test_mutating_op_like_add(+, add!, A, B)
+      ConformanceTests.test_mutating_op_like_add(-, sub!, A, B)
+      ConformanceTests.test_mutating_op_like_add(*, mul!, A, randcoeff(), SRow)
+      ConformanceTests.test_mutating_op_like_add(*, mul!, randcoeff(), A, SRow)
+      ConformanceTests.test_mutating_op_like_add(*, mul!, A, ZZ(randcoeff()), SRow)
+      ConformanceTests.test_mutating_op_like_add(*, mul!, ZZ(randcoeff()), A, SRow)
 
-      test_mutating_op_like_addmul((a, b, c) -> a + b*c, addmul!, A, B, randcoeff(), SRow)
-      test_mutating_op_like_addmul((a, b, c) -> a + b*c, addmul!, A, randcoeff(), B, SRow)
-      test_mutating_op_like_addmul((a, b, c) -> a - b*c, submul!, A, B, randcoeff(), SRow)
-      test_mutating_op_like_addmul((a, b, c) -> a - b*c, submul!, A, randcoeff(), B, SRow)
+      ConformanceTests.test_mutating_op_like_addmul((a, b, c) -> a + b*c, addmul!, A, B, randcoeff(), SRow)
+      ConformanceTests.test_mutating_op_like_addmul((a, b, c) -> a + b*c, addmul!, A, randcoeff(), B, SRow)
+      ConformanceTests.test_mutating_op_like_addmul((a, b, c) -> a - b*c, submul!, A, B, randcoeff(), SRow)
+      ConformanceTests.test_mutating_op_like_addmul((a, b, c) -> a - b*c, submul!, A, randcoeff(), B, SRow)
     end
   end
 end

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -6,7 +6,6 @@ using Hecke.Random
 using Hecke.RandomExtensions
 
 import Hecke.AbstractAlgebra
-include(joinpath(pathof(AbstractAlgebra), "..", "..", "test", "Rings-conformance-tests.jl"))
 
 import Hecke: mul!
 


### PR DESCRIPTION
Make use of the new submodule structure and names introduced in https://github.com/Nemocas/AbstractAlgebra.jl/pull/1954.

For some types I encountered multiple `test_elem` methods in different files. I did my best trying to somehow merge them together, but it would be good if someone with domain knowledge had a second look if they still do mathematically sensible things. See be21c136bd4c9c0714d144444a6861796a37b3d8 for the relevant changes.