### PR TITLE
fix: mend assert order

### DIFF
--- a/src/AlgAssAbsOrd/ICM.jl
+++ b/src/AlgAssAbsOrd/ICM.jl
@@ -319,10 +319,10 @@ function _isconjugate(O::Union{ AbsNumFieldOrder, AlgAssAbsOrd }, M::ZZMatrix, N
   I, basisI = matrix_to_ideal(O, M)
   J, basisJ = matrix_to_ideal(O, N)
   t, a = is_isomorphic_with_map(J, I)
-  @assert J == a*I
   if !t
     return false, zero_matrix(ZZ, nrows(M), ncols(M))
   end
+  @assert J == a*I
 
   aBI = basis_matrix([ a*b for b in basisI ], FakeFmpqMat)
   BJ = basis_matrix(basisJ, FakeFmpqMat)

--- a/test/AlgAssAbsOrd/ICM.jl
+++ b/test/AlgAssAbsOrd/ICM.jl
@@ -89,4 +89,8 @@ end
   b, V = is_conjugate(M, N)
   @test b == false
 
+  M = ZZ[-2 0; -3 -8]
+  N = ZZ[2 5; -8 -12]
+  b, V = is_conjugate(M, N)
+  @test b == false
 end


### PR DESCRIPTION
Assert condition can only hold if ideals are isomorphic