### PR TITLE
Use Requires.jl for package extensions pre-1.9

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,12 +16,18 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RandomExtensions = "fb686558-2515-59ef-acaa-46db3789a887"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[extras]
+GAP = "c863536a-3901-11e9-33e7-d5cd0df7b904"
+Polymake = "d720cf60-89b5-51f5-aff5-213f193123e7"
 
 [weakdeps]
 GAP = "c863536a-3901-11e9-33e7-d5cd0df7b904"
 Polymake = "d720cf60-89b5-51f5-aff5-213f193123e7"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [extensions]
 GAPExt = "GAP"
@@ -43,10 +49,7 @@ Polymake = "0.10, 0.11"
 Printf = "1.6"
 Random = "1.6"
 RandomExtensions = "0.4.3"
+Requires = "1.3.0"
 Serialization = "1.6"
 SparseArrays = "1.6"
 julia = "1.6"
-
-[extras]
-GAP = "c863536a-3901-11e9-33e7-d5cd0df7b904"
-Polymake = "d720cf60-89b5-51f5-aff5-213f193123e7"

--- a/src/Hecke.jl
+++ b/src/Hecke.jl
@@ -37,6 +37,9 @@ using SparseArrays
 using Serialization
 using Random
 using Pkg
+if !isdefined(Base, :get_extension)
+  using Requires: @require
+end
 
 import AbstractAlgebra
 import AbstractAlgebra: get_cached!, @alias
@@ -252,6 +255,13 @@ function __init__()
 
   add_verbosity_scope(:ZGenRep)
   add_assertion_scope(:ZGenRep)
+
+  # Remove once all supported julia versions support package extensions, i.e. 1.9 or later.
+  # Same for all other places that use `isdefined(Base, :get_extension)`.
+  @static if !isdefined(Base, :get_extension)
+    @require GAP = "c863536a-3901-11e9-33e7-d5cd0df7b904" include("../ext/GAPExt/GAPExt.jl")
+    @require Polymake = "d720cf60-89b5-51f5-aff5-213f193123e7" include("../ext/PolymakeExt.jl")
+  end
 end
 
 module Globals


### PR DESCRIPTION
This enables some code deduplication in Oscar, see https://github.com/oscar-system/Oscar.jl/pull/4635.

It is exactly the same setup that we use for `TestExt` in AbstractAlgebra. Once we raise the minimum required julia version, most of this can get reverted again.

ping @thofma 