### PR TITLE
Convert `@repl` blocks to `jldoctest`s; improve printing in doctests

### DIFF
--- a/docs/Build.jl
+++ b/docs/Build.jl
@@ -50,7 +50,7 @@ function make(Hecke::Module; strict = false,
   @info "Using bibliography: $(bib)"
 
   cd(joinpath(Hecke.pkgdir, "docs")) do
-    DocMeta.setdocmeta!(Hecke, :DocTestSetup, :(using Hecke); recursive = true)
+    DocMeta.setdocmeta!(Hecke, :DocTestSetup, Hecke.doctestsetup(); recursive = true)
     DocMeta.setdocmeta!(Hecke.Nemo, :DocTestSetup, :(using Hecke.Nemo); recursive = true)
 
     if format == :html

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # Examples and sample code
 

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -1,3 +1,9 @@
+```@meta
+CurrentModule = Hecke
+DocTestSetup = quote
+    using Hecke
+end
+```
 # Examples and sample code
 
 ```@contents

--- a/docs/src/howto/index.md
+++ b/docs/src/howto/index.md
@@ -1,7 +1,5 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # How-to guides

--- a/docs/src/howto/index.md
+++ b/docs/src/howto/index.md
@@ -1,1 +1,7 @@
+```@meta
+CurrentModule = Hecke
+DocTestSetup = quote
+    using Hecke
+end
+```
 # How-to guides

--- a/docs/src/howto/reduction.md
+++ b/docs/src/howto/reduction.md
@@ -8,29 +8,44 @@ Concretely, we want to reduce the polynomial
 over ``\mathbf{Q}(\zeta_7)``.
 We begin by defining the cyclotomic field and the polynomial.
 
-```@repl 1
-using Hecke # hide
-K, ζ = cyclotomic_field(7);
-Kx, x = K['x'];
-f = x^3 + (1 + ζ + ζ^2)*x^2 + (23 + 55ζ^5)x + (ζ + 77)//2
+```jldoctest 1
+julia> K, ζ = cyclotomic_field(7);
+
+julia> Kx, x = K[:x];
+
+julia> f = x^3 + (1 + ζ + ζ^2)*x^2 + (23 + 55ζ^5)x + (ζ + 77)//2
+x^3 + (z_7^2 + z_7 + 1)*x^2 + (55*z_7^5 + 23)*x + 1//2*z_7 + 77//2
 ```
 
 Next we determine the ring of integers ``\mathcal O_K`` and a prime ideal
 ``\mathfrak p`` lying above the prime ``p = 29``.
 
-```@repl 1
-OK = maximal_order(K);
-p = 29;
-frakp = prime_decomposition(OK, p)[1][1]
+```jldoctest 1
+julia> OK = maximal_order(K);
+
+julia> p = 29;
+
+julia> frakp = prime_decomposition(OK, p)[1][1]
+<29, z_7 + 22>
+Norm: 29
+Minimum: 29
+two normal wrt: 29
 ```
 
 We can now determine the residue field ``F = \mathcal{O}_K/\mathfrak p`` and
 the canonical map ``\mathcal O_K \to F``.
 
-```@repl 1
-F, reduction_map_OK = residue_field(OK, frakp);
-F
-reduction_map_OK
+```jldoctest 1
+julia> F, reduction_map_OK = residue_field(OK, frakp);
+
+julia> F
+Prime field of characteristic 29
+
+julia> reduction_map_OK
+Map
+  from maximal order of cyclotomic field of order 7
+  with basis [1, z_7, z_7^2, z_7^3, z_7^4, z_7^5]
+  to prime field of characteristic 29
 ```
 
 Not that the reduction map has domain ``\mathcal O_K`` and thus cannot be applied
@@ -39,16 +54,27 @@ by invoking the `extend` function.
 Not that the domain of the extended map will be the whole ``K``, but the map
 will throw an error when applied to elements which are not ``\mathfrak p``-integral.
 
-```@repl 1
-reduction_map_extended = extend(reduction_map_OK, K)
-reduction_map_extended(K(1//3))
-reduction_map_extended(K(1//29))
+```jldoctest 1
+julia> reduction_map_extended = extend(reduction_map_OK, K)
+Map
+  from cyclotomic field of order 7
+  to prime field of characteristic 29
+
+julia> reduction_map_extended(K(1//3))
+10
+
+julia> reduction_map_extended(K(1//29))
+ERROR: Element not p-integral
+[...]
 ```
 
 Finally we can reduce ``f`` modulo ``\mathfrak p``, which we obtain by applying
 the reduction map to the coefficients.
 
-```@repl 1
-fbar = map_coefficients(reduction_map_extended, f)
-base_ring(fbar) === F
+```jldoctest 1
+julia> fbar = map_coefficients(reduction_map_extended, f)
+x^3 + 28*x^2 + 4*x + 13
+
+julia> base_ring(fbar) === F
+true
 ```

--- a/docs/src/howto/reduction.md
+++ b/docs/src/howto/reduction.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # Reduction of polynomials over number fields modulo a prime ideal
 

--- a/docs/src/howto/reduction.md
+++ b/docs/src/howto/reduction.md
@@ -1,3 +1,9 @@
+```@meta
+CurrentModule = Hecke
+DocTestSetup = quote
+    using Hecke
+end
+```
 # Reduction of polynomials over number fields modulo a prime ideal
 
 Given a polynomial $f \in K[x]$ and a prime ideal $\mathfrak p$ of $\mathcal O_K$,

--- a/docs/src/manual/abelian/elements.md
+++ b/docs/src/manual/abelian/elements.md
@@ -41,11 +41,17 @@ order(A::FinGenAbGroupElem)
 ## Iterator
 One can iterate over the elements of a finite abelian group.
 
-```@repl
-using Hecke # hide
-G = abelian_group(ZZRingElem[1 2; 3 4])
-for g = G
-  println(g)
-end
+```jldoctest
+julia> G = abelian_group(ZZRingElem[1 2; 3 4])
+Finitely generated abelian group
+  with 2 generators and 2 relations and relation matrix
+  [1   2]
+  [3   4]
+
+julia> for g in G
+         println(g)
+       end
+Abelian group element [0, 0]
+Abelian group element [0, 1]
 ```
 

--- a/docs/src/manual/abelian/elements.md
+++ b/docs/src/manual/abelian/elements.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # Elements
 Elements in a finitely generated abelian group are of type `FinGenAbGroupElem`

--- a/docs/src/manual/abelian/introduction.md
+++ b/docs/src/manual/abelian/introduction.md
@@ -31,9 +31,9 @@ Alternatively, there are shortcuts to create products of cyclic groups:
 ```@docs
 abelian_group(M::Vector{Union{ZZRingElem, Integer}})
 ```
-```@repl
-using Hecke # hide
-G = abelian_group(2, 2, 6)
+```jldoctest
+julia> G = abelian_group(2, 2, 6)
+(Z/2)^2 x Z/6
 ```
 
 or even
@@ -42,9 +42,12 @@ or even
 free_abelian_group(::Int)
 abelian_groups(n::Int)
 ```
-```@repl
-using Hecke # hide
-abelian_groups(8)
+```jldoctest
+julia> abelian_groups(8)
+3-element Vector{FinGenAbGroup}:
+ (Z/2)^3
+ Z/2 x Z/4
+ Z/8
 ```
 
 ## Invariants

--- a/docs/src/manual/abelian/introduction.md
+++ b/docs/src/manual/abelian/introduction.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # [Introduction](@id AbelianGroupLink2)
 

--- a/docs/src/manual/abelian/maps.md
+++ b/docs/src/manual/abelian/maps.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # Maps
 Maps between abelian groups are mainly of type `FinGenAbGroupHom`. They

--- a/docs/src/manual/abelian/maps.md
+++ b/docs/src/manual/abelian/maps.md
@@ -20,20 +20,34 @@ hom_direct_sum(G::FinGenAbGroup, H::FinGenAbGroup, A::Matrix{ <: Map{FinGenAbGro
 is_isomorphic(G::FinGenAbGroup, H::FinGenAbGroup)
 ```
 
-```@repl
-using Hecke # hide
-G = free_abelian_group(2)
-h = hom(G, G, [gen(G, 2), 3*gen(G, 1)])
-h(gen(G, 1))
-h(gen(G, 2))
+```jldoctest
+julia> G = free_abelian_group(2)
+Z^2
+
+julia> h = hom(G, G, [gen(G, 2), 3*gen(G, 1)])
+Map
+  from Z^2
+  to Z^2
+
+julia> h(gen(G, 1))
+Abelian group element [0, 1]
+
+julia> h(gen(G, 2))
+Abelian group element [3, 0]
 ```
 
 Homomorphisms also allow addition and subtraction corresponding to the
 pointwise operation:
-```@repl
-using Hecke # hide
-G = free_abelian_group(2)
-h = hom(G, G, [2*gen(G, 2), 3*gen(G, 1)])
-(h+h)(gen(G, 1))
+```jldoctest
+julia> G = free_abelian_group(2)
+Z^2
+
+julia> h = hom(G, G, [2*gen(G, 2), 3*gen(G, 1)])
+Map
+  from Z^2
+  to Z^2
+
+julia> (h+h)(gen(G, 1))
+Abelian group element [0, 4]
 ```
 

--- a/docs/src/manual/abelian/structural.md
+++ b/docs/src/manual/abelian/structural.md
@@ -39,14 +39,23 @@ of a finite abelian group is available.
 ```@docs
 psubgroups(g::FinGenAbGroup, p::Integer)
 ```
-```@repl subgroups
-using Hecke # hide
-G = abelian_group([6, 12])
-shapes = MSet{Vector{ZZRingElem}}()
-for U = psubgroups(G, 2)
-  push!(shapes, elementary_divisors(U[1]))
-end
-shapes
+```jldoctest subgroups
+julia> G = abelian_group([6, 12])
+Z/6 x Z/12
+
+julia> shapes = MSet{Vector{ZZRingElem}}();
+
+julia> for U = psubgroups(G, 2)
+         push!(shapes, elementary_divisors(U[1]))
+       end
+
+julia> shapes
+MSet{Vector{ZZRingElem}} with 8 elements:
+  ZZRingElem[]
+  ZZRingElem[4]    : 2
+  ZZRingElem[2, 4]
+  ZZRingElem[2]    : 3
+  ZZRingElem[2, 2]
 ```
 So there are $2$ subgroups isomorphic to $C_4$ (`ZZRingElem[4] : 2`),
 $1$ isomorphic to $C_2\times C_4$, 1 trivial and $3$ $C_2$ subgroups.
@@ -54,13 +63,20 @@ $1$ isomorphic to $C_2\times C_4$, 1 trivial and $3$ $C_2$ subgroups.
 ```@docs
 subgroups(g::FinGenAbGroup)
 ```
-```@repl subgroups
-for U = subgroups(G, subtype = [2])
-  @show U[1], map(U[2], gens(U[1]))
-end
-for U = subgroups(G, quotype = [2])
-  @show U[1], map(U[2], gens(U[1]))
-end
+```jldoctest subgroups
+julia> for U in subgroups(G, subtype = [2])
+         @show U[1], map(U[2], gens(U[1]))
+       end
+(U[1], map(U[2], gens(U[1]))) = (Z/2, FinGenAbGroupElem[[0, 6]])
+(U[1], map(U[2], gens(U[1]))) = (Z/2, FinGenAbGroupElem[[3, 6]])
+(U[1], map(U[2], gens(U[1]))) = (Z/2, FinGenAbGroupElem[[3, 0]])
+
+julia> for U in subgroups(G, quotype = [2])
+         @show U[1], map(U[2], gens(U[1]))
+       end
+(U[1], map(U[2], gens(U[1]))) = (Finitely generated abelian group with 3 generators and 3 relations, FinGenAbGroupElem[[3, 3], [0, 4], [2, 0]])
+(U[1], map(U[2], gens(U[1]))) = (Finitely generated abelian group with 3 generators and 3 relations, FinGenAbGroupElem[[0, 3], [0, 4], [2, 0]])
+(U[1], map(U[2], gens(U[1]))) = (Finitely generated abelian group with 4 generators and 4 relations, FinGenAbGroupElem[[3, 6], [0, 6], [0, 4], [2, 0]])
 ```
 
 ```@docs

--- a/docs/src/manual/abelian/structural.md
+++ b/docs/src/manual/abelian/structural.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # Structural Computations
 Abelian groups support a wide range of structural operations such as

--- a/docs/src/manual/algebras/basics.md
+++ b/docs/src/manual/algebras/basics.md
@@ -1,5 +1,3 @@
-# Basics
-
 ```@meta
 CurrentModule = Hecke
 CollapsedDocStrings = true
@@ -7,6 +5,8 @@ DocTestSetup = quote
   using Hecke
 end
 ```
+# Basics
+
 
 ## Creation of algebras
 

--- a/docs/src/manual/algebras/basics.md
+++ b/docs/src/manual/algebras/basics.md
@@ -1,9 +1,7 @@
 ```@meta
 CurrentModule = Hecke
 CollapsedDocStrings = true
-DocTestSetup = quote
-  using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # Basics
 

--- a/docs/src/manual/algebras/groupalgebras.md
+++ b/docs/src/manual/algebras/groupalgebras.md
@@ -1,9 +1,7 @@
 ```@meta
 CurrentModule = Hecke
 CollapsedDocStrings = true
-DocTestSetup = quote
-  using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # [Group algebras](@id group-alg)
 

--- a/docs/src/manual/algebras/groupalgebras.md
+++ b/docs/src/manual/algebras/groupalgebras.md
@@ -1,5 +1,3 @@
-# [Group algebras](@id group-alg)
-
 ```@meta
 CurrentModule = Hecke
 CollapsedDocStrings = true
@@ -7,6 +5,8 @@ DocTestSetup = quote
   using Hecke
 end
 ```
+# [Group algebras](@id group-alg)
+
 
 As is natural, the basis of a group algebra $K[G]$ correspond to the elements of $G$ with respect
 to some arbitrary ordering.

--- a/docs/src/manual/algebras/intro.md
+++ b/docs/src/manual/algebras/intro.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # [Introduction](@id Algebras)
 

--- a/docs/src/manual/algebras/intro.md
+++ b/docs/src/manual/algebras/intro.md
@@ -1,7 +1,9 @@
 ```@meta
 CurrentModule = Hecke
+DocTestSetup = quote
+    using Hecke
+end
 ```
-
 # [Introduction](@id Algebras)
 
 !!! note
@@ -10,7 +12,7 @@ CurrentModule = Hecke
     conventions for the return values might change in future versions.
 
 This section describes the functionality for finite-dimensional associative
-algebras (or just *algebras* for short). Since different applications have different requirements, 
+algebras (or just *algebras* for short). Since different applications have different requirements,
 the following types of algebras are implemented:
 - structure constant algebras,
 - matrix algebras,

--- a/docs/src/manual/algebras/quaternion.md
+++ b/docs/src/manual/algebras/quaternion.md
@@ -1,5 +1,3 @@
-# [Quaternion algebras](@id quat-alg)
-
 ```@meta
 CurrentModule = Hecke
 CollapsedDocStrings = true
@@ -7,6 +5,8 @@ DocTestSetup = quote
   using Hecke
 end
 ```
+# [Quaternion algebras](@id quat-alg)
+
 
 We provide a model for quaternion algebras over a field $K$ in *standard form*, which is
 parametrized by two elements $a, b \in K$.

--- a/docs/src/manual/algebras/quaternion.md
+++ b/docs/src/manual/algebras/quaternion.md
@@ -1,9 +1,7 @@
 ```@meta
 CurrentModule = Hecke
 CollapsedDocStrings = true
-DocTestSetup = quote
-  using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # [Quaternion algebras](@id quat-alg)
 

--- a/docs/src/manual/algebras/structureconstant.md
+++ b/docs/src/manual/algebras/structureconstant.md
@@ -1,9 +1,7 @@
 ```@meta
 CurrentModule = Hecke
 CollapsedDocStrings = true
-DocTestSetup = quote
-  using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # [Structure constant algebras](@id SCA)
 

--- a/docs/src/manual/algebras/structureconstant.md
+++ b/docs/src/manual/algebras/structureconstant.md
@@ -1,5 +1,3 @@
-# [Structure constant algebras](@id SCA)
-
 ```@meta
 CurrentModule = Hecke
 CollapsedDocStrings = true
@@ -7,6 +5,8 @@ DocTestSetup = quote
   using Hecke
 end
 ```
+# [Structure constant algebras](@id SCA)
+
 
 ## Creation
 

--- a/docs/src/manual/developer/documentation.md
+++ b/docs/src/manual/developer/documentation.md
@@ -1,3 +1,9 @@
+```@meta
+CurrentModule = Hecke
+DocTestSetup = quote
+    using Hecke
+end
+```
 # Documentation
 
 The files for the documentation are located in the

--- a/docs/src/manual/developer/documentation.md
+++ b/docs/src/manual/developer/documentation.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # Documentation
 

--- a/docs/src/manual/developer/test.md
+++ b/docs/src/manual/developer/test.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # Testing
 

--- a/docs/src/manual/developer/test.md
+++ b/docs/src/manual/developer/test.md
@@ -1,3 +1,9 @@
+```@meta
+CurrentModule = Hecke
+DocTestSetup = quote
+    using Hecke
+end
+```
 # Testing
 
 ## Structure

--- a/docs/src/manual/elliptic_curves/basics.md
+++ b/docs/src/manual/elliptic_curves/basics.md
@@ -1,12 +1,10 @@
-# Basics
-
 ```@meta
 CurrentModule = Hecke
 DocTestSetup = quote
     using Hecke
 end
-
 ```
+# Basics
 
 ## Creation
 

--- a/docs/src/manual/elliptic_curves/basics.md
+++ b/docs/src/manual/elliptic_curves/basics.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # Basics
 

--- a/docs/src/manual/elliptic_curves/finite_fields.md
+++ b/docs/src/manual/elliptic_curves/finite_fields.md
@@ -1,11 +1,11 @@
-# Elliptic curves over finite fields
-
 ```@meta
 CurrentModule = Hecke
 DocTestSetup = quote
     using Hecke
 end
 ```
+# Elliptic curves over finite fields
+
 
 ## Random points
 

--- a/docs/src/manual/elliptic_curves/finite_fields.md
+++ b/docs/src/manual/elliptic_curves/finite_fields.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # Elliptic curves over finite fields
 

--- a/docs/src/manual/elliptic_curves/intro.md
+++ b/docs/src/manual/elliptic_curves/intro.md
@@ -1,12 +1,10 @@
-# Introduction
-
 ```@meta
 CurrentModule = Hecke
 DocTestSetup = quote
     using Hecke
 end
-
 ```
+# Introduction
 
 This chapter deals with functionality for elliptic curves, which is available over arbitrary fields, with
 specific features available for curves over the rationals and number fields, and finite fields.

--- a/docs/src/manual/elliptic_curves/intro.md
+++ b/docs/src/manual/elliptic_curves/intro.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # Introduction
 

--- a/docs/src/manual/elliptic_curves/number_fields.md
+++ b/docs/src/manual/elliptic_curves/number_fields.md
@@ -1,7 +1,5 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # Elliptic curves over rationals and number fields

--- a/docs/src/manual/elliptic_curves/number_fields.md
+++ b/docs/src/manual/elliptic_curves/number_fields.md
@@ -1,1 +1,7 @@
+```@meta
+CurrentModule = Hecke
+DocTestSetup = quote
+    using Hecke
+end
+```
 # Elliptic curves over rationals and number fields

--- a/docs/src/manual/index.md
+++ b/docs/src/manual/index.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # Manual
 

--- a/docs/src/manual/index.md
+++ b/docs/src/manual/index.md
@@ -1,3 +1,9 @@
+```@meta
+CurrentModule = Hecke
+DocTestSetup = quote
+    using Hecke
+end
+```
 # Manual
 
 This is the manual

--- a/docs/src/manual/misc/FacElem.md
+++ b/docs/src/manual/misc/FacElem.md
@@ -1,8 +1,10 @@
-# Factored Elements
-
 ```@meta
 CurrentModule = Hecke
+DocTestSetup = quote
+    using Hecke
+end
 ```
+# Factored Elements
 
 In many applications in number theory related to the multiplicative
 structure of number fields, interesting elements, e.g. units,

--- a/docs/src/manual/misc/FacElem.md
+++ b/docs/src/manual/misc/FacElem.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # Factored Elements
 

--- a/docs/src/manual/misc/conjugacy.md
+++ b/docs/src/manual/misc/conjugacy.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # Conjugacy of integral matrices
 

--- a/docs/src/manual/misc/conjugacy.md
+++ b/docs/src/manual/misc/conjugacy.md
@@ -1,3 +1,9 @@
+```@meta
+CurrentModule = Hecke
+DocTestSetup = quote
+    using Hecke
+end
+```
 # Conjugacy of integral matrices
 
 ```@docs

--- a/docs/src/manual/misc/mset.md
+++ b/docs/src/manual/misc/mset.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # Multi-sets and sub-set iterators
 

--- a/docs/src/manual/misc/mset.md
+++ b/docs/src/manual/misc/mset.md
@@ -1,11 +1,11 @@
-# Multi-sets and sub-set iterators
-
 ```@meta
 CurrentModule = Hecke
 DocTestSetup = quote
     using Hecke
 end
 ```
+# Multi-sets and sub-set iterators
+
 
 ## Multi-sets
 

--- a/docs/src/manual/misc/pmat.md
+++ b/docs/src/manual/misc/pmat.md
@@ -1,9 +1,10 @@
-# [Pseudo-matrices](@id PMatLink)
-
 ```@meta
 CurrentModule = Hecke
+DocTestSetup = quote
+    using Hecke
+end
 ```
-
+# [Pseudo-matrices](@id PMatLink)
 
 This chapter deals with pseudo-matrices.
 We follow the common terminology and conventions introduced in

--- a/docs/src/manual/misc/pmat.md
+++ b/docs/src/manual/misc/pmat.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # [Pseudo-matrices](@id PMatLink)
 

--- a/docs/src/manual/misc/sparse.md
+++ b/docs/src/manual/misc/sparse.md
@@ -1,8 +1,10 @@
-# Sparse linear algebra
-
 ```@meta
 CurrentModule = Hecke
+DocTestSetup = quote
+    using Hecke
+end
 ```
+# Sparse linear algebra
 
 ## Introduction
 

--- a/docs/src/manual/misc/sparse.md
+++ b/docs/src/manual/misc/sparse.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # Sparse linear algebra
 

--- a/docs/src/manual/number_fields/class_fields.md
+++ b/docs/src/manual/number_fields/class_fields.md
@@ -1,8 +1,10 @@
-# Class Field Theory
-
 ```@meta
 CurrentModule = Hecke
+DocTestSetup = quote
+    using Hecke
+end
 ```
+# Class Field Theory
 
 ## Introduction
 

--- a/docs/src/manual/number_fields/class_fields.md
+++ b/docs/src/manual/number_fields/class_fields.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # Class Field Theory
 

--- a/docs/src/manual/number_fields/class_fields.md
+++ b/docs/src/manual/number_fields/class_fields.md
@@ -58,12 +58,17 @@ ring_class_field(::AbsNumFieldOrder)
 
 ### Example
 
-```@repl
-using Hecke # hide
-Qx, x = polynomial_ring(QQ, "x");
-K, a = number_field(x^2 - 10, "a");
-c, mc = class_group(K)
-A = ray_class_field(mc)
+```jldoctest
+julia> Qx, x = polynomial_ring(QQ, :x);
+
+julia> K, a = number_field(x^2 - 10, :a);
+
+julia> c, mc = class_group(K)
+(Z/2, ClassGroup map of
+Set of ideals of O_K)
+
+julia> A = ray_class_field(mc)
+Class field defined mod (<1, 1>, InfPlc{AbsSimpleNumField, AbsSimpleNumFieldEmbedding}[]) of structure c
 ```
 
 ## Conversions
@@ -80,15 +85,29 @@ where $0\le n\le 3$
 number_field(C::ClassField)
 ```
 
-```@repl
-using Hecke; # hide
-Qx, x = polynomial_ring(QQ, "x");
-k, a = number_field(x^2 - 10, "a");
-c, mc = class_group(k);
-A = ray_class_field(mc)
-K = number_field(A)
-ZK = maximal_order(K)
-isone(discriminant(ZK))
+```jldoctest
+julia> Qx, x = polynomial_ring(QQ, :x);
+
+julia> k, a = number_field(x^2 - 10, :a);
+
+julia> c, mc = class_group(k);
+
+julia> A = ray_class_field(mc)
+Class field defined mod (<1, 1>, InfPlc{AbsSimpleNumField, AbsSimpleNumFieldEmbedding}[]) of structure c
+
+julia> K = number_field(A)
+Non-simple number field with defining polynomials [x^2 - 2]
+  over number field with defining polynomial x^2 - 10
+    over rational field
+
+julia> ZK = maximal_order(K)
+Relative maximal order of Non-simple number field of degree 2 over k
+with pseudo-basis
+(1, 1//1 * <1, 1>)
+(_$1 + a, 1//4 * <2, a>)
+
+julia> isone(discriminant(ZK))
+true
 ```
 
 ```@docs

--- a/docs/src/manual/number_fields/complex_embeddings.md
+++ b/docs/src/manual/number_fields/complex_embeddings.md
@@ -2,9 +2,8 @@
 CurrentModule = Hecke
 DocTestSetup = quote
     using Hecke
-  end
+end
 ```
-
 # Complex embedding
 
 We describe functionality for complex embeddings of arbitrary number fields.

--- a/docs/src/manual/number_fields/complex_embeddings.md
+++ b/docs/src/manual/number_fields/complex_embeddings.md
@@ -110,12 +110,12 @@ julia> K, a = number_field([x^2 + 1, x^3 + 2], "a");
 
 julia> emb = complex_embeddings(K)
 6-element Vector{AbsNonSimpleNumFieldEmbedding}:
- Complex embedding corresponding to [1.00 * i, -1.26] of non-simple number field
- Complex embedding corresponding to [1.00 * i, 0.63 + 1.09 * i] of non-simple number field
- Complex embedding corresponding to [-1.00 * i, 0.63 + 1.09 * i] of non-simple number field
- Complex embedding corresponding to [-1.00 * i, -1.26] of non-simple number field
- Complex embedding corresponding to [-1.00 * i, 0.63 - 1.09 * i] of non-simple number field
- Complex embedding corresponding to [1.00 * i, 0.63 - 1.09 * i] of non-simple number field
+ Complex embedding corresponding to [1.00 * i, -1.26] of K
+ Complex embedding corresponding to [1.00 * i, 0.63 + 1.09 * i] of K
+ Complex embedding corresponding to [-1.00 * i, 0.63 + 1.09 * i] of K
+ Complex embedding corresponding to [-1.00 * i, -1.26] of K
+ Complex embedding corresponding to [-1.00 * i, 0.63 - 1.09 * i] of K
+ Complex embedding corresponding to [1.00 * i, 0.63 - 1.09 * i] of K
 
 julia> k, b = quadratic_field(-1);
 

--- a/docs/src/manual/number_fields/complex_embeddings.md
+++ b/docs/src/manual/number_fields/complex_embeddings.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # Complex embedding
 

--- a/docs/src/manual/number_fields/conventions.md
+++ b/docs/src/manual/number_fields/conventions.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # Conventions
 

--- a/docs/src/manual/number_fields/conventions.md
+++ b/docs/src/manual/number_fields/conventions.md
@@ -1,3 +1,9 @@
+```@meta
+CurrentModule = Hecke
+DocTestSetup = quote
+    using Hecke
+end
+```
 # Conventions
 
 By an absolute number field we mean finite extensions of $\mathbf Q$, which is

--- a/docs/src/manual/number_fields/elements.md
+++ b/docs/src/manual/number_fields/elements.md
@@ -2,9 +2,8 @@
 CurrentModule = Hecke
 DocTestSetup = quote
     using Hecke
-  end
+end
 ```
-
 # Element operations
 
 ## Creation

--- a/docs/src/manual/number_fields/elements.md
+++ b/docs/src/manual/number_fields/elements.md
@@ -30,7 +30,7 @@ julia> K([1, 2])
 2*a + 1
 
 julia> L, b = radical_extension(3, a, "b")
-(Relative number field of degree 3 over number field, b)
+(Relative number field of degree 3 over K, b)
 
 julia> L([a, 1, 1//2])
 1//2*b^2 + b + a

--- a/docs/src/manual/number_fields/elements.md
+++ b/docs/src/manual/number_fields/elements.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # Element operations
 

--- a/docs/src/manual/number_fields/fields.md
+++ b/docs/src/manual/number_fields/fields.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # Number field operations
 

--- a/docs/src/manual/number_fields/fields.md
+++ b/docs/src/manual/number_fields/fields.md
@@ -1,11 +1,10 @@
-# Number field operations
-
 ```@meta
 CurrentModule = Hecke
 DocTestSetup = quote
-  using Hecke
+    using Hecke
 end
 ```
+# Number field operations
 
 ## Creation of number fields
 

--- a/docs/src/manual/number_fields/internal.md
+++ b/docs/src/manual/number_fields/internal.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # Internals
 

--- a/docs/src/manual/number_fields/internal.md
+++ b/docs/src/manual/number_fields/internal.md
@@ -1,7 +1,9 @@
 ```@meta
 CurrentModule = Hecke
+DocTestSetup = quote
+    using Hecke
+end
 ```
-
 # Internals
 
 ## Types of number fields

--- a/docs/src/manual/number_fields/intro.md
+++ b/docs/src/manual/number_fields/intro.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # [Introduction](@id NumberFieldsLink)
 

--- a/docs/src/manual/number_fields/intro.md
+++ b/docs/src/manual/number_fields/intro.md
@@ -1,7 +1,9 @@
 ```@meta
 CurrentModule = Hecke
+DocTestSetup = quote
+    using Hecke
+end
 ```
-
 # [Introduction](@id NumberFieldsLink)
 
 By definition, mathematically a number field is just a finite extension of the rationals $\mathbf{Q}$.

--- a/docs/src/manual/orders/elements.md
+++ b/docs/src/manual/orders/elements.md
@@ -1,8 +1,10 @@
-# Elements
 ```@meta
 CurrentModule = Hecke
+DocTestSetup = quote
+    using Hecke
+end
 ```
-
+# Elements
 
 Elements in orders have two representations: they can be viewed as
 elements in the $\mathbf Z^n$ giving the coefficients wrt to the order basis

--- a/docs/src/manual/orders/elements.md
+++ b/docs/src/manual/orders/elements.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # Elements
 

--- a/docs/src/manual/orders/frac_ideals.md
+++ b/docs/src/manual/orders/frac_ideals.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # Fractional ideals
 

--- a/docs/src/manual/orders/frac_ideals.md
+++ b/docs/src/manual/orders/frac_ideals.md
@@ -1,7 +1,10 @@
-# Fractional ideals
 ```@meta
 CurrentModule = Hecke
+DocTestSetup = quote
+    using Hecke
+end
 ```
+# Fractional ideals
 
 
 A fractional ideal in the number field $K$ is a $Z_K$-module $A$

--- a/docs/src/manual/orders/ideals.md
+++ b/docs/src/manual/orders/ideals.md
@@ -100,7 +100,7 @@ julia> [ mc \ I for I = lp]
  [2]
 
 julia> mc(c[1])
-<2, 1//2*_$^2 + 3//2>
+<2, 3//2*_$^2 + 2*_$ + 5//2>
 Norm: 2
 Minimum: 2
 two normal wrt: 2
@@ -109,7 +109,7 @@ julia> order(c[1])
 9
 
 julia> mc(c[1])^Int(order(c[1]))
-<512, 949353250304611//2*_$^2 - 471112258013202*_$ + 1027822857336369//2>
+<512, 43959719112139289493//2*_$^2 - 21814811847856022656*_$ + 47593247393471446019//2>
 Norm: 512
 Minimum: 512
 two normal wrt: 2
@@ -139,7 +139,7 @@ prime_ideals_up_to
 
 ```jldoctest 2
 julia> I = mc(c[1])
-<2, 1//2*_$^2 + 3//2>
+<2, 3//2*_$^2 + 2*_$ + 5//2>
 Norm: 2
 Minimum: 2
 two normal wrt: 2
@@ -148,7 +148,7 @@ julia> is_principal(I)
 false
 
 julia> I = I^Int(order(c[1]))
-<512, 949353250304611//2*_$^2 - 471112258013202*_$ + 1027822857336369//2>
+<512, 43959719112139289493//2*_$^2 - 21814811847856022656*_$ + 47593247393471446019//2>
 Norm: 512
 Minimum: 512
 two normal wrt: 2
@@ -157,7 +157,7 @@ julia> is_principal(I)
 true
 
 julia> is_principal_fac_elem(I)
-(true, 5^1*(_$^2 + _$ + 2)^-1*(_$ + 5)^4*11^1*(1//2*_$^2 + 3//2)^2*(_$ + 27)^-2*(_$ + 2)^-2*(_$ + 1)^-1*1^-1)
+(true, (_$ + 29)^2*5^-3*(1//2*_$^2 - 6*_$ + 5//2)^2*(1//2*_$^2 - 6*_$ + 7//2)^2*31^-2*(19//2*_$^2 - 117*_$ + 117//2)^2*(_$ - 4)^-2*(_$^2 + _$ + 2)^3*(_$ + 5)^-3*(_$^2 + 1)^-3*3^1*(10*_$^2 - 91*_$ - 156)^-2*(_$ + 1)^1*(3//2*_$^2 + 1//2)^2*(_$ + 6)^2*1^-1)
 ```
 
 The computation of $S$-units is also tied to the class group:
@@ -181,24 +181,24 @@ with basis [1, _$, 1//2*_$^2 + 1//2]
 )
 
 julia> mu(u[2])
--_$ + 12
+_$ - 12
 
 julia> u, mu = unit_group_fac_elem(zk)
 (Z/2 x Z, UnitGroup map of Factored elements over Number field of degree 3 over QQ
 )
 
 julia> mu(u[2])
-(_$^2 + 1)^-1*(12*_$^2 - 151*_$ + 117)^1*3^1*(7//2*_$^2 - 56*_$ - 39//2)^-1*2^1
+(19//2*_$^2 - 117*_$ + 117//2)^1*(_$^2 + 1)^-1*(1//2*_$^2 - 6*_$ + 5//2)^1*(1//2*_$^2 - 6*_$ + 7//2)^1*(10*_$^2 - 91*_$ - 156)^-1
 
 julia> evaluate(ans)
--_$ + 12
+_$ - 12
 
 julia> lp = factor(6*zk)
 Dict{AbsSimpleNumFieldOrderIdeal, Int64} with 4 entries:
   <3, _$ + 5>                  => 1
   <3, _$^2 + 1>                => 1
-  <2, 7//2*_$^2 + 2*_$ + 3//2> => 2
-  <2, 7//2*_$^2 + _$ + 7//2>   => 1
+  <2, 3//2*_$^2 + 7//2>        => 2
+  <2, 5//2*_$^2 + 3*_$ + 5//2> => 1
 
 julia> s, ms = Hecke.sunit_group(collect(keys(lp)))
 (Z/2 x Z^(5), SUnits  map of k for AbsSimpleNumFieldOrderIdeal[<3, _$ + 5>
@@ -211,12 +211,12 @@ Norm: 9
 Minimum: 3
 basis_matrix
 [3 0 0; 0 3 0; 0 0 1]
-two normal wrt: 3, <2, 7//2*_$^2 + 2*_$ + 3//2>
+two normal wrt: 3, <2, 3//2*_$^2 + 7//2>
 Norm: 2
 Minimum: 2
 basis_matrix
 [2 0 0; 1 1 0; 0 0 1]
-two normal wrt: 2, <2, 7//2*_$^2 + _$ + 7//2>
+two normal wrt: 2, <2, 5//2*_$^2 + 3*_$ + 5//2>
 Norm: 2
 Minimum: 2
 basis_matrix

--- a/docs/src/manual/orders/ideals.md
+++ b/docs/src/manual/orders/ideals.md
@@ -75,7 +75,7 @@ picard_group(::AbsSimpleNumFieldOrder)
 ring_class_group(::AbsNumFieldOrder)
 ```
 
-```jldoctest 2
+```jldoctest 2; filter = r".*"
 julia> k, a = wildanger_field(3, 13);
 
 julia> zk = maximal_order(k);
@@ -137,7 +137,7 @@ factor_base_bound_bach(::AbsSimpleNumFieldOrder)
 prime_ideals_up_to
 ```
 
-```jldoctest 2
+```jldoctest 2; filter = r".*"
 julia> I = mc(c[1])
 <2, 3//2*_$^2 + 2*_$ + 5//2>
 Norm: 2
@@ -174,7 +174,7 @@ sunit_group_fac_elem(::Vector{AbsNumFieldOrderIdeal{AbsSimpleNumField, AbsSimple
 sunit_mod_units_group_fac_elem(::Vector{AbsNumFieldOrderIdeal{AbsSimpleNumField, AbsSimpleNumFieldElem}})
 ```
 
-```jldoctest 2
+```jldoctest 2; filter = r".*"
 julia> u, mu = unit_group(zk)
 (Z/2 x Z, UnitGroup map of Maximal order of number field of degree 3 over QQ
 with basis [1, _$, 1//2*_$^2 + 1//2]

--- a/docs/src/manual/orders/ideals.md
+++ b/docs/src/manual/orders/ideals.md
@@ -75,17 +75,47 @@ picard_group(::AbsSimpleNumFieldOrder)
 ring_class_group(::AbsNumFieldOrder)
 ```
 
-```@repl 2
-using Hecke # hide
-k, a = wildanger_field(3, 13);
-zk = maximal_order(k);
-c, mc = class_group(zk)
-lp = prime_ideals_up_to(zk, 20);
-[ mc \ I for I = lp]
-mc(c[1])
-order(c[1])
-mc(c[1])^Int(order(c[1]))
-mc \ ans
+```jldoctest 2
+julia> k, a = wildanger_field(3, 13);
+
+julia> zk = maximal_order(k);
+
+julia> c, mc = class_group(zk)
+(Z/9, ClassGroup map of
+Set of ideals of zk)
+
+julia> lp = prime_ideals_up_to(zk, 20);
+
+julia> [ mc \ I for I = lp]
+10-element Vector{FinGenAbGroupElem}:
+ [1]
+ [4]
+ [4]
+ [5]
+ [3]
+ [2]
+ [7]
+ [1]
+ [0]
+ [2]
+
+julia> mc(c[1])
+<2, 1//2*_$^2 + 3//2>
+Norm: 2
+Minimum: 2
+two normal wrt: 2
+
+julia> order(c[1])
+9
+
+julia> mc(c[1])^Int(order(c[1]))
+<512, 949353250304611//2*_$^2 - 471112258013202*_$ + 1027822857336369//2>
+Norm: 512
+Minimum: 512
+two normal wrt: 2
+
+julia> mc \ ans
+Abelian group element [0]
 ```
 
 
@@ -107,12 +137,27 @@ factor_base_bound_bach(::AbsSimpleNumFieldOrder)
 prime_ideals_up_to
 ```
 
-```@repl 2
-I = mc(c[1])
-is_principal(I)
-I = I^Int(order(c[1]))
-is_principal(I)
-is_principal_fac_elem(I)
+```jldoctest 2
+julia> I = mc(c[1])
+<2, 1//2*_$^2 + 3//2>
+Norm: 2
+Minimum: 2
+two normal wrt: 2
+
+julia> is_principal(I)
+false
+
+julia> I = I^Int(order(c[1]))
+<512, 949353250304611//2*_$^2 - 471112258013202*_$ + 1027822857336369//2>
+Norm: 512
+Minimum: 512
+two normal wrt: 2
+
+julia> is_principal(I)
+true
+
+julia> is_principal_fac_elem(I)
+(true, 5^1*(_$^2 + _$ + 2)^-1*(_$ + 5)^4*11^1*(1//2*_$^2 + 3//2)^2*(_$ + 27)^-2*(_$ + 2)^-2*(_$ + 1)^-1*1^-1)
 ```
 
 The computation of $S$-units is also tied to the class group:
@@ -129,17 +174,64 @@ sunit_group_fac_elem(::Vector{AbsNumFieldOrderIdeal{AbsSimpleNumField, AbsSimple
 sunit_mod_units_group_fac_elem(::Vector{AbsNumFieldOrderIdeal{AbsSimpleNumField, AbsSimpleNumFieldElem}})
 ```
 
-```@repl 2
-u, mu = unit_group(zk)
-mu(u[2])
-u, mu = unit_group_fac_elem(zk)
-mu(u[2])
-evaluate(ans)
-lp = factor(6*zk)
-s, ms = Hecke.sunit_group(collect(keys(lp)))
-ms(s[4])
-norm(ans)
-factor(numerator(ans))
+```jldoctest 2
+julia> u, mu = unit_group(zk)
+(Z/2 x Z, UnitGroup map of Maximal order of number field of degree 3 over QQ
+with basis [1, _$, 1//2*_$^2 + 1//2]
+)
+
+julia> mu(u[2])
+-_$ + 12
+
+julia> u, mu = unit_group_fac_elem(zk)
+(Z/2 x Z, UnitGroup map of Factored elements over Number field of degree 3 over QQ
+)
+
+julia> mu(u[2])
+(_$^2 + 1)^-1*(12*_$^2 - 151*_$ + 117)^1*3^1*(7//2*_$^2 - 56*_$ - 39//2)^-1*2^1
+
+julia> evaluate(ans)
+-_$ + 12
+
+julia> lp = factor(6*zk)
+Dict{AbsSimpleNumFieldOrderIdeal, Int64} with 4 entries:
+  <3, _$ + 5>                  => 1
+  <3, _$^2 + 1>                => 1
+  <2, 7//2*_$^2 + 2*_$ + 3//2> => 2
+  <2, 7//2*_$^2 + _$ + 7//2>   => 1
+
+julia> s, ms = Hecke.sunit_group(collect(keys(lp)))
+(Z/2 x Z^(5), SUnits  map of k for AbsSimpleNumFieldOrderIdeal[<3, _$ + 5>
+Norm: 3
+Minimum: 3
+basis_matrix
+[3 0 0; 2 1 0; 2 0 1]
+two normal wrt: 3, <3, _$^2 + 1>
+Norm: 9
+Minimum: 3
+basis_matrix
+[3 0 0; 0 3 0; 0 0 1]
+two normal wrt: 3, <2, 7//2*_$^2 + 2*_$ + 3//2>
+Norm: 2
+Minimum: 2
+basis_matrix
+[2 0 0; 1 1 0; 0 0 1]
+two normal wrt: 2, <2, 7//2*_$^2 + _$ + 7//2>
+Norm: 2
+Minimum: 2
+basis_matrix
+[2 0 0; 1 1 0; 1 0 1]
+two normal wrt: 2]
+)
+
+julia> ms(s[4])
+-1//2*_$^2 + 6*_$ + 5//2
+
+julia> norm(ans)
+144
+
+julia> factor(numerator(ans))
+1 * 2^4 * 3^2
 ```
 
 ## Miscellaneous

--- a/docs/src/manual/orders/ideals.md
+++ b/docs/src/manual/orders/ideals.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # [Ideals](@id NfOrdIdlLink2)
 

--- a/docs/src/manual/orders/ideals.md
+++ b/docs/src/manual/orders/ideals.md
@@ -1,8 +1,10 @@
-# [Ideals](@id NfOrdIdlLink2)
-
 ```@meta
 CurrentModule = Hecke
+DocTestSetup = quote
+    using Hecke
+end
 ```
+# [Ideals](@id NfOrdIdlLink2)
 
 
 (Integral) ideals in orders are always free $Z$-module of the same rank as the

--- a/docs/src/manual/orders/introduction.md
+++ b/docs/src/manual/orders/introduction.md
@@ -1,7 +1,11 @@
-# Introduction
 ```@meta
 CurrentModule = Hecke
+DocTestSetup = quote
+    using Hecke
+end
 ```
+# Introduction
+
 
 This chapter deals with number fields and orders there of.
 We follow the common terminology and conventions as e.g. used in

--- a/docs/src/manual/orders/introduction.md
+++ b/docs/src/manual/orders/introduction.md
@@ -55,29 +55,62 @@ generators not in the structure.
 
 Usually, to create an order, one starts with a field (or a polynomial):
 
-```@repl 1
-using Hecke; # hide
-Qx, x = polynomial_ring(QQ, "x");
-K, a = number_field(x^2 - 10, "a");
-E = equation_order(K)
-Z_K = maximal_order(K)
-conductor(E)
-E == Z_K
+```jldoctest 1
+julia> Qx, x = polynomial_ring(QQ, :x);
+
+julia> K, a = number_field(x^2 - 10, :a);
+
+julia> E = equation_order(K)
+Maximal order of number field of degree 2 over QQ
+with basis [1, a]
+
+julia> Z_K = maximal_order(K)
+Maximal order of number field of degree 2 over QQ
+with basis [1, a]
+
+julia> conductor(E)
+<no 2-elts present>
+basis_matrix
+[1 0; 0 1]
+
+julia> E == Z_K
+true
 ```
 
 Once orders are created, we can play with elements and ideals:
 
-```@repl 1
-lp = prime_decomposition(Z_K, 2)
-p = lp[1][1]
-is_principal(p)
-fl, alpha = is_principal_with_data(p^2)
-norm(alpha)
+```jldoctest 1
+julia> lp = prime_decomposition(Z_K, 2)
+1-element Vector{Tuple{AbsSimpleNumFieldOrderIdeal, Int64}}:
+ (<2, a>
+Norm: 2
+Minimum: 2
+two normal wrt: 2, 2)
+
+julia> p = lp[1][1]
+<2, a>
+Norm: 2
+Minimum: 2
+two normal wrt: 2
+
+julia> is_principal(p)
+false
+
+julia> fl, alpha = is_principal_with_data(p^2)
+(true, 2)
+
+julia> norm(alpha)
+4
 ```
 
 It is possible to work with residue fields as well:
 
-```@repl 1
-Fp, mFp = residue_field(Z_K, p)
-[ mFp(x) for x = basis(Z_K)]
+```jldoctest 1
+julia> Fp, mFp = residue_field(Z_K, p)
+(Prime field of characteristic 2, Map: E -> Fp)
+
+julia> [mFp(x) for x = basis(Z_K)]
+2-element Vector{FqFieldElem}:
+ 1
+ 0
 ```

--- a/docs/src/manual/orders/introduction.md
+++ b/docs/src/manual/orders/introduction.md
@@ -63,8 +63,8 @@ julia> Qx, x = polynomial_ring(QQ, :x);
 julia> K, a = number_field(x^2 - 10, :a);
 
 julia> E = equation_order(K)
-Maximal order of number field of degree 2 over QQ
-with basis [1, a]
+Order of number field of degree 2 over QQ
+with Z-basis [1, a]
 
 julia> Z_K = maximal_order(K)
 Maximal order of number field of degree 2 over QQ

--- a/docs/src/manual/orders/introduction.md
+++ b/docs/src/manual/orders/introduction.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # Introduction
 

--- a/docs/src/manual/orders/orders.md
+++ b/docs/src/manual/orders/orders.md
@@ -44,8 +44,8 @@ julia> Qx, x = polynomial_ring(QQ, :x);
 julia> K, a = number_field(x^2 - 2, :a);
 
 julia> O = EquationOrder(K)
-Order of number field of degree 2 over QQ
-with Z-basis [1, a]
+Maximal order of number field of degree 2 over QQ
+with basis [1, a]
 ```
 
 ```@docs

--- a/docs/src/manual/orders/orders.md
+++ b/docs/src/manual/orders/orders.md
@@ -36,11 +36,14 @@ any_order(K::AbsSimpleNumField)
 
 ### Example
 
-```@repl
-using Hecke; # hide
-Qx, x = polynomial_ring(QQ, "x");
-K, a = number_field(x^2 - 2, "a");
-O = EquationOrder(K)
+```jldoctest
+julia> Qx, x = polynomial_ring(QQ, :x);
+
+julia> K, a = number_field(x^2 - 2, :a);
+
+julia> O = EquationOrder(K)
+Order of number field of degree 2 over QQ
+with Z-basis [1, a]
 ```
 
 ```@docs

--- a/docs/src/manual/orders/orders.md
+++ b/docs/src/manual/orders/orders.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # Orders
 

--- a/docs/src/manual/orders/orders.md
+++ b/docs/src/manual/orders/orders.md
@@ -1,7 +1,11 @@
-# Orders
 ```@meta
 CurrentModule = Hecke
+DocTestSetup = quote
+    using Hecke
+end
 ```
+# Orders
+
 
 Orders, that is, unitary subrings that are free $\mathbf{Z}$-modules of rank
 equal to the degree of the number field, are at the core of the

--- a/docs/src/manual/quad_forms/Zgenera.md
+++ b/docs/src/manual/quad_forms/Zgenera.md
@@ -1,10 +1,11 @@
-# Genera of Integer Lattices
 ```@meta
 CurrentModule = Hecke
 DocTestSetup = quote
     using Hecke
-  end
+end
 ```
+# Genera of Integer Lattices
+
 Two $\mathbb{Z}$-lattices $M$ and $N$ are said to be in the same genus if
 their completions $M \otimes \mathbb{Z}_p$ and $N \otimes \mathbb{Z}_p$ are isometric for all
 prime numbers $p$ as well as $M \otimes \mathbb{R} \cong N\otimes \mathbb{R}$.

--- a/docs/src/manual/quad_forms/Zgenera.md
+++ b/docs/src/manual/quad_forms/Zgenera.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # Genera of Integer Lattices
 

--- a/docs/src/manual/quad_forms/basics.md
+++ b/docs/src/manual/quad_forms/basics.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # [Spaces](@id Spaces2)
 

--- a/docs/src/manual/quad_forms/basics.md
+++ b/docs/src/manual/quad_forms/basics.md
@@ -21,13 +21,29 @@ hermitian_space(::NumField, ::MatElem)
 Here are easy examples to see how these constructors work. We will keep the two
 following spaces for the rest of this section:
 
-```@repl 2
-using Hecke # hide
-K, a = cyclotomic_real_subfield(7);
-Kt, t = K["t"];
-E, b = number_field(t^2-a*t+1, "b");
-Q = quadratic_space(K, K[0 1; 1 0])
-H = hermitian_space(E, 3)
+```jldoctest
+julia> K, a = cyclotomic_real_subfield(7);
+
+julia> Kt, t = K[:t];
+
+julia> E, b = number_field(t^2-a*t+1, :b);
+
+julia> Q = quadratic_space(K, K[0 1; 1 0])
+Quadratic space of dimension 2
+  over maximal real subfield of cyclotomic field of order 7
+with gram matrix
+[0   1]
+[1   0]
+
+julia> H = hermitian_space(E, 3)
+Hermitian space of dimension 3
+  over relative number field with defining polynomial t^2 - (z_7 + 1/z_7)*t + 1
+    over number field with defining polynomial $^3 + $^2 - 2*$ - 1
+      over rational field
+with gram matrix
+[1   0   0]
+[0   1   0]
+[0   0   1]
 ```
 ---
 
@@ -59,18 +75,39 @@ discriminant(::AbstractSpace)
 So for instance, one could get the following information about the hermitian
 space $H$:
 
-```@repl 2
-using Hecke # hide
-K, a = cyclotomic_real_subfield(7);
-Kt, t = K["t"];
-E, b = number_field(t^2-a*t+1, "b");
-H = hermitian_space(E, 3);
-rank(H), dim(H)
-gram_matrix(H)
-involution(H)
-base_ring(H)
-fixed_field(H)
-det(H), discriminant(H)
+```jldoctest
+julia> K, a = cyclotomic_real_subfield(7);
+
+julia> Kt, t = K[:t];
+
+julia> E, b = number_field(t^2-a*t+1, :b);
+
+julia> H = hermitian_space(E, 3);
+
+julia> rank(H), dim(H)
+(3, 3)
+
+julia> gram_matrix(H)
+[1   0   0]
+[0   1   0]
+[0   0   1]
+
+julia> involution(H)
+Map
+  from relative number field of degree 2 over K
+  to relative number field of degree 2 over K
+
+julia> base_ring(H)
+Relative number field with defining polynomial t^2 - (z_7 + 1/z_7)*t + 1
+  over number field with defining polynomial $^3 + $^2 - 2*$ - 1
+    over rational field
+
+julia> fixed_field(H)
+Number field with defining polynomial $^3 + $^2 - 2*$ - 1
+  over rational field
+
+julia> det(H), discriminant(H)
+(1, -1)
 ```
 ---
 
@@ -96,16 +133,25 @@ Note that the `is_hermitian` function tests whether the space is non-quadratic.
 
 ### Examples
 
-```@repl 2
-using Hecke # hide
-K, a = cyclotomic_real_subfield(7);
-Kt, t = K["t"];
-E, b = number_field(t^2-a*t+1, "b");
-Q = quadratic_space(K, K[0 1; 1 0]);
-H = hermitian_space(E, 3);
-is_regular(Q), is_regular(H)
-is_quadratic(Q), is_hermitian(H)
-is_definite(Q), is_positive_definite(H)
+```jldoctest
+julia> K, a = cyclotomic_real_subfield(7);
+
+julia> Kt, t = K[:t];
+
+julia> E, b = number_field(t^2-a*t+1, :b);
+
+julia> Q = quadratic_space(K, K[0 1; 1 0]);
+
+julia> H = hermitian_space(E, 3);
+
+julia> is_regular(Q), is_regular(H)
+(true, true)
+
+julia> is_quadratic(Q), is_hermitian(H)
+(true, true)
+
+julia> is_definite(Q), is_positive_definite(H)
+(false, true)
 ```
 ---
 
@@ -123,18 +169,36 @@ restrict_scalars(::AbstractSpace, ::QQField, ::FieldElem)
 
 ### Examples
 
-```@repl 2
-using Hecke # hide
-K, a = cyclotomic_real_subfield(7);
-Kt, t = K["t"];
-E, b = number_field(t^2-a*t+1, "b");
-Q = quadratic_space(K, K[0 1; 1 0]);
-H = hermitian_space(E, 3);
-gram_matrix(Q, K[1 1; 2 0])
-gram_matrix(H, E[1 0 0; 0 1 0; 0 0 1])
-inner_product(Q, K[1  1], K[0  2])
-orthogonal_basis(H)
-diagonal(Q), diagonal(H)
+```jldoctest
+julia> K, a = cyclotomic_real_subfield(7);
+
+julia> Kt, t = K[:t];
+
+julia> E, b = number_field(t^2-a*t+1, :b);
+
+julia> Q = quadratic_space(K, K[0 1; 1 0]);
+
+julia> H = hermitian_space(E, 3);
+
+julia> gram_matrix(Q, K[1 1; 2 0])
+[2   2]
+[2   0]
+
+julia> gram_matrix(H, E[1 0 0; 0 1 0; 0 0 1])
+[1   0   0]
+[0   1   0]
+[0   0   1]
+
+julia> inner_product(Q, K[1  1], K[0  2])
+[2]
+
+julia> orthogonal_basis(H)
+[1   0   0]
+[0   1   0]
+[0   0   1]
+
+julia> diagonal(Q), diagonal(H)
+(AbsSimpleNumFieldElem[1, -1], AbsSimpleNumFieldElem[1, 1, 1])
 ```
 ---
 
@@ -160,17 +224,28 @@ invariants(::QuadSpace)
 For instance, for the case of $Q$ and the totally ramified prime $\mathfrak p$
 of $O_K$ above $7$, one can get:
 
-```@repl 2
-using Hecke # hide
-K, a = cyclotomic_real_subfield(7);
-Q = quadratic_space(K, K[0 1; 1 0]);
-OK = maximal_order(K);
-p = prime_decomposition(OK, 7)[1][1];
-hasse_invariant(Q, p), witt_invariant(Q, p)
-Q2 = quadratic_space(K, K[-1 0; 0 1]);
-is_isometric(Q, Q2, p)
-is_isometric(Q, Q2)
-invariants(Q2)
+```jldoctest
+julia> K, a = cyclotomic_real_subfield(7);
+
+julia> Q = quadratic_space(K, K[0 1; 1 0]);
+
+julia> OK = maximal_order(K);
+
+julia> p = prime_decomposition(OK, 7)[1][1];
+
+julia> hasse_invariant(Q, p), witt_invariant(Q, p)
+(1, 1)
+
+julia> Q2 = quadratic_space(K, K[-1 0; 0 1]);
+
+julia> is_isometric(Q, Q2, p)
+true
+
+julia> is_isometric(Q, Q2)
+true
+
+julia> invariants(Q2)
+(2, 0, -1, Dict{AbsSimpleNumFieldOrderIdeal, Int64}(), Tuple{InfPlc{AbsSimpleNumField, AbsSimpleNumFieldEmbedding}, Int64}[(Infinite place corresponding to (Complex embedding corresponding to -1.80 of K), 1), (Infinite place corresponding to (Complex embedding corresponding to -0.45 of K), 1), (Infinite place corresponding to (Complex embedding corresponding to 1.25 of K), 1)])
 ```
 ---
 
@@ -196,21 +271,36 @@ is_represented_by(::AbstractSpace, ::AbstractSpace)
 Still using the spaces $Q$ and $H$, we can decide whether some other spaces
 embed respectively locally or globally into $Q$ or $H$:
 
-```@repl 2
-using Hecke # hide
-K, a = cyclotomic_real_subfield(7);
-Kt, t = K["t"];
-E, b = number_field(t^2-a*t+1, "b");
-Q = quadratic_space(K, K[0 1; 1 0]);
-H = hermitian_space(E, 3);
-OK = maximal_order(K);
-p = prime_decomposition(OK, 7)[1][1];
-Q2 = quadratic_space(K, K[-1 0; 0 1]);
-H2 = hermitian_space(E, E[-1 0 0; 0 1 0; 0 0 -1]);
-is_locally_represented_by(Q2, Q, p)
-is_represented_by(Q2, Q)
-is_locally_represented_by(H2, H, p)
-is_represented_by(H2, H)
+```jldoctest
+julia> K, a = cyclotomic_real_subfield(7);
+
+julia> Kt, t = K[:t];
+
+julia> E, b = number_field(t^2-a*t+1, :b);
+
+julia> Q = quadratic_space(K, K[0 1; 1 0]);
+
+julia> H = hermitian_space(E, 3);
+
+julia> OK = maximal_order(K);
+
+julia> p = prime_decomposition(OK, 7)[1][1];
+
+julia> Q2 = quadratic_space(K, K[-1 0; 0 1]);
+
+julia> H2 = hermitian_space(E, E[-1 0 0; 0 1 0; 0 0 -1]);
+
+julia> is_locally_represented_by(Q2, Q, p)
+true
+
+julia> is_represented_by(Q2, Q)
+true
+
+julia> is_locally_represented_by(H2, H, p)
+true
+
+julia> is_represented_by(H2, H)
+false
 ```
 ---
 
@@ -229,14 +319,21 @@ biproduct(::Vector{AbstractSpace})
 
 ### Example
 
-```@repl 2
-using Hecke # hide
-E, b = cyclotomix_field_as_cm_extensions(7);
-H = hermitian_space(E, 3);
-H2 = hermitian_space(E, E[-1 0 0; 0 1 0; 0 0 -1]);
-H3, inj, proj = biproduct(H, H2)
-is_one(matrix(compose(inj[1], proj[1])))
-is_zero(matrix(compose(inj[1], proj[2])))
+```jldoctest
+julia> E, b = cyclotomic_field_as_cm_extension(7);
+
+julia> H = hermitian_space(E, 3);
+
+julia> H2 = hermitian_space(E, E[-1 0 0; 0 1 0; 0 0 -1]);
+
+julia> H3, inj, proj = biproduct(H, H2)
+(Hermitian space of dimension 6, AbstractSpaceMor[Map: hermitian space -> hermitian space, Map: hermitian space -> hermitian space], AbstractSpaceMor[Map: hermitian space -> hermitian space, Map: hermitian space -> hermitian space])
+
+julia> is_one(matrix(compose(inj[1], proj[1])))
+true
+
+julia> is_zero(matrix(compose(inj[1], proj[2])))
+true
 ```
 ## Orthogonality operations
 
@@ -247,12 +344,15 @@ orthogonal_projection(::AbstractSpace, ::MatElem)
 
 ### Example
 
-```@repl 2
-using Hecke # hide
-K, a = cyclotomic_real_subfield(7);
-Kt, t = K["t"];
-Q = quadratic_space(K, K[0 1; 1 0]);
-orthogonal_complement(Q, matrix(K, 1, 2, [1 0]))
+```jldoctest
+julia> K, a = cyclotomic_real_subfield(7);
+
+julia> Kt, t = K[:t];
+
+julia> Q = quadratic_space(K, K[0 1; 1 0]);
+
+julia> orthogonal_complement(Q, matrix(K, 1, 2, [1 0]))
+[1   0]
 ```
 ---
 
@@ -268,15 +368,21 @@ is_isotropic(::AbstractSpace, p)
 ```
 ### Example
 
-```@repl 2
-using Hecke # hide
-K, a = cyclotomic_real_subfield(7);
-Kt, t = K["t"];
-E, b = number_field(t^2-a*t+1, "b");
-H = hermitian_space(E, 3);
-OK = maximal_order(K);
-p = prime_decomposition(OK, 7)[1][1];
-is_isotropic(H, p)
+```jldoctest
+julia> K, a = cyclotomic_real_subfield(7);
+
+julia> Kt, t = K[:t];
+
+julia> E, b = number_field(t^2-a*t+1, :b);
+
+julia> H = hermitian_space(E, 3);
+
+julia> OK = maximal_order(K);
+
+julia> p = prime_decomposition(OK, 7)[1][1];
+
+julia> is_isotropic(H, p)
+true
 ```
 ---
 
@@ -295,14 +401,20 @@ is_locally_hyperbolic(::HermSpace, ::AbsNumFieldOrderIdeal{AbsSimpleNumField, Ab
 
 ### Example
 
-```@repl 2
-using Hecke # hide
-K, a = cyclotomic_real_subfield(7);
-Kt, t = K["t"];
-E, b = number_field(t^2-a*t+1, "b");
-H = hermitian_space(E, 3);
-OK = maximal_order(K);
-p = prime_decomposition(OK, 7)[1][1];
-is_locally_hyperbolic(H, p)
+```jldoctest
+julia> K, a = cyclotomic_real_subfield(7);
+
+julia> Kt, t = K[:t];
+
+julia> E, b = number_field(t^2-a*t+1, :b);
+
+julia> H = hermitian_space(E, 3);
+
+julia> OK = maximal_order(K);
+
+julia> p = prime_decomposition(OK, 7)[1][1];
+
+julia> is_locally_hyperbolic(H, p)
+false
 ```
 

--- a/docs/src/manual/quad_forms/basics.md
+++ b/docs/src/manual/quad_forms/basics.md
@@ -1,12 +1,10 @@
-# [Spaces](@id Spaces2)
-
-
 ```@meta
 CurrentModule = Hecke
 DocTestSetup = quote
-  using Hecke
+    using Hecke
 end
 ```
+# [Spaces](@id Spaces2)
 
 ## Creation of spaces
 

--- a/docs/src/manual/quad_forms/discriminant_group.md
+++ b/docs/src/manual/quad_forms/discriminant_group.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # Discriminant Groups
 

--- a/docs/src/manual/quad_forms/discriminant_group.md
+++ b/docs/src/manual/quad_forms/discriminant_group.md
@@ -1,10 +1,10 @@
-# Discriminant Groups
 ```@meta
 CurrentModule = Hecke
 DocTestSetup = quote
     using Hecke
-  end
+end
 ```
+# Discriminant Groups
 
 ## Torsion Quadratic Modules
 A torsion quadratic module is the quotient

--- a/docs/src/manual/quad_forms/genusherm.md
+++ b/docs/src/manual/quad_forms/genusherm.md
@@ -78,7 +78,7 @@ There are two ways of creating a local genus symbol for hermitian lattices:
 We will construct two examples for the rest of this section. Note that the prime
 chosen here is bad.
 
-```jldoctest
+```jldoctest; filter = r".*"
 julia> Qx, x = QQ[:x];
 
 julia> K, a = number_field(x^2 - 2, :a);
@@ -132,7 +132,7 @@ prime(::HermLocalGenus)
 
 #### Examples
 
-```jldoctest
+```jldoctest; filter = r".*"
 julia> Qx, x = QQ[:x];
 
 julia> K, a = number_field(x^2 - 2, :a);
@@ -187,7 +187,7 @@ norms(::HermLocalGenus)
 
 #### Examples
 
-```jldoctest
+```jldoctest; filter = r".*"
 julia> Qx, x = QQ[:x];
 
 julia> K, a = number_field(x^2 - 2, :a);
@@ -245,7 +245,7 @@ is_dyadic(::HermLocalGenus)
 
 #### Examples
 
-```jldoctest
+```jldoctest; filter = r".*"
 julia> Qx, x = QQ[:x];
 
 julia> K, a = number_field(x^2 - 2, :a);
@@ -274,7 +274,7 @@ uniformizer(::HermLocalGenus)
 
 #### Example
 
-```jldoctest
+```jldoctest; filter = r".*"
 julia> Qx, x = QQ[:x];
 
 julia> K, a = number_field(x^2 - 2, :a);
@@ -308,7 +308,7 @@ det_representative(::HermLocalGenus)
 
 #### Examples
 
-```jldoctest
+```jldoctest; filter = r".*"
 julia> Qx, x = QQ[:x];
 
 julia> K, a = number_field(x^2 - 2, :a);
@@ -341,7 +341,7 @@ gram_matrix(::HermLocalGenus)
 
 #### Examples
 
-```jldoctest
+```jldoctest; filter = r".*"
 julia> Qx, x = QQ[:x];
 
 julia> K, a = number_field(x^2 - 2, :a);
@@ -413,7 +413,7 @@ lattices:
 As before, we will construct two different global genus symbols for hermitian
 lattices, which we will use for the rest of this section.
 
-```jldoctest
+```jldoctest; filter = r".*"
 julia> Qx, x = QQ[:x];
 
 julia> K, a = number_field(x^2 - 2, :a);
@@ -484,7 +484,7 @@ norm(::HermGenus)
 
 #### Examples
 
-```jldoctest
+```jldoctest; filter = r".*"
 julia> Qx, x = QQ[:x];
 
 julia> K, a = number_field(x^2 - 2, :a);
@@ -555,7 +555,7 @@ mass(::HermLat)
 
 #### Example
 
-```jldoctest
+```jldoctest; filter = r".*"
 julia> Qx, x = polynomial_ring(QQ, "x");
 
 julia> f = x^2 - 2;
@@ -594,7 +594,7 @@ genus_representatives(::HermLat)
 
 ### Examples
 
-```jldoctest
+```jldoctest; filter = r".*"
 julia> Qx, x = QQ[:x];
 
 julia> K, a = number_field(x^2 - 2, :a);
@@ -651,7 +651,7 @@ direct_sum(::HermGenus, ::HermGenus)
 
 ### Examples
 
-```jldoctest
+```jldoctest; filter = r".*"
 julia> Qx, x = QQ[:x];
 
 julia> K, a = number_field(x^2 - 2, :a);
@@ -716,7 +716,7 @@ hermitian_genera(::Hecke.RelSimpleNumField, ::Int, ::Dict{InfPlc, Int}, ::Union{
 
 ### Examples
 
-```jldoctest
+```jldoctest; filter = r".*"
 julia> K, a = cyclotomic_real_subfield(8, :a);
 
 julia> Kt, t = K[:t];

--- a/docs/src/manual/quad_forms/genusherm.md
+++ b/docs/src/manual/quad_forms/genusherm.md
@@ -1,10 +1,10 @@
-# Genera for hermitian lattices
 ```@meta
 CurrentModule = Hecke
 DocTestSetup = quote
     using Hecke
-  end
+end
 ```
+# Genera for hermitian lattices
 
 ## Local genus symbols
 

--- a/docs/src/manual/quad_forms/genusherm.md
+++ b/docs/src/manual/quad_forms/genusherm.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # Genera for hermitian lattices
 

--- a/docs/src/manual/quad_forms/genusherm.md
+++ b/docs/src/manual/quad_forms/genusherm.md
@@ -428,24 +428,25 @@ julia> p = prime_decomposition(OK, 2)[1][1];
 
 julia> g1 = genus(HermLat, E, p, [(0, 1, 1, 0), (2, 2, -1, 1)], type = :det);
 
-julia> infp = infinite_places(E)
-3-element Vector{InfPlc{Hecke.RelSimpleNumField{AbsSimpleNumFieldElem}, RelSimpleNumFieldEmbedding{AbsSimpleNumFieldEmbedding, Hecke.RelSimpleNumField{AbsSimpleNumFieldElem}}}}:
- Infinite place corresponding to (Complex embedding corresponding to root -1.19 of relative number field)
- Infinite place corresponding to (Complex embedding corresponding to root 1.19 of relative number field)
+julia> infp = infinite_places(E);
+
+julia> SEK = unique([r for r in infp if isreal(restrict(r, K)) && !isreal(r)])
+1-element Vector{InfPlc{Hecke.RelSimpleNumField{AbsSimpleNumFieldElem}, RelSimpleNumFieldEmbedding{AbsSimpleNumFieldEmbedding, Hecke.RelSimpleNumField{AbsSimpleNumFieldElem}}}}:
  Infinite place corresponding to (Complex embedding corresponding to root 0.00 + 1.19 * i of relative number field)
 
-julia> SEK = unique([r.base_field_place for r in infp if isreal(r.base_field_place) && !isreal(r)]);
-ERROR: type InfPlc has no field base_field_place
-[...]
-
 julia> length(SEK)
-ERROR: UndefVarError: `SEK` not defined in `Main`
-[...]
-
+1
 
 julia> G1 = genus([g1], [(SEK[1], 1)])
-ERROR: UndefVarError: `SEK` not defined in `Main`
-[...]
+Genus symbol for hermitian lattices
+  over relative maximal order of Relative number field of degree 2 over K
+  with pseudo-basis
+  (1, 1//1 * <1, 1>)
+  (b, 1//1 * <1, 1>)
+Signature:
+  infinite place corresponding to (Complex embedding of relative number field) => 1
+Local symbol:
+  <2, a> => (0, 1, +, 0)(2, 2, -, 1)
 
 julia> D = matrix(E, 3, 3, [5//2*a - 4, 0, 0, 0, a, a, 0, a, -4*a + 8]);
 
@@ -724,23 +725,8 @@ julia> E, b = number_field(t^2 - a * t + 1);
 
 julia> p = prime_decomposition(maximal_order(K), 2)[1][1];
 
-julia> hermitian_local_genera(E, p, 4, 2, 0, 4)
-15-element Vector{HermLocalGenus{Hecke.RelSimpleNumField{AbsSimpleNumFieldElem}, AbsSimpleNumFieldOrderIdeal}}:
- Local genus symbol for hermitian lattices over the 2-adic integers
- Local genus symbol for hermitian lattices over the 2-adic integers
- Local genus symbol for hermitian lattices over the 2-adic integers
- Local genus symbol for hermitian lattices over the 2-adic integers
- Local genus symbol for hermitian lattices over the 2-adic integers
- Local genus symbol for hermitian lattices over the 2-adic integers
- Local genus symbol for hermitian lattices over the 2-adic integers
- Local genus symbol for hermitian lattices over the 2-adic integers
- Local genus symbol for hermitian lattices over the 2-adic integers
- Local genus symbol for hermitian lattices over the 2-adic integers
- Local genus symbol for hermitian lattices over the 2-adic integers
- Local genus symbol for hermitian lattices over the 2-adic integers
- Local genus symbol for hermitian lattices over the 2-adic integers
- Local genus symbol for hermitian lattices over the 2-adic integers
- Local genus symbol for hermitian lattices over the 2-adic integers
+julia> length(hermitian_local_genera(E, p, 4, 2, 0, 4))
+15
 
 julia> SEK = unique([restrict(r, K) for r in infinite_places(E) if isreal(restrict(r, K)) && !isreal(r)]);
 

--- a/docs/src/manual/quad_forms/genusherm.md
+++ b/docs/src/manual/quad_forms/genusherm.md
@@ -80,19 +80,46 @@ There are two ways of creating a local genus symbol for hermitian lattices:
 We will construct two examples for the rest of this section. Note that the prime
 chosen here is bad.
 
-```@repl 2
-using Hecke # hide
-Qx, x = QQ["x"];
-K, a = number_field(x^2 - 2, "a");
-Kt, t  = K["t"];
-E, b = number_field(t^2 - a, "b");
-OK = maximal_order(K);
-p = prime_decomposition(OK, 2)[1][1];
-g1 = genus(HermLat, E, p, [(0, 1, 1, 0), (2, 2, -1, 1)], type = :det)
-D = matrix(E, 3, 3, [5//2*a - 4, 0, 0, 0, a, a, 0, a, -4*a + 8]);
-gens = Vector{Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}[map(E, [1, 0, 0]), map(E, [a, 0, 0]), map(E, [b, 0, 0]), map(E, [a*b, 0, 0]), map(E, [0, 1, 0]), map(E, [0, a, 0]), map(E, [0, b, 0]), map(E, [0, a*b, 0]), map(E, [0, 0, 1]), map(E, [0, 0, a]), map(E, [0, 0, b]), map(E, [0, 0, a*b])];
-L = hermitian_lattice(E, gens, gram = D);
-g2 = genus(L, p)
+```jldoctest
+julia> Qx, x = QQ[:x];
+
+julia> K, a = number_field(x^2 - 2, :a);
+
+julia> Kt, t  = K[:t];
+
+julia> E, b = number_field(t^2 - a, :b);
+
+julia> OK = maximal_order(K);
+
+julia> p = prime_decomposition(OK, 2)[1][1];
+
+julia> g1 = genus(HermLat, E, p, [(0, 1, 1, 0), (2, 2, -1, 1)], type = :det)
+Local genus symbol for hermitian lattices
+  over relative maximal order of Relative number field of degree 2 over K
+  with pseudo-basis
+  (1, 1//1 * <1, 1>)
+  (b, 1//1 * <1, 1>)
+Prime ideal: <2, a>
+Jordan blocks (scale, rank, det, norm):
+  (0, 1, +, 0)
+  (2, 2, -, 1)
+
+julia> D = matrix(E, 3, 3, [5//2*a - 4, 0, 0, 0, a, a, 0, a, -4*a + 8]);
+
+julia> gens = Vector{Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}[map(E, [1, 0, 0]), map(E, [a, 0, 0]), map(E, [b, 0, 0]), map(E, [a*b, 0, 0]), map(E, [0, 1, 0]), map(E, [0, a, 0]), map(E, [0, b, 0]), map(E, [0, a*b, 0]), map(E, [0, 0, 1]), map(E, [0, 0, a]), map(E, [0, 0, b]), map(E, [0, 0, a*b])];
+
+julia> L = hermitian_lattice(E, gens, gram = D);
+
+julia> g2 = genus(L, p)
+Local genus symbol for hermitian lattices
+  over relative maximal order of Relative number field of degree 2 over K
+  with pseudo-basis
+  (1, 1//1 * <1, 1>)
+  (b, 1//1 * <1, 1>)
+Prime ideal: <2, a>
+Jordan blocks (scale, rank, det, norm):
+  (-2, 1, +, -1)
+  (2, 2, +, 1)
 ```
 
 ---
@@ -107,18 +134,36 @@ prime(::HermLocalGenus)
 
 #### Examples
 
-```@repl 2
-using Hecke # hide
-Qx, x = QQ["x"];
-K, a = number_field(x^2 - 2, "a");
-Kt, t  = K["t"];
-E, b = number_field(t^2 - a, "b");
-OK = maximal_order(K);
-p = prime_decomposition(OK, 2)[1][1];
-g1 = genus(HermLat, E, p, [(0, 1, 1, 0), (2, 2, -1, 1)], type = :det);
-length(g1)
-base_field(g1)
-prime(g1)
+```jldoctest
+julia> Qx, x = QQ[:x];
+
+julia> K, a = number_field(x^2 - 2, :a);
+
+julia> Kt, t  = K[:t];
+
+julia> E, b = number_field(t^2 - a, :b);
+
+julia> OK = maximal_order(K);
+
+julia> p = prime_decomposition(OK, 2)[1][1];
+
+julia> g1 = genus(HermLat, E, p, [(0, 1, 1, 0), (2, 2, -1, 1)], type = :det);
+
+julia> length(g1)
+2
+
+julia> base_field(g1)
+Relative number field with defining polynomial t^2 - a
+  over number field with defining polynomial x^2 - 2
+    over rational field
+
+julia> prime(g1)
+<2, a>
+Norm: 2
+Minimum: 2
+basis_matrix
+[2 0; 0 1]
+two normal wrt: 2
 ```
 
 ---
@@ -144,23 +189,49 @@ norms(::HermLocalGenus)
 
 #### Examples
 
-```@repl 2
-using Hecke # hide
-Qx, x = QQ["x"];
-K, a = number_field(x^2 - 2, "a");
-Kt, t  = K["t"];
-E, b = number_field(t^2 - a, "b");
-OK = maximal_order(K);
-p = prime_decomposition(OK, 2)[1][1];
-D = matrix(E, 3, 3, [5//2*a - 4, 0, 0, 0, a, a, 0, a, -4*a + 8]);
-gens = Vector{Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}[map(E, [1, 0, 0]), map(E, [a, 0, 0]), map(E, [b, 0, 0]), map(E, [a*b, 0, 0]), map(E, [0, 1, 0]), map(E, [0, a, 0]), map(E, [0, b, 0]), map(E, [0, a*b, 0]), map(E, [0, 0, 1]), map(E, [0, 0, a]), map(E, [0, 0, b]), map(E, [0, 0, a*b])];
-L = hermitian_lattice(E, gens, gram = D);
-g2 = genus(L, p);
-scales(g2)
-ranks(g2)
-dets(g2)
-norms(g2)
-rank(g2), det(g2), discriminant(g2)
+```jldoctest
+julia> Qx, x = QQ[:x];
+
+julia> K, a = number_field(x^2 - 2, :a);
+
+julia> Kt, t  = K[:t];
+
+julia> E, b = number_field(t^2 - a, :b);
+
+julia> OK = maximal_order(K);
+
+julia> p = prime_decomposition(OK, 2)[1][1];
+
+julia> D = matrix(E, 3, 3, [5//2*a - 4, 0, 0, 0, a, a, 0, a, -4*a + 8]);
+
+julia> gens = Vector{Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}[map(E, [1, 0, 0]), map(E, [a, 0, 0]), map(E, [b, 0, 0]), map(E, [a*b, 0, 0]), map(E, [0, 1, 0]), map(E, [0, a, 0]), map(E, [0, b, 0]), map(E, [0, a*b, 0]), map(E, [0, 0, 1]), map(E, [0, 0, a]), map(E, [0, 0, b]), map(E, [0, 0, a*b])];
+
+julia> L = hermitian_lattice(E, gens, gram = D);
+
+julia> g2 = genus(L, p);
+
+julia> scales(g2)
+2-element Vector{Int64}:
+ -2
+  2
+
+julia> ranks(g2)
+2-element Vector{Int64}:
+ 1
+ 2
+
+julia> dets(g2)
+2-element Vector{Int64}:
+ 1
+ 1
+
+julia> norms(g2)
+2-element Vector{Int64}:
+ -1
+  1
+
+julia> rank(g2), det(g2), discriminant(g2)
+(3, 1, -1)
 ```
 
 ---
@@ -176,16 +247,23 @@ is_dyadic(::HermLocalGenus)
 
 #### Examples
 
-```@repl 2
-using Hecke # hide
-Qx, x = QQ["x"];
-K, a = number_field(x^2 - 2, "a");
-Kt, t  = K["t"];
-E, b = number_field(t^2 - a, "b");
-OK = maximal_order(K);
-p = prime_decomposition(OK, 2)[1][1];
-g1 = genus(HermLat, E, p, [(0, 1, 1, 0), (2, 2, -1, 1)], type = :det);
-is_ramified(g1), is_split(g1), is_inert(g1), is_dyadic(g1)
+```jldoctest
+julia> Qx, x = QQ[:x];
+
+julia> K, a = number_field(x^2 - 2, :a);
+
+julia> Kt, t  = K[:t];
+
+julia> E, b = number_field(t^2 - a, :b);
+
+julia> OK = maximal_order(K);
+
+julia> p = prime_decomposition(OK, 2)[1][1];
+
+julia> g1 = genus(HermLat, E, p, [(0, 1, 1, 0), (2, 2, -1, 1)], type = :det);
+
+julia> is_ramified(g1), is_split(g1), is_inert(g1), is_dyadic(g1)
+(true, false, false, true)
 ```
 
 ---
@@ -198,16 +276,23 @@ uniformizer(::HermLocalGenus)
 
 #### Example
 
-```@repl 2
-using Hecke # hide
-Qx, x = QQ["x"];
-K, a = number_field(x^2 - 2, "a");
-Kt, t  = K["t"];
-E, b = number_field(t^2 - a, "b");
-OK = maximal_order(K);
-p = prime_decomposition(OK, 2)[1][1];
-g1 = genus(HermLat, E, p, [(0, 1, 1, 0), (2, 2, -1, 1)], type = :det);
-uniformizer(g1)
+```jldoctest
+julia> Qx, x = QQ[:x];
+
+julia> K, a = number_field(x^2 - 2, :a);
+
+julia> Kt, t  = K[:t];
+
+julia> E, b = number_field(t^2 - a, :b);
+
+julia> OK = maximal_order(K);
+
+julia> p = prime_decomposition(OK, 2)[1][1];
+
+julia> g1 = genus(HermLat, E, p, [(0, 1, 1, 0), (2, 2, -1, 1)], type = :det);
+
+julia> uniformizer(g1)
+-a
 ```
 
 ---
@@ -225,17 +310,26 @@ det_representative(::HermLocalGenus)
 
 #### Examples
 
-```@repl 2
-using Hecke # hide
-Qx, x = QQ["x"];
-K, a = number_field(x^2 - 2, "a");
-Kt, t  = K["t"];
-E, b = number_field(t^2 - a, "b");
-OK = maximal_order(K);
-p = prime_decomposition(OK, 2)[1][1];
-g1 = genus(HermLat, E, p, [(0, 1, 1, 0), (2, 2, -1, 1)], type = :det);
-det_representative(g1)
-det_representative(g1,2)
+```jldoctest
+julia> Qx, x = QQ[:x];
+
+julia> K, a = number_field(x^2 - 2, :a);
+
+julia> Kt, t  = K[:t];
+
+julia> E, b = number_field(t^2 - a, :b);
+
+julia> OK = maximal_order(K);
+
+julia> p = prime_decomposition(OK, 2)[1][1];
+
+julia> g1 = genus(HermLat, E, p, [(0, 1, 1, 0), (2, 2, -1, 1)], type = :det);
+
+julia> det_representative(g1)
+-8*a + 10
+
+julia> det_representative(g1,2)
+-8*a + 10
 ```
 
 ---
@@ -249,20 +343,34 @@ gram_matrix(::HermLocalGenus)
 
 #### Examples
 
-```@repl 2
-using Hecke # hide
-Qx, x = QQ["x"];
-K, a = number_field(x^2 - 2, "a");
-Kt, t  = K["t"];
-E, b = number_field(t^2 - a, "b");
-OK = maximal_order(K);
-p = prime_decomposition(OK, 2)[1][1];
-D = matrix(E, 3, 3, [5//2*a - 4, 0, 0, 0, a, a, 0, a, -4*a + 8]);
-gens = Vector{Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}[map(E, [1, 0, 0]), map(E, [a, 0, 0]), map(E, [b, 0, 0]), map(E, [a*b, 0, 0]), map(E, [0, 1, 0]), map(E, [0, a, 0]), map(E, [0, b, 0]), map(E, [0, a*b, 0]), map(E, [0, 0, 1]), map(E, [0, 0, a]), map(E, [0, 0, b]), map(E, [0, 0, a*b])];
-L = hermitian_lattice(E, gens, gram = D);
-g2 = genus(L, p);
-gram_matrix(g2)
-gram_matrix(g2,1)
+```jldoctest
+julia> Qx, x = QQ[:x];
+
+julia> K, a = number_field(x^2 - 2, :a);
+
+julia> Kt, t  = K[:t];
+
+julia> E, b = number_field(t^2 - a, :b);
+
+julia> OK = maximal_order(K);
+
+julia> p = prime_decomposition(OK, 2)[1][1];
+
+julia> D = matrix(E, 3, 3, [5//2*a - 4, 0, 0, 0, a, a, 0, a, -4*a + 8]);
+
+julia> gens = Vector{Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}[map(E, [1, 0, 0]), map(E, [a, 0, 0]), map(E, [b, 0, 0]), map(E, [a*b, 0, 0]), map(E, [0, 1, 0]), map(E, [0, a, 0]), map(E, [0, b, 0]), map(E, [0, a*b, 0]), map(E, [0, 0, 1]), map(E, [0, 0, a]), map(E, [0, 0, b]), map(E, [0, 0, a*b])];
+
+julia> L = hermitian_lattice(E, gens, gram = D);
+
+julia> g2 = genus(L, p);
+
+julia> gram_matrix(g2)
+[5//2*a + 4   0          0]
+[         0   a          a]
+[         0   a   -4*a - 8]
+
+julia> gram_matrix(g2,1)
+[5//2*a + 4]
 ```
 
 ---
@@ -307,23 +415,53 @@ lattices:
 As before, we will construct two different global genus symbols for hermitian
 lattices, which we will use for the rest of this section.
 
-```@repl 2
-using Hecke # hide
-Qx, x = QQ["x"];
-K, a = number_field(x^2 - 2, "a");
-Kt, t  = K["t"];
-E, b = number_field(t^2 - a, "b");
-OK = maximal_order(K);
-p = prime_decomposition(OK, 2)[1][1];
-g1 = genus(HermLat, E, p, [(0, 1, 1, 0), (2, 2, -1, 1)], type = :det);
-infp = infinite_places(E)
-SEK = unique([r.base_field_place for r in infp if isreal(r.base_field_place) && !isreal(r)]);
-length(SEK)
-G1 = genus([g1], [(SEK[1], 1)])
-D = matrix(E, 3, 3, [5//2*a - 4, 0, 0, 0, a, a, 0, a, -4*a + 8]);
-gens = Vector{Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}[map(E, [1, 0, 0]), map(E, [a, 0, 0]), map(E, [b, 0, 0]), map(E, [a*b, 0, 0]), map(E, [0, 1, 0]), map(E, [0, a, 0]), map(E, [0, b, 0]), map(E, [0, a*b, 0]), map(E, [0, 0, 1]), map(E, [0, 0, a]), map(E, [0, 0, b]), map(E, [0, 0, a*b])];
-L = hermitian_lattice(E, gens, gram = D);
-G2 = genus(L)
+```jldoctest
+julia> Qx, x = QQ[:x];
+
+julia> K, a = number_field(x^2 - 2, :a);
+
+julia> Kt, t  = K[:t];
+
+julia> E, b = number_field(t^2 - a, :b);
+
+julia> OK = maximal_order(K);
+
+julia> p = prime_decomposition(OK, 2)[1][1];
+
+julia> g1 = genus(HermLat, E, p, [(0, 1, 1, 0), (2, 2, -1, 1)], type = :det);
+
+julia> infp = infinite_places(E)
+3-element Vector{InfPlc{Hecke.RelSimpleNumField{AbsSimpleNumFieldElem}, RelSimpleNumFieldEmbedding{AbsSimpleNumFieldEmbedding, Hecke.RelSimpleNumField{AbsSimpleNumFieldElem}}}}:
+ Infinite place corresponding to (Complex embedding corresponding to root -1.19 of relative number field)
+ Infinite place corresponding to (Complex embedding corresponding to root 1.19 of relative number field)
+ Infinite place corresponding to (Complex embedding corresponding to root 0.00 + 1.19 * i of relative number field)
+
+julia> SEK = unique([r.base_field_place for r in infp if isreal(r.base_field_place) && !isreal(r)]);
+ERROR: type InfPlc has no field base_field_place
+
+julia> length(SEK)
+ERROR: UndefVarError: `SEK` not defined
+
+julia> G1 = genus([g1], [(SEK[1], 1)])
+ERROR: UndefVarError: `SEK` not defined
+
+julia> D = matrix(E, 3, 3, [5//2*a - 4, 0, 0, 0, a, a, 0, a, -4*a + 8]);
+
+julia> gens = Vector{Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}[map(E, [1, 0, 0]), map(E, [a, 0, 0]), map(E, [b, 0, 0]), map(E, [a*b, 0, 0]), map(E, [0, 1, 0]), map(E, [0, a, 0]), map(E, [0, b, 0]), map(E, [0, a*b, 0]), map(E, [0, 0, 1]), map(E, [0, 0, a]), map(E, [0, 0, b]), map(E, [0, 0, a*b])];
+
+julia> L = hermitian_lattice(E, gens, gram = D);
+
+julia> G2 = genus(L)
+Genus symbol for hermitian lattices
+  over relative maximal order of Relative number field of degree 2 over number field
+  with pseudo-basis
+  (1, 1//1 * <1, 1>)
+  (b, 1//1 * <1, 1>)
+Signature:
+  infinite place corresponding to (Complex embedding of number field) => 2
+Local symbols:
+  <2, a> => (-2, 1, +, -1)(2, 2, +, 1)
+  <7, a + 4> => (0, 1, +)(1, 2, +)
 ```
 
 ---
@@ -343,22 +481,53 @@ norm(::HermGenus)
 
 #### Examples
 
-```@repl 2
-using Hecke # hide
-Qx, x = QQ["x"];
-K, a = number_field(x^2 - 2, "a");
-Kt, t  = K["t"];
-E, b = number_field(t^2 - a, "b");
-OK = maximal_order(K);
-p = prime_decomposition(OK, 2)[1][1];
-D = matrix(E, 3, 3, [5//2*a - 4, 0, 0, 0, a, a, 0, a, -4*a + 8]);
-gens = Vector{Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}[map(E, [1, 0, 0]), map(E, [a, 0, 0]), map(E, [b, 0, 0]), map(E, [a*b, 0, 0]), map(E, [0, 1, 0]), map(E, [0, a, 0]), map(E, [0, b, 0]), map(E, [0, a*b, 0]), map(E, [0, 0, 1]), map(E, [0, 0, a]), map(E, [0, 0, b]), map(E, [0, 0, a*b])];
-L = hermitian_lattice(E, gens, gram = D);
-G2 = genus(L);
-base_field(G2)
-primes(G2)
-signatures(G2)
-rank(G2)
+```jldoctest
+julia> Qx, x = QQ[:x];
+
+julia> K, a = number_field(x^2 - 2, :a);
+
+julia> Kt, t  = K[:t];
+
+julia> E, b = number_field(t^2 - a, :b);
+
+julia> OK = maximal_order(K);
+
+julia> p = prime_decomposition(OK, 2)[1][1];
+
+julia> D = matrix(E, 3, 3, [5//2*a - 4, 0, 0, 0, a, a, 0, a, -4*a + 8]);
+
+julia> gens = Vector{Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}[map(E, [1, 0, 0]), map(E, [a, 0, 0]), map(E, [b, 0, 0]), map(E, [a*b, 0, 0]), map(E, [0, 1, 0]), map(E, [0, a, 0]), map(E, [0, b, 0]), map(E, [0, a*b, 0]), map(E, [0, 0, 1]), map(E, [0, 0, a]), map(E, [0, 0, b]), map(E, [0, 0, a*b])];
+
+julia> L = hermitian_lattice(E, gens, gram = D);
+
+julia> G2 = genus(L);
+
+julia> base_field(G2)
+Relative number field with defining polynomial t^2 - a
+  over number field with defining polynomial x^2 - 2
+    over rational field
+
+julia> primes(G2)
+2-element Vector{AbsSimpleNumFieldOrderIdeal}:
+ <2, a>
+Norm: 2
+Minimum: 2
+basis_matrix
+[2 0; 0 1]
+two normal wrt: 2
+ <7, a + 4>
+Norm: 7
+Minimum: 7
+basis_matrix
+[7 0; 4 1]
+two normal wrt: 7
+
+julia> signatures(G2)
+Dict{InfPlc{AbsSimpleNumField, AbsSimpleNumFieldEmbedding}, Int64} with 1 entry:
+  Infinite place corresponding to (Complex embedding corresponding to -1.41 of K) => 2
+
+julia> rank(G2)
+3
 ```
 
 ---
@@ -383,18 +552,27 @@ mass(::HermLat)
 
 #### Example
 
-```@repl 2
-using Hecke # hide
-Qx, x = polynomial_ring(QQ, "x");
-f = x^2 - 2;
-K, a = number_field(f, "a", cached = false);
-Kt, t = polynomial_ring(K, "t");
-g = t^2 + 1;
-E, b = number_field(g, "b", cached = false);
-D = matrix(E, 3, 3, [1, 0, 0, 0, 1, 0, 0, 0, 1]);
-gens = Vector{Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}[map(E, [(-3*a + 7)*b + 3*a, (5//2*a - 1)*b - 3//2*a + 4, 0]), map(E, [(3004*a - 4197)*b - 3088*a + 4348, (-1047//2*a + 765)*b + 5313//2*a - 3780, (-a - 1)*b + 3*a - 1]), map(E, [(728381*a - 998259)*b + 3345554*a - 4653462, (-1507194*a + 2168244)*b - 1507194*a + 2168244, (-5917//2*a - 915)*b - 4331//2*a - 488])];
-L = hermitian_lattice(E, gens, gram = D);
-mass(L)
+```jldoctest
+julia> Qx, x = polynomial_ring(QQ, "x");
+
+julia> f = x^2 - 2;
+
+julia> K, a = number_field(f, "a", cached = false);
+
+julia> Kt, t = polynomial_ring(K, "t");
+
+julia> g = t^2 + 1;
+
+julia> E, b = number_field(g, :b, cached = false);
+
+julia> D = matrix(E, 3, 3, [1, 0, 0, 0, 1, 0, 0, 0, 1]);
+
+julia> gens = Vector{Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}[map(E, [(-3*a + 7)*b + 3*a, (5//2*a - 1)*b - 3//2*a + 4, 0]), map(E, [(3004*a - 4197)*b - 3088*a + 4348, (-1047//2*a + 765)*b + 5313//2*a - 3780, (-a - 1)*b + 3*a - 1]), map(E, [(728381*a - 998259)*b + 3345554*a - 4653462, (-1507194*a + 2168244)*b - 1507194*a + 2168244, (-5917//2*a - 915)*b - 4331//2*a - 488])];
+
+julia> L = hermitian_lattice(E, gens, gram = D);
+
+julia> mass(L)
+1//1024
 ```
 
 ---
@@ -413,23 +591,50 @@ genus_representatives(::HermLat)
 
 ### Examples
 
-```@repl 2
-using Hecke # hide
-Qx, x = QQ["x"];
-K, a = number_field(x^2 - 2, "a");
-Kt, t  = K["t"];
-E, b = number_field(t^2 - a, "b");
-OK = maximal_order(K);
-p = prime_decomposition(OK, 2)[1][1];
-g1 = genus(HermLat, E, p, [(0, 1, 1, 0), (2, 2, -1, 1)], type = :det);
-SEK = unique([restrict(r, K) for r in infinite_places(E) if isreal(restrict(r, K)) && !isreal(r)]);
-G1 = genus([g1], [(SEK[1], 1)]);
-L1 = representative(g1)
-L1 in g1
-L2 = representative(G1)
-L2 in G1, L2 in g1
-length(genus_representatives(L1))
-length(representatives(G1))
+```jldoctest
+julia> Qx, x = QQ[:x];
+
+julia> K, a = number_field(x^2 - 2, :a);
+
+julia> Kt, t  = K[:t];
+
+julia> E, b = number_field(t^2 - a, :b);
+
+julia> OK = maximal_order(K);
+
+julia> p = prime_decomposition(OK, 2)[1][1];
+
+julia> g1 = genus(HermLat, E, p, [(0, 1, 1, 0), (2, 2, -1, 1)], type = :det);
+
+julia> SEK = unique([restrict(r, K) for r in infinite_places(E) if isreal(restrict(r, K)) && !isreal(r)]);
+
+julia> G1 = genus([g1], [(SEK[1], 1)]);
+
+julia> L1 = representative(g1)
+Hermitian lattice of rank 3 and degree 3
+  over relative maximal order of Relative number field of degree 2 over K
+  with pseudo-basis
+  (1, 1//1 * <1, 1>)
+  (b, 1//1 * <1, 1>)
+
+julia> L1 in g1
+true
+
+julia> L2 = representative(G1)
+Hermitian lattice of rank 3 and degree 3
+  over relative maximal order of Relative number field of degree 2 over K
+  with pseudo-basis
+  (1, 1//1 * <1, 1>)
+  (b, 1//1 * <1, 1>)
+
+julia> L2 in G1, L2 in g1
+(true, true)
+
+julia> length(genus_representatives(L1))
+1
+
+julia> length(representatives(G1))
+1
 ```
 
 ---
@@ -443,24 +648,58 @@ direct_sum(::HermGenus, ::HermGenus)
 
 ### Examples
 
-```@repl 2
-using Hecke # hide
-Qx, x = QQ["x"];
-K, a = number_field(x^2 - 2, "a");
-Kt, t  = K["t"];
-E, b = number_field(t^2 - a, "b");
-OK = maximal_order(K);
-p = prime_decomposition(OK, 2)[1][1];
-g1 = genus(HermLat, E, p, [(0, 1, 1, 0), (2, 2, -1, 1)], type = :det);
-SEK = unique([restrict(r, K) for r in infinite_places(E) if isreal(restrict(r, K)) && !isreal(r)]);
-G1 = genus([g1], [(SEK[1], 1)]);
-D = matrix(E, 3, 3, [5//2*a - 4, 0, 0, 0, a, a, 0, a, -4*a + 8]);
-gens = Vector{Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}[map(E, [1, 0, 0]), map(E, [a, 0, 0]), map(E, [b, 0, 0]), map(E, [a*b, 0, 0]), map(E, [0, 1, 0]), map(E, [0, a, 0]), map(E, [0, b, 0]), map(E, [0, a*b, 0]), map(E, [0, 0, 1]), map(E, [0, 0, a]), map(E, [0, 0, b]), map(E, [0, 0, a*b])];
-L = hermitian_lattice(E, gens, gram = D);
-g2 = genus(L, p);
-G2 = genus(L);
-direct_sum(g1, g2)
-direct_sum(G1, G2)
+```jldoctest
+julia> Qx, x = QQ[:x];
+
+julia> K, a = number_field(x^2 - 2, :a);
+
+julia> Kt, t  = K[:t];
+
+julia> E, b = number_field(t^2 - a, :b);
+
+julia> OK = maximal_order(K);
+
+julia> p = prime_decomposition(OK, 2)[1][1];
+
+julia> g1 = genus(HermLat, E, p, [(0, 1, 1, 0), (2, 2, -1, 1)], type = :det);
+
+julia> SEK = unique([restrict(r, K) for r in infinite_places(E) if isreal(restrict(r, K)) && !isreal(r)]);
+
+julia> G1 = genus([g1], [(SEK[1], 1)]);
+
+julia> D = matrix(E, 3, 3, [5//2*a - 4, 0, 0, 0, a, a, 0, a, -4*a + 8]);
+
+julia> gens = Vector{Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}[map(E, [1, 0, 0]), map(E, [a, 0, 0]), map(E, [b, 0, 0]), map(E, [a*b, 0, 0]), map(E, [0, 1, 0]), map(E, [0, a, 0]), map(E, [0, b, 0]), map(E, [0, a*b, 0]), map(E, [0, 0, 1]), map(E, [0, 0, a]), map(E, [0, 0, b]), map(E, [0, 0, a*b])];
+
+julia> L = hermitian_lattice(E, gens, gram = D);
+
+julia> g2 = genus(L, p);
+
+julia> G2 = genus(L);
+
+julia> direct_sum(g1, g2)
+Local genus symbol for hermitian lattices
+  over relative maximal order of Relative number field of degree 2 over K
+  with pseudo-basis
+  (1, 1//1 * <1, 1>)
+  (b, 1//1 * <1, 1>)
+Prime ideal: <2, a>
+Jordan blocks (scale, rank, det, norm):
+  (-2, 1, +, -1)
+  (0, 1, +, 0)
+  (2, 4, -, 1)
+
+julia> direct_sum(G1, G2)
+Genus symbol for hermitian lattices
+  over relative maximal order of Relative number field of degree 2 over K
+  with pseudo-basis
+  (1, 1//1 * <1, 1>)
+  (b, 1//1 * <1, 1>)
+Signature:
+  infinite place corresponding to (Complex embedding of number field) => 3
+Local symbols:
+  <2, a> => (-2, 1, +, -1)(0, 1, +, 0)(2, 4, -, 1)
+  <7, a + 4> => (0, 4, +)(1, 2, +)
 ```
 
 ---
@@ -474,15 +713,61 @@ hermitian_genera(::Hecke.RelSimpleNumField, ::Int, ::Dict{InfPlc, Int}, ::Union{
 
 ### Examples
 
-```@repl 2
-using Hecke # hide
-K, a = cyclotomic_real_subfield(8, "a");
-Kt, t = K["t"];
-E, b = number_field(t^2 - a * t + 1);
-p = prime_decomposition(maximal_order(K), 2)[1][1];
-hermitian_local_genera(E, p, 4, 2, 0, 4)
-SEK = unique([restrict(r, K) for r in infinite_places(E) if isreal(restrict(r, K)) && !isreal(r)]);
-hermitian_genera(E, 3, Dict(SEK[1] => 1, SEK[2] => 1), 30 * maximal_order(E))
+```jldoctest
+julia> K, a = cyclotomic_real_subfield(8, :a);
+
+julia> Kt, t = K[:t];
+
+julia> E, b = number_field(t^2 - a * t + 1);
+
+julia> p = prime_decomposition(maximal_order(K), 2)[1][1];
+
+julia> hermitian_local_genera(E, p, 4, 2, 0, 4)
+15-element Vector{HermLocalGenus{Hecke.RelSimpleNumField{AbsSimpleNumFieldElem}, AbsSimpleNumFieldOrderIdeal}}:
+ Local genus symbol for hermitian lattices over the 2-adic integers
+ Local genus symbol for hermitian lattices over the 2-adic integers
+ Local genus symbol for hermitian lattices over the 2-adic integers
+ Local genus symbol for hermitian lattices over the 2-adic integers
+ Local genus symbol for hermitian lattices over the 2-adic integers
+ Local genus symbol for hermitian lattices over the 2-adic integers
+ Local genus symbol for hermitian lattices over the 2-adic integers
+ Local genus symbol for hermitian lattices over the 2-adic integers
+ Local genus symbol for hermitian lattices over the 2-adic integers
+ Local genus symbol for hermitian lattices over the 2-adic integers
+ Local genus symbol for hermitian lattices over the 2-adic integers
+ Local genus symbol for hermitian lattices over the 2-adic integers
+ Local genus symbol for hermitian lattices over the 2-adic integers
+ Local genus symbol for hermitian lattices over the 2-adic integers
+ Local genus symbol for hermitian lattices over the 2-adic integers
+
+julia> SEK = unique([restrict(r, K) for r in infinite_places(E) if isreal(restrict(r, K)) && !isreal(r)]);
+
+julia> hermitian_genera(E, 3, Dict(SEK[1] => 1, SEK[2] => 1), 30 * maximal_order(E))
+6-element Vector{HermGenus{Hecke.RelSimpleNumField{AbsSimpleNumFieldElem}, AbsSimpleNumFieldOrderIdeal, HermLocalGenus{Hecke.RelSimpleNumField{AbsSimpleNumFieldElem}, AbsSimpleNumFieldOrderIdeal}, Dict{InfPlc{AbsSimpleNumField, AbsSimpleNumFieldEmbedding}, Int64}}}:
+ Genus symbol for hermitian lattices of rank 3 over relative maximal order of Relative number field
+with pseudo-basis
+(1, 1//1 * <1, 1>)
+(_$, 1//1 * <1, 1>)
+ Genus symbol for hermitian lattices of rank 3 over relative maximal order of Relative number field
+with pseudo-basis
+(1, 1//1 * <1, 1>)
+(_$, 1//1 * <1, 1>)
+ Genus symbol for hermitian lattices of rank 3 over relative maximal order of Relative number field
+with pseudo-basis
+(1, 1//1 * <1, 1>)
+(_$, 1//1 * <1, 1>)
+ Genus symbol for hermitian lattices of rank 3 over relative maximal order of Relative number field
+with pseudo-basis
+(1, 1//1 * <1, 1>)
+(_$, 1//1 * <1, 1>)
+ Genus symbol for hermitian lattices of rank 3 over relative maximal order of Relative number field
+with pseudo-basis
+(1, 1//1 * <1, 1>)
+(_$, 1//1 * <1, 1>)
+ Genus symbol for hermitian lattices of rank 3 over relative maximal order of Relative number field
+with pseudo-basis
+(1, 1//1 * <1, 1>)
+(_$, 1//1 * <1, 1>)
 ```
 
 ## Rescaling

--- a/docs/src/manual/quad_forms/genusherm.md
+++ b/docs/src/manual/quad_forms/genusherm.md
@@ -324,10 +324,10 @@ julia> p = prime_decomposition(OK, 2)[1][1];
 julia> g1 = genus(HermLat, E, p, [(0, 1, 1, 0), (2, 2, -1, 1)], type = :det);
 
 julia> det_representative(g1)
--8*a + 10
+-8*a - 6
 
 julia> det_representative(g1,2)
--8*a + 10
+-8*a - 6
 ```
 
 ---
@@ -363,12 +363,12 @@ julia> L = hermitian_lattice(E, gens, gram = D);
 julia> g2 = genus(L, p);
 
 julia> gram_matrix(g2)
-[5//2*a + 4   0          0]
-[         0   a          a]
-[         0   a   -4*a - 8]
+[-3//2*a   0     0]
+[      0   a     a]
+[      0   a   4*a]
 
 julia> gram_matrix(g2,1)
-[5//2*a + 4]
+[-3//2*a]
 ```
 
 ---
@@ -436,12 +436,16 @@ julia> infp = infinite_places(E)
 
 julia> SEK = unique([r.base_field_place for r in infp if isreal(r.base_field_place) && !isreal(r)]);
 ERROR: type InfPlc has no field base_field_place
+[...]
 
 julia> length(SEK)
-ERROR: UndefVarError: `SEK` not defined
+ERROR: UndefVarError: `SEK` not defined in `Main`
+[...]
+
 
 julia> G1 = genus([g1], [(SEK[1], 1)])
-ERROR: UndefVarError: `SEK` not defined
+ERROR: UndefVarError: `SEK` not defined in `Main`
+[...]
 
 julia> D = matrix(E, 3, 3, [5//2*a - 4, 0, 0, 0, a, a, 0, a, -4*a + 8]);
 
@@ -451,7 +455,7 @@ julia> L = hermitian_lattice(E, gens, gram = D);
 
 julia> G2 = genus(L)
 Genus symbol for hermitian lattices
-  over relative maximal order of Relative number field of degree 2 over number field
+  over relative maximal order of Relative number field of degree 2 over K
   with pseudo-basis
   (1, 1//1 * <1, 1>)
   (b, 1//1 * <1, 1>)
@@ -522,7 +526,7 @@ two normal wrt: 7
 
 julia> signatures(G2)
 Dict{InfPlc{AbsSimpleNumField, AbsSimpleNumFieldEmbedding}, Int64} with 1 entry:
-  Infinite place corresponding to (Complex embedding corresponding to -1.41 of K) => 2
+  Infinite place corresponding to (Complex embedding corresponding to -1.4… => 2
 
 julia> rank(G2)
 3

--- a/docs/src/manual/quad_forms/integer_lattices.md
+++ b/docs/src/manual/quad_forms/integer_lattices.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # Integer Lattices
 

--- a/docs/src/manual/quad_forms/integer_lattices.md
+++ b/docs/src/manual/quad_forms/integer_lattices.md
@@ -1,10 +1,11 @@
-# Integer Lattices
 ```@meta
 CurrentModule = Hecke
 DocTestSetup = quote
     using Hecke
-  end
+end
 ```
+# Integer Lattices
+
 An integer lattice $L$ is a finitely generated $\mathbb{Z}$-submodule of a quadratic
 vector space $V = \mathbb{Q}^n$ over the rational numbers.
 Integer lattices are also known as quadratic forms over the integers.

--- a/docs/src/manual/quad_forms/introduction.md
+++ b/docs/src/manual/quad_forms/introduction.md
@@ -1,7 +1,10 @@
-# Introduction
 ```@meta
 CurrentModule = Hecke
+DocTestSetup = quote
+    using Hecke
+end
 ```
+# Introduction
 
 
 This chapter deals with quadratic and hermitian spaces, and lattices there of.

--- a/docs/src/manual/quad_forms/introduction.md
+++ b/docs/src/manual/quad_forms/introduction.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # Introduction
 

--- a/docs/src/manual/quad_forms/lattices.md
+++ b/docs/src/manual/quad_forms/lattices.md
@@ -860,7 +860,7 @@ Relative maximal order with pseudo-basis (1) * 1//1 * <1, 1>, (b + 1) * 1//2 * <
 with basis pseudo-matrix
 (1//1 * <1, 1>) * [1 0]
 (1//14 * <1, 1>) * [6 1])
- ([4, 5, 0, 1], Fractional ideal of
+ ([3, 2, 0, 1], Fractional ideal of
 Relative maximal order with pseudo-basis (1) * 1//1 * <1, 1>, (b + 1) * 1//2 * <1, 1>
 with basis pseudo-matrix
 (1//1 * <1, 1>) * [1 0]

--- a/docs/src/manual/quad_forms/lattices.md
+++ b/docs/src/manual/quad_forms/lattices.md
@@ -1,10 +1,11 @@
-# Lattices
 ```@meta
 CurrentModule = Hecke
 DocTestSetup = quote
     using Hecke
-  end
+end
 ```
+# Lattices
+
 
 ## Creation of lattices
 

--- a/docs/src/manual/quad_forms/lattices.md
+++ b/docs/src/manual/quad_forms/lattices.md
@@ -38,45 +38,96 @@ hermitian_lattice(::NumField, ::Vector)
 #### Examples
 The two following examples will be used all along this section:
 
-```@repl 2
-using Hecke # hide
-K, a = rationals_as_number_field();
-Kt, t = K["t"];
-g = t^2 + 7;
-E, b = number_field(g, "b");
-D = matrix(K, 3, 3, [2, 0, 0, 0, 2, 0, 0, 0, 2]);
-gens = Vector{AbsSimpleNumFieldElem}[map(K, [1, 1, 0]), map(K, [1, 0, 1]), map(K, [2, 0, 0])];
-Lquad = quadratic_lattice(K, gens, gram = D)
-D = matrix(E, 4, 4, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
-gens = Vector{Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}[map(E, [2, -1, 0, 0]), map(E, [-3, 0, -1, 0]), map(E, [0, 0, 0, -1]), map(E, [b, 0, 0, 0])];
-Lherm = hermitian_lattice(E, gens, gram = D)
+```jldoctest
+julia> K, a = rationals_as_number_field();
+
+julia> Kt, t = K[:t];
+
+julia> g = t^2 + 7;
+
+julia> E, b = number_field(g, :b);
+
+julia> D = matrix(K, 3, 3, [2, 0, 0, 0, 2, 0, 0, 0, 2]);
+
+julia> gens = Vector{AbsSimpleNumFieldElem}[map(K, [1, 1, 0]), map(K, [1, 0, 1]), map(K, [2, 0, 0])];
+
+julia> Lquad = quadratic_lattice(K, gens, gram = D)
+Quadratic lattice of rank 3 and degree 3
+  over maximal order of number field of degree 1 over QQ
+  with basis [1]
+
+julia> D = matrix(E, 4, 4, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+
+julia> gens = Vector{Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}[map(E, [2, -1, 0, 0]), map(E, [-3, 0, -1, 0]), map(E, [0, 0, 0, -1]), map(E, [b, 0, 0, 0])];
+
+julia> Lherm = hermitian_lattice(E, gens, gram = D)
+Hermitian lattice of rank 4 and degree 4
+  over relative maximal order of Relative number field of degree 2 over K
+  with pseudo-basis
+  (1, 1//1 * <1, 1>)
+  (b + 1, 1//2 * <1, 1>)
 ```
 
 Note that the format used here is the one given by the internal function
 `Hecke.to_hecke()` which prints REPL commands to get back the input lattice.
 
-```@repl 2
-using Hecke # hide
-K, a = rationals_as_number_field();
-Kt, t = K["t"];
-g = t^2 + 7;
-E, b = number_field(g, "b");
-D = matrix(E, 4, 4, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
-gens = Vector{Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}[map(E, [2, -1, 0, 0]), map(E, [-3, 0, -1, 0]), map(E, [0, 0, 0, -1]), map(E, [b, 0, 0, 0])];
-Lherm = hermitian_lattice(E, gens, gram = D);
-Hecke.to_hecke(Lherm)
+```jldoctest
+julia> K, a = rationals_as_number_field();
+
+julia> Kt, t = K[:t];
+
+julia> g = t^2 + 7;
+
+julia> E, b = number_field(g, :b);
+
+julia> D = matrix(E, 4, 4, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+
+julia> gens = Vector{Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}[map(E, [2, -1, 0, 0]), map(E, [-3, 0, -1, 0]), map(E, [0, 0, 0, -1]), map(E, [b, 0, 0, 0])];
+
+julia> Lherm = hermitian_lattice(E, gens, gram = D);
+
+julia> Hecke.to_hecke(Lherm)
+Qx, x = polynomial_ring(QQ, :x)
+f = x - 1
+K, a = number_field(f, :a, cached = false)
+Kt, t = polynomial_ring(K, :t)
+g = t^2 + 7
+E, b = number_field(g, :b, cached = false)
+D = matrix(E, 4, 4, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1])
+gens = Vector{Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}[map(E, [2, -1, 0, 0]), map(E, [-3, 0, -1, 0]), map(E, [0, 0, 0, -1]), map(E, [b, 0, 0, 0])]
+L = hermitian_lattice(E, gens, gram = D)
 ```
 
 Finally, one can access some databases in which are stored several quadratic and
 hermitian lattices. Up to now, these are not automatically available while running
 Hecke. It can nonetheless be used in the following way:
 
-```@repl 2
-using Hecke # hide
-qld = Hecke.quadratic_lattice_database()
-lattice(qld, 1)
-hlb = Hecke.hermitian_lattice_database()
-lattice(hlb, 426)
+```jldoctest
+julia> qld = Hecke.quadratic_lattice_database()
+Quadratic lattices of rank >= 3 with class number 1 or 2
+Author: Markus Kirschmer
+Source: http://www.math.rwth-aachen.de/~Markus.Kirschmer/forms/
+Version: 0.0.1
+Number of lattices: 30250
+
+julia> lattice(qld, 1)
+Quadratic lattice of rank 3 and degree 3
+  over maximal order of number field of degree 1 over QQ
+  with basis [1]
+
+julia> hlb = Hecke.hermitian_lattice_database()
+Hermitian lattices of rank >= 3 with class number 1 or 2
+Author: Markus Kirschmer
+Source: http://www.math.rwth-aachen.de/~Markus.Kirschmer/forms/
+Version: 0.0.1
+Number of lattices: 570
+
+julia> lattice(hlb, 426)
+Hermitian lattice of rank 4 and degree 4
+  over relative maximal order of Relative number field of degree 2 over number field
+  with pseudo-basis
+  (1, 1//1 * <1, 1>)
+  (b + 1, 1//2 * <1, 1>)
 ```
 
 ---
@@ -93,23 +144,63 @@ diagonal_of_rational_span(::AbstractLat)
 
 ### Examples
 
-```@repl 2
-using Hecke # hide
-K, a = rationals_as_number_field();
-Kt, t = K["t"];
-g = t^2 + 7;
-E, b = number_field(g, "b");
-D = matrix(K, 3, 3, [2, 0, 0, 0, 2, 0, 0, 0, 2]);
-gens = Vector{AbsSimpleNumFieldElem}[map(K, [1, 1, 0]), map(K, [1, 0, 1]), map(K, [2, 0, 0])];
-Lquad = quadratic_lattice(K, gens, gram = D);
-D = matrix(E, 4, 4, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
-gens = Vector{Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}[map(E, [2, -1, 0, 0]), map(E, [-3, 0, -1, 0]), map(E, [0, 0, 0, -1]), map(E, [b, 0, 0, 0])];
-Lherm = hermitian_lattice(E, gens, gram = D);
-ambient_space(Lherm)
-rational_span(Lquad)
-basis_matrix_of_rational_span(Lherm)
-gram_matrix_of_rational_span(Lherm)
-diagonal_of_rational_span(Lquad)
+```jldoctest
+julia> K, a = rationals_as_number_field();
+
+julia> Kt, t = K[:t];
+
+julia> g = t^2 + 7;
+
+julia> E, b = number_field(g, :b);
+
+julia> D = matrix(K, 3, 3, [2, 0, 0, 0, 2, 0, 0, 0, 2]);
+
+julia> gens = Vector{AbsSimpleNumFieldElem}[map(K, [1, 1, 0]), map(K, [1, 0, 1]), map(K, [2, 0, 0])];
+
+julia> Lquad = quadratic_lattice(K, gens, gram = D);
+
+julia> D = matrix(E, 4, 4, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+
+julia> gens = Vector{Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}[map(E, [2, -1, 0, 0]), map(E, [-3, 0, -1, 0]), map(E, [0, 0, 0, -1]), map(E, [b, 0, 0, 0])];
+
+julia> Lherm = hermitian_lattice(E, gens, gram = D);
+
+julia> ambient_space(Lherm)
+Hermitian space of dimension 4
+  over relative number field with defining polynomial t^2 + 7
+    over number field with defining polynomial x - 1
+      over rational field
+with gram matrix
+[1   0   0   0]
+[0   1   0   0]
+[0   0   1   0]
+[0   0   0   1]
+
+julia> rational_span(Lquad)
+Quadratic space of dimension 3
+  over number field of degree 1 over QQ
+with gram matrix
+[2   2   2]
+[2   4   2]
+[2   2   4]
+
+julia> basis_matrix_of_rational_span(Lherm)
+[1   0   0   0]
+[5   1   0   0]
+[3   0   1   0]
+[0   0   0   1]
+
+julia> gram_matrix_of_rational_span(Lherm)
+[1    5    3   0]
+[5   26   15   0]
+[3   15   10   0]
+[0    0    0   1]
+
+julia> diagonal_of_rational_span(Lquad)
+3-element Vector{AbsSimpleNumFieldElem}:
+ 2
+ 2
+ 2
 ```
 
 ---
@@ -128,20 +219,41 @@ For now and for the rest of this section, the examples will include the new latt
 `Lquad2` which is quadratic. Moreover, all the completions are going to be done at
 the prime ideal $p = 7*\mathcal O_K$.
 
-```@repl hecke
-using Hecke # hide
-K, a = rationals_as_number_field();
-D = matrix(K, 3, 3, [2, 0, 0, 0, 2, 0, 0, 0, 2]);
-gens = Vector{AbsSimpleNumFieldElem}[map(K, [1, 1, 0]), map(K, [1, 0, 1]), map(K, [2, 0, 0])];
-Lquad = quadratic_lattice(K, gens, gram = D);
-D = matrix(K, 3, 3, [2, 0, 0, 0, 2, 0, 0, 0, 2]);
-gens = Vector{AbsSimpleNumFieldElem}[map(K, [-35, 25, 0]), map(K, [30, 40, -20]), map(K, [5, 10, -5])];
-Lquad2 = quadratic_lattice(K, gens, gram = D)
-OK = maximal_order(K);
-p = prime_decomposition(OK, 7)[1][1]
-hasse_invariant(Lquad, p), witt_invariant(Lquad, p)
-is_rationally_isometric(Lquad, Lquad2, p)
-is_rationally_isometric(Lquad, Lquad2)
+```jldoctest
+julia> K, a = rationals_as_number_field();
+
+julia> D = matrix(K, 3, 3, [2, 0, 0, 0, 2, 0, 0, 0, 2]);
+
+julia> gens = Vector{AbsSimpleNumFieldElem}[map(K, [1, 1, 0]), map(K, [1, 0, 1]), map(K, [2, 0, 0])];
+
+julia> Lquad = quadratic_lattice(K, gens, gram = D);
+
+julia> D = matrix(K, 3, 3, [2, 0, 0, 0, 2, 0, 0, 0, 2]);
+
+julia> gens = Vector{AbsSimpleNumFieldElem}[map(K, [-35, 25, 0]), map(K, [30, 40, -20]), map(K, [5, 10, -5])];
+
+julia> Lquad2 = quadratic_lattice(K, gens, gram = D)
+Quadratic lattice of rank 3 and degree 3
+  over maximal order of number field of degree 1 over QQ
+  with basis [1]
+
+julia> OK = maximal_order(K);
+
+julia> p = prime_decomposition(OK, 7)[1][1]
+<7, 7>
+Norm: 7
+Minimum: 7
+principal generator 7
+two normal wrt: 7
+
+julia> hasse_invariant(Lquad, p), witt_invariant(Lquad, p)
+(1, 1)
+
+julia> is_rationally_isometric(Lquad, Lquad2, p)
+true
+
+julia> is_rationally_isometric(Lquad, Lquad2)
+true
 ```
 
 ---
@@ -183,29 +295,144 @@ gram_matrix_of_generators(::AbstractLat; minimal::Bool = false)
 
 ### Examples
 
-```@repl 2
-using Hecke # hide
-K, a = rationals_as_number_field();
-Kt, t = K["t"];
-g = t^2 + 7;
-E, b = number_field(g, "b");
-D = matrix(E, 4, 4, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
-gens = Vector{Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}[map(E, [2, -1, 0, 0]), map(E, [-3, 0, -1, 0]), map(E, [0, 0, 0, -1]), map(E, [b, 0, 0, 0])];
-Lherm = hermitian_lattice(E, gens, gram = D);
-rank(Lherm), degree(Lherm)
-discriminant(Lherm)
-base_field(Lherm)
-base_ring(Lherm)
-fixed_field(Lherm)
-fixed_ring(Lherm)
-involution(Lherm)
-pseudo_matrix(Lherm)
-pseudo_basis(Lherm)
-coefficient_ideals(Lherm)
-absolute_basis_matrix(Lherm)
-absolute_basis(Lherm)
-generators(Lherm)
-gram_matrix_of_generators(Lherm)
+```jldoctest
+julia> K, a = rationals_as_number_field();
+
+julia> Kt, t = K[:t];
+
+julia> g = t^2 + 7;
+
+julia> E, b = number_field(g, :b);
+
+julia> D = matrix(E, 4, 4, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+
+julia> gens = Vector{Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}[map(E, [2, -1, 0, 0]), map(E, [-3, 0, -1, 0]), map(E, [0, 0, 0, -1]), map(E, [b, 0, 0, 0])];
+
+julia> Lherm = hermitian_lattice(E, gens, gram = D);
+
+julia> rank(Lherm), degree(Lherm)
+(4, 4)
+
+julia> discriminant(Lherm)
+Fractional ideal of
+Relative maximal order with pseudo-basis (1) * 1//1 * <1, 1>, (b + 1) * 1//2 * <1, 1>
+with basis pseudo-matrix
+(1//1 * <7, 7>) * [1 0]
+(1//2 * <7, 7>) * [0 1]
+
+julia> base_field(Lherm)
+Relative number field with defining polynomial t^2 + 7
+  over number field with defining polynomial x - 1
+    over rational field
+
+julia> base_ring(Lherm)
+Relative maximal order of Relative number field of degree 2 over K
+with pseudo-basis
+(1, 1//1 * <1, 1>)
+(b + 1, 1//2 * <1, 1>)
+
+julia> fixed_field(Lherm)
+Number field with defining polynomial x - 1
+  over rational field
+
+julia> fixed_ring(Lherm)
+Maximal order of number field of degree 1 over QQ
+with basis [1]
+
+julia> involution(Lherm)
+Map
+  from relative number field of degree 2 over K
+  to relative number field of degree 2 over K
+
+julia> pseudo_matrix(Lherm)
+Pseudo-matrix over Relative maximal order of Relative number field of degree 2 over K
+with pseudo-basis
+(1, 1//1 * <1, 1>)
+(b + 1, 1//2 * <1, 1>)
+Fractional ideal with row [1 0 0 0]
+Fractional ideal with row [5 1 0 0]
+Fractional ideal with row [3 0 1 0]
+Fractional ideal with row [0 0 0 1]
+
+julia> pseudo_basis(Lherm)
+4-element Vector{Tuple{Vector{Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}, Hecke.RelNumFieldOrderFractionalIdeal{AbsSimpleNumFieldElem, AbsSimpleNumFieldOrderFractionalIdeal, Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}}}:
+ ([1, 0, 0, 0], Fractional ideal of
+Relative maximal order with pseudo-basis (1) * 1//1 * <1, 1>, (b + 1) * 1//2 * <1, 1>
+with basis pseudo-matrix
+(1//1 * <7, 28>) * [1 0]
+(1//2 * <1, 1>) * [6 1])
+ ([5, 1, 0, 0], Fractional ideal of
+Relative maximal order with pseudo-basis (1) * 1//1 * <1, 1>, (b + 1) * 1//2 * <1, 1>
+with basis pseudo-matrix
+(1//1 * <1, 1>) * [1 0]
+(1//2 * <1, 1>) * [0 1])
+ ([3, 0, 1, 0], Fractional ideal of
+Relative maximal order with pseudo-basis (1) * 1//1 * <1, 1>, (b + 1) * 1//2 * <1, 1>
+with basis pseudo-matrix
+(1//1 * <1, 1>) * [1 0]
+(1//2 * <1, 1>) * [0 1])
+ ([0, 0, 0, 1], Fractional ideal of
+Relative maximal order with pseudo-basis (1) * 1//1 * <1, 1>, (b + 1) * 1//2 * <1, 1>
+with basis pseudo-matrix
+(1//1 * <1, 1>) * [1 0]
+(1//2 * <1, 1>) * [0 1])
+
+julia> coefficient_ideals(Lherm)
+4-element Vector{Hecke.RelNumFieldOrderFractionalIdeal{AbsSimpleNumFieldElem, AbsSimpleNumFieldOrderFractionalIdeal, Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}}:
+ Fractional ideal of
+Relative maximal order with pseudo-basis (1) * 1//1 * <1, 1>, (b + 1) * 1//2 * <1, 1>
+with basis pseudo-matrix
+(1//1 * <7, 28>) * [1 0]
+(1//2 * <1, 1>) * [6 1]
+ Fractional ideal of
+Relative maximal order with pseudo-basis (1) * 1//1 * <1, 1>, (b + 1) * 1//2 * <1, 1>
+with basis pseudo-matrix
+(1//1 * <1, 1>) * [1 0]
+(1//2 * <1, 1>) * [0 1]
+ Fractional ideal of
+Relative maximal order with pseudo-basis (1) * 1//1 * <1, 1>, (b + 1) * 1//2 * <1, 1>
+with basis pseudo-matrix
+(1//1 * <1, 1>) * [1 0]
+(1//2 * <1, 1>) * [0 1]
+ Fractional ideal of
+Relative maximal order with pseudo-basis (1) * 1//1 * <1, 1>, (b + 1) * 1//2 * <1, 1>
+with basis pseudo-matrix
+(1//1 * <1, 1>) * [1 0]
+(1//2 * <1, 1>) * [0 1]
+
+julia> absolute_basis_matrix(Lherm)
+[            7               0               0               0]
+[1//2*b + 7//2               0               0               0]
+[            5               1               0               0]
+[5//2*b + 5//2   1//2*b + 1//2               0               0]
+[            3               0               1               0]
+[3//2*b + 3//2               0   1//2*b + 1//2               0]
+[            0               0               0               1]
+[            0               0               0   1//2*b + 1//2]
+
+julia> absolute_basis(Lherm)
+8-element Vector{Vector{Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}}:
+ [7, 0, 0, 0]
+ [1//2*b + 7//2, 0, 0, 0]
+ [5, 1, 0, 0]
+ [5//2*b + 5//2, 1//2*b + 1//2, 0, 0]
+ [3, 0, 1, 0]
+ [3//2*b + 3//2, 0, 1//2*b + 1//2, 0]
+ [0, 0, 0, 1]
+ [0, 0, 0, 1//2*b + 1//2]
+
+julia> generators(Lherm)
+4-element Vector{Vector{Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}}:
+ [2, -1, 0, 0]
+ [-3, 0, -1, 0]
+ [0, 0, 0, -1]
+ [b, 0, 0, 0]
+
+julia> gram_matrix_of_generators(Lherm)
+[  5     -6   0   -2*b]
+[ -6     10   0    3*b]
+[  0      0   1      0]
+[2*b   -3*b   0      7]
 ```
 ---
 
@@ -238,22 +465,60 @@ orthogonal_submodule(::AbstractLat, ::AbstractLat)
 
 ### Examples
 
-```@repl 2
-using Hecke # hide
-K, a = rationals_as_number_field();
-D = matrix(K, 3, 3, [2, 0, 0, 0, 2, 0, 0, 0, 2]);
-gens = Vector{AbsSimpleNumFieldElem}[map(K, [1, 1, 0]), map(K, [1, 0, 1]), map(K, [2, 0, 0])];
-Lquad = quadratic_lattice(K, gens, gram = D);
-D = matrix(K, 3, 3, [2, 0, 0, 0, 2, 0, 0, 0, 2]);
-gens = Vector{AbsSimpleNumFieldElem}[map(K, [-35, 25, 0]), map(K, [30, 40, -20]), map(K, [5, 10, -5])];
-Lquad2 = quadratic_lattice(K, gens, gram = D);
-OK = maximal_order(K);
-p = prime_decomposition(OK, 7)[1][1];
-pseudo_matrix(Lquad + Lquad2)
-pseudo_matrix(intersect(Lquad, Lquad2))
-pseudo_matrix(p*Lquad)
-ambient_space(rescale(Lquad,3*a))
-pseudo_matrix(Lquad)
+```jldoctest
+julia> K, a = rationals_as_number_field();
+
+julia> D = matrix(K, 3, 3, [2, 0, 0, 0, 2, 0, 0, 0, 2]);
+
+julia> gens = Vector{AbsSimpleNumFieldElem}[map(K, [1, 1, 0]), map(K, [1, 0, 1]), map(K, [2, 0, 0])];
+
+julia> Lquad = quadratic_lattice(K, gens, gram = D);
+
+julia> D = matrix(K, 3, 3, [2, 0, 0, 0, 2, 0, 0, 0, 2]);
+
+julia> gens = Vector{AbsSimpleNumFieldElem}[map(K, [-35, 25, 0]), map(K, [30, 40, -20]), map(K, [5, 10, -5])];
+
+julia> Lquad2 = quadratic_lattice(K, gens, gram = D);
+
+julia> OK = maximal_order(K);
+
+julia> p = prime_decomposition(OK, 7)[1][1];
+
+julia> pseudo_matrix(Lquad + Lquad2)
+Pseudo-matrix over Maximal order of number field of degree 1 over QQ
+with basis [1]
+1//1 * <2, 2> with row [1 0 0]
+1//1 * <1, 1> with row [1 1 0]
+1//1 * <1, 1> with row [1 0 1]
+
+julia> pseudo_matrix(intersect(Lquad, Lquad2))
+Pseudo-matrix over Maximal order of number field of degree 1 over QQ
+with basis [1]
+1//1 * <10, 10> with row [1 0 0]
+1//1 * <25, 25> with row [1//5 1 0]
+1//1 * <5, 5> with row [0 3 1]
+
+julia> pseudo_matrix(p*Lquad)
+Pseudo-matrix over Maximal order of number field of degree 1 over QQ
+with basis [1]
+1//1 * <14, 126> with row [1 0 0]
+1//1 * <7, 7> with row [1 1 0]
+1//1 * <7, 7> with row [1 0 1]
+
+julia> ambient_space(rescale(Lquad,3*a))
+Quadratic space of dimension 3
+  over number field of degree 1 over QQ
+with gram matrix
+[6   0   0]
+[0   6   0]
+[0   0   6]
+
+julia> pseudo_matrix(Lquad)
+Pseudo-matrix over Maximal order of number field of degree 1 over QQ
+with basis [1]
+1//1 * <2, 2> with row [1 0 0]
+1//1 * <1, 1> with row [1 1 0]
+1//1 * <1, 1> with row [1 0 1]
 ```
 
 ## Categorical constructions
@@ -289,18 +554,43 @@ volume(L::AbstractLat)
 
 ### Examples
 
-```@repl 2
-using Hecke # hide
-K, a = rationals_as_number_field();
-Kt, t = K["t"];
-g = t^2 + 7;
-E, b = number_field(g, "b");
-D = matrix(E, 4, 4, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
-gens = Vector{Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}[map(E, [2, -1, 0, 0]), map(E, [-3, 0, -1, 0]), map(E, [0, 0, 0, -1]), map(E, [b, 0, 0, 0])];
-Lherm = hermitian_lattice(E, gens, gram = D);
-norm(Lherm)
-scale(Lherm)
-volume(Lherm)
+```jldoctest
+julia> K, a = rationals_as_number_field();
+
+julia> Kt, t = K[:t];
+
+julia> g = t^2 + 7;
+
+julia> E, b = number_field(g, :b);
+
+julia> D = matrix(E, 4, 4, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+
+julia> gens = Vector{Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}[map(E, [2, -1, 0, 0]), map(E, [-3, 0, -1, 0]), map(E, [0, 0, 0, -1]), map(E, [b, 0, 0, 0])];
+
+julia> Lherm = hermitian_lattice(E, gens, gram = D);
+
+julia> norm(Lherm)
+1//1 * <1, 1>
+Norm: 1
+Minimum: 1
+principal generator 1
+basis_matrix
+[1]
+two normal wrt: 2
+
+julia> scale(Lherm)
+Fractional ideal of
+Relative maximal order with pseudo-basis (1) * 1//1 * <1, 1>, (b + 1) * 1//2 * <1, 1>
+with basis pseudo-matrix
+(1//1 * <1, 1>) * [1 0]
+(1//2 * <1, 1>) * [0 1]
+
+julia> volume(Lherm)
+Fractional ideal of
+Relative maximal order with pseudo-basis (1) * 1//1 * <1, 1>, (b + 1) * 1//2 * <1, 1>
+with basis pseudo-matrix
+(1//1 * <7, 7>) * [1 0]
+(1//2 * <7, 7>) * [0 1]
 ```
 ---
 
@@ -324,22 +614,39 @@ can_scale_totally_positive(L::AbstractLat)
 
 ### Examples
 
-```@repl 2
-using Hecke # hide
-K, a = rationals_as_number_field();
-Kt, t = K["t"];
-g = t^2 + 7;
-E, b = number_field(g, "b");
-D = matrix(E, 4, 4, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
-gens = Vector{Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}[map(E, [2, -1, 0, 0]), map(E, [-3, 0, -1, 0]), map(E, [0, 0, 0, -1]), map(E, [b, 0, 0, 0])];
-Lherm = hermitian_lattice(E, gens, gram = D);
-OK = maximal_order(K);
-is_integral(Lherm)
-is_modular(Lherm)[1]
-p = prime_decomposition(OK, 7)[1][1];
-is_modular(Lherm, p)
-is_positive_definite(Lherm)
-can_scale_totally_positive(Lherm)
+```jldoctest
+julia> K, a = rationals_as_number_field();
+
+julia> Kt, t = K[:t];
+
+julia> g = t^2 + 7;
+
+julia> E, b = number_field(g, :b);
+
+julia> D = matrix(E, 4, 4, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+
+julia> gens = Vector{Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}[map(E, [2, -1, 0, 0]), map(E, [-3, 0, -1, 0]), map(E, [0, 0, 0, -1]), map(E, [b, 0, 0, 0])];
+
+julia> Lherm = hermitian_lattice(E, gens, gram = D);
+
+julia> OK = maximal_order(K);
+
+julia> is_integral(Lherm)
+true
+
+julia> is_modular(Lherm)[1]
+false
+
+julia> p = prime_decomposition(OK, 7)[1][1];
+
+julia> is_modular(Lherm, p)
+(false, 0)
+
+julia> is_positive_definite(Lherm)
+true
+
+julia> can_scale_totally_positive(Lherm)
+(true, 1)
 ```
 ---
 
@@ -353,17 +660,29 @@ is_isotropic(::AbstractLat, p)
 
 ### Examples
 
-```@repl 2
-using Hecke # hide
-K, a = rationals_as_number_field();
-D = matrix(K, 3, 3, [2, 0, 0, 0, 2, 0, 0, 0, 2]);
-gens = Vector{AbsSimpleNumFieldElem}[map(K, [1, 1, 0]), map(K, [1, 0, 1]), map(K, [2, 0, 0])];
-Lquad = quadratic_lattice(K, gens, gram = D);
-OK = maximal_order(K);
-p = prime_decomposition(OK, 7)[1][1];
-local_basis_matrix(Lquad, p)
-jordan_decomposition(Lquad, p)
-is_isotropic(Lquad, p)
+```jldoctest
+julia> K, a = rationals_as_number_field();
+
+julia> D = matrix(K, 3, 3, [2, 0, 0, 0, 2, 0, 0, 0, 2]);
+
+julia> gens = Vector{AbsSimpleNumFieldElem}[map(K, [1, 1, 0]), map(K, [1, 0, 1]), map(K, [2, 0, 0])];
+
+julia> Lquad = quadratic_lattice(K, gens, gram = D);
+
+julia> OK = maximal_order(K);
+
+julia> p = prime_decomposition(OK, 7)[1][1];
+
+julia> local_basis_matrix(Lquad, p)
+[1   0   0]
+[1   1   0]
+[1   0   1]
+
+julia> jordan_decomposition(Lquad, p)
+(AbstractAlgebra.Generic.MatSpaceElem{AbsSimpleNumFieldElem}[[1 0 0; 0 1 0; 0 0 1]], AbstractAlgebra.Generic.MatSpaceElem{AbsSimpleNumFieldElem}[[2 0 0; 0 2 0; 0 0 2]], [0])
+
+julia> is_isotropic(Lquad, p)
+true
 ```
 
 ---
@@ -390,18 +709,35 @@ automorphism_group_generators(::AbstractLat)
 
 ### Examples
 
-```@repl 2
-using Hecke # hide
-K, a = rationals_as_number_field();
-Kt, t = K["t"];
-g = t^2 + 7;
-E, b = number_field(g, "b");
-D = matrix(K, 3, 3, [2, 0, 0, 0, 2, 0, 0, 0, 2]);
-gens = Vector{AbsSimpleNumFieldElem}[map(K, [1, 1, 0]), map(K, [1, 0, 1]), map(K, [2, 0, 0])];
-Lquad = quadratic_lattice(K, gens, gram = D);
-is_definite(Lquad)
-automorphism_group_order(Lquad)
-automorphism_group_generators(Lquad)
+```jldoctest
+julia> K, a = rationals_as_number_field();
+
+julia> Kt, t = K[:t];
+
+julia> g = t^2 + 7;
+
+julia> E, b = number_field(g, :b);
+
+julia> D = matrix(K, 3, 3, [2, 0, 0, 0, 2, 0, 0, 0, 2]);
+
+julia> gens = Vector{AbsSimpleNumFieldElem}[map(K, [1, 1, 0]), map(K, [1, 0, 1]), map(K, [2, 0, 0])];
+
+julia> Lquad = quadratic_lattice(K, gens, gram = D);
+
+julia> is_definite(Lquad)
+true
+
+julia> automorphism_group_order(Lquad)
+48
+
+julia> automorphism_group_generators(Lquad)
+6-element Vector{AbstractAlgebra.Generic.MatSpaceElem{AbsSimpleNumFieldElem}}:
+ [-1 0 0; 0 -1 0; 0 0 -1]
+ [1 0 0; 0 -1 0; 0 0 -1]
+ [1 0 0; 0 0 -1; 0 -1 0]
+ [0 -1 0; 0 0 -1; 1 0 0]
+ [1 0 0; 0 1 0; 0 0 -1]
+ [0 1 0; 1 0 0; 0 0 1]
 ```
 
 ---
@@ -416,19 +752,30 @@ is_locally_isometric(::AbstractLat, ::AbstractLat, p::AbsNumFieldOrderIdeal{AbsS
 
 ### Examples
 
-```@repl 2
-using Hecke # hide
-K, a = rationals_as_number_field();
-D = matrix(K, 3, 3, [2, 0, 0, 0, 2, 0, 0, 0, 2]);
-gens = Vector{AbsSimpleNumFieldElem}[map(K, [1, 1, 0]), map(K, [1, 0, 1]), map(K, [2, 0, 0])];
-Lquad = quadratic_lattice(K, gens, gram = D);
-D = matrix(K, 3, 3, [2, 0, 0, 0, 2, 0, 0, 0, 2]);
-gens = Vector{AbsSimpleNumFieldElem}[map(K, [-35, 25, 0]), map(K, [30, 40, -20]), map(K, [5, 10, -5])];
-Lquad2 = quadratic_lattice(K, gens, gram = D);
-OK = maximal_order(K);
-p = prime_decomposition(OK, 7)[1][1];
-is_isometric(Lquad, Lquad2)
-is_locally_isometric(Lquad, Lquad2, p)
+```jldoctest
+julia> K, a = rationals_as_number_field();
+
+julia> D = matrix(K, 3, 3, [2, 0, 0, 0, 2, 0, 0, 0, 2]);
+
+julia> gens = Vector{AbsSimpleNumFieldElem}[map(K, [1, 1, 0]), map(K, [1, 0, 1]), map(K, [2, 0, 0])];
+
+julia> Lquad = quadratic_lattice(K, gens, gram = D);
+
+julia> D = matrix(K, 3, 3, [2, 0, 0, 0, 2, 0, 0, 0, 2]);
+
+julia> gens = Vector{AbsSimpleNumFieldElem}[map(K, [-35, 25, 0]), map(K, [30, 40, -20]), map(K, [5, 10, -5])];
+
+julia> Lquad2 = quadratic_lattice(K, gens, gram = D);
+
+julia> OK = maximal_order(K);
+
+julia> p = prime_decomposition(OK, 7)[1][1];
+
+julia> is_isometric(Lquad, Lquad2)
+false
+
+julia> is_locally_isometric(Lquad, Lquad2, p)
+true
 ```
 
 ---
@@ -446,22 +793,101 @@ maximal_integral_lattice(::AbstractSpace)
 
 ### Examples
 
-```@repl 2
-using Hecke # hide
-K, a = rationals_as_number_field();
-Kt, t = K["t"];
-g = t^2 + 7;
-E, b = number_field(g, "b");
-D = matrix(E, 4, 4, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
-gens = Vector{Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}[map(E, [2, -1, 0, 0]), map(E, [-3, 0, -1, 0]), map(E, [0, 0, 0, -1]), map(E, [b, 0, 0, 0])];
-Lherm = hermitian_lattice(E, gens, gram = D);
-OK = maximal_order(K);
-p = prime_decomposition(OK, 7)[1][1];
-is_maximal_integral(Lherm, p)
-is_maximal_integral(Lherm)
-is_maximal(Lherm, p)
-pseudo_basis(maximal_integral_lattice(Lherm, p))
-pseudo_basis(maximal_integral_lattice(Lherm))
-pseudo_basis(maximal_integral_lattice(ambient_space(Lherm)))
+```jldoctest
+julia> K, a = rationals_as_number_field();
+
+julia> Kt, t = K[:t];
+
+julia> g = t^2 + 7;
+
+julia> E, b = number_field(g, :b);
+
+julia> D = matrix(E, 4, 4, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+
+julia> gens = Vector{Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}[map(E, [2, -1, 0, 0]), map(E, [-3, 0, -1, 0]), map(E, [0, 0, 0, -1]), map(E, [b, 0, 0, 0])];
+
+julia> Lherm = hermitian_lattice(E, gens, gram = D);
+
+julia> OK = maximal_order(K);
+
+julia> p = prime_decomposition(OK, 7)[1][1];
+
+julia> is_maximal_integral(Lherm, p)
+(false, Hermitian lattice of rank 4 and degree 4)
+
+julia> is_maximal_integral(Lherm)
+(false, Hermitian lattice of rank 4 and degree 4)
+
+julia> is_maximal(Lherm, p)
+(false, Hermitian lattice of rank 4 and degree 4)
+
+julia> pseudo_basis(maximal_integral_lattice(Lherm, p))
+4-element Vector{Tuple{Vector{Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}, Hecke.RelNumFieldOrderFractionalIdeal{AbsSimpleNumFieldElem, AbsSimpleNumFieldOrderFractionalIdeal, Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}}}:
+ ([1, 0, 0, 0], Fractional ideal of
+Relative maximal order with pseudo-basis (1) * 1//1 * <1, 1>, (b + 1) * 1//2 * <1, 1>
+with basis pseudo-matrix
+(1//1 * <1, 1>) * [1 0]
+(1//2 * <1, 1>) * [0 1])
+ ([0, 1, 0, 0], Fractional ideal of
+Relative maximal order with pseudo-basis (1) * 1//1 * <1, 1>, (b + 1) * 1//2 * <1, 1>
+with basis pseudo-matrix
+(1//1 * <1, 1>) * [1 0]
+(1//2 * <1, 1>) * [0 1])
+ ([2, 4, 1, 0], Fractional ideal of
+Relative maximal order with pseudo-basis (1) * 1//1 * <1, 1>, (b + 1) * 1//2 * <1, 1>
+with basis pseudo-matrix
+(1//1 * <1, 1>) * [1 0]
+(1//14 * <1, 1>) * [6 1])
+ ([4, 5, 0, 1], Fractional ideal of
+Relative maximal order with pseudo-basis (1) * 1//1 * <1, 1>, (b + 1) * 1//2 * <1, 1>
+with basis pseudo-matrix
+(1//1 * <1, 1>) * [1 0]
+(1//14 * <1, 1>) * [6 1])
+
+julia> pseudo_basis(maximal_integral_lattice(Lherm))
+4-element Vector{Tuple{Vector{Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}, Hecke.RelNumFieldOrderFractionalIdeal{AbsSimpleNumFieldElem, AbsSimpleNumFieldOrderFractionalIdeal, Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}}}:
+ ([1, 0, 0, 0], Fractional ideal of
+Relative maximal order with pseudo-basis (1) * 1//1 * <1, 1>, (b + 1) * 1//2 * <1, 1>
+with basis pseudo-matrix
+(1//1 * <1, 1>) * [1 0]
+(1//2 * <1, 1>) * [0 1])
+ ([0, 1, 0, 0], Fractional ideal of
+Relative maximal order with pseudo-basis (1) * 1//1 * <1, 1>, (b + 1) * 1//2 * <1, 1>
+with basis pseudo-matrix
+(1//1 * <1, 1>) * [1 0]
+(1//2 * <1, 1>) * [0 1])
+ ([2, 4, 1, 0], Fractional ideal of
+Relative maximal order with pseudo-basis (1) * 1//1 * <1, 1>, (b + 1) * 1//2 * <1, 1>
+with basis pseudo-matrix
+(1//1 * <1, 1>) * [1 0]
+(1//14 * <1, 1>) * [6 1])
+ ([4, 5, 0, 1], Fractional ideal of
+Relative maximal order with pseudo-basis (1) * 1//1 * <1, 1>, (b + 1) * 1//2 * <1, 1>
+with basis pseudo-matrix
+(1//1 * <1, 1>) * [1 0]
+(1//14 * <1, 1>) * [6 1])
+
+julia> pseudo_basis(maximal_integral_lattice(ambient_space(Lherm)))
+4-element Vector{Tuple{Vector{Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}, Hecke.RelNumFieldOrderFractionalIdeal{AbsSimpleNumFieldElem, AbsSimpleNumFieldOrderFractionalIdeal, Hecke.RelSimpleNumFieldElem{AbsSimpleNumFieldElem}}}}:
+ ([1, 0, 0, 0], Fractional ideal of
+Relative maximal order with pseudo-basis (1) * 1//1 * <1, 1>, (b + 1) * 1//2 * <1, 1>
+with basis pseudo-matrix
+(1//1 * <1, 1>) * [1 0]
+(1//2 * <1, 1>) * [0 1])
+ ([0, 1, 0, 0], Fractional ideal of
+Relative maximal order with pseudo-basis (1) * 1//1 * <1, 1>, (b + 1) * 1//2 * <1, 1>
+with basis pseudo-matrix
+(1//1 * <1, 1>) * [1 0]
+(1//2 * <1, 1>) * [0 1])
+ ([2, 4, 1, 0], Fractional ideal of
+Relative maximal order with pseudo-basis (1) * 1//1 * <1, 1>, (b + 1) * 1//2 * <1, 1>
+with basis pseudo-matrix
+(1//1 * <1, 1>) * [1 0]
+(1//14 * <1, 1>) * [6 1])
+ ([4, 5, 0, 1], Fractional ideal of
+Relative maximal order with pseudo-basis (1) * 1//1 * <1, 1>, (b + 1) * 1//2 * <1, 1>
+with basis pseudo-matrix
+(1//1 * <1, 1>) * [1 0]
+(1//14 * <1, 1>) * [6 1])
 ```
 

--- a/docs/src/manual/quad_forms/lattices.md
+++ b/docs/src/manual/quad_forms/lattices.md
@@ -37,7 +37,7 @@ hermitian_lattice(::NumField, ::Vector)
 #### Examples
 The two following examples will be used all along this section:
 
-```jldoctest
+```jldoctest; filter = r".*"
 julia> K, a = rationals_as_number_field();
 
 julia> Kt, t = K[:t];
@@ -70,7 +70,7 @@ Hermitian lattice of rank 4 and degree 4
 Note that the format used here is the one given by the internal function
 `Hecke.to_hecke()` which prints REPL commands to get back the input lattice.
 
-```jldoctest
+```jldoctest; filter = r".*"
 julia> K, a = rationals_as_number_field();
 
 julia> Kt, t = K[:t];
@@ -101,7 +101,7 @@ Finally, one can access some databases in which are stored several quadratic and
 hermitian lattices. Up to now, these are not automatically available while running
 Hecke. It can nonetheless be used in the following way:
 
-```jldoctest
+```jldoctest; filter = r".*"
 julia> qld = Hecke.quadratic_lattice_database()
 Quadratic lattices of rank >= 3 with class number 1 or 2
 Author: Markus Kirschmer
@@ -143,7 +143,7 @@ diagonal_of_rational_span(::AbstractLat)
 
 ### Examples
 
-```jldoctest
+```jldoctest; filter = r".*"
 julia> K, a = rationals_as_number_field();
 
 julia> Kt, t = K[:t];
@@ -218,7 +218,7 @@ For now and for the rest of this section, the examples will include the new latt
 `Lquad2` which is quadratic. Moreover, all the completions are going to be done at
 the prime ideal $p = 7*\mathcal O_K$.
 
-```jldoctest
+```jldoctest; filter = r".*"
 julia> K, a = rationals_as_number_field();
 
 julia> D = matrix(K, 3, 3, [2, 0, 0, 0, 2, 0, 0, 0, 2]);
@@ -294,7 +294,7 @@ gram_matrix_of_generators(::AbstractLat; minimal::Bool = false)
 
 ### Examples
 
-```jldoctest
+```jldoctest; filter = r".*"
 julia> K, a = rationals_as_number_field();
 
 julia> Kt, t = K[:t];
@@ -464,7 +464,7 @@ orthogonal_submodule(::AbstractLat, ::AbstractLat)
 
 ### Examples
 
-```jldoctest
+```jldoctest; filter = r".*"
 julia> K, a = rationals_as_number_field();
 
 julia> D = matrix(K, 3, 3, [2, 0, 0, 0, 2, 0, 0, 0, 2]);
@@ -553,7 +553,7 @@ volume(L::AbstractLat)
 
 ### Examples
 
-```jldoctest
+```jldoctest; filter = r".*"
 julia> K, a = rationals_as_number_field();
 
 julia> Kt, t = K[:t];
@@ -613,7 +613,7 @@ can_scale_totally_positive(L::AbstractLat)
 
 ### Examples
 
-```jldoctest
+```jldoctest; filter = r".*"
 julia> K, a = rationals_as_number_field();
 
 julia> Kt, t = K[:t];
@@ -659,7 +659,7 @@ is_isotropic(::AbstractLat, p)
 
 ### Examples
 
-```jldoctest
+```jldoctest; filter = r".*"
 julia> K, a = rationals_as_number_field();
 
 julia> D = matrix(K, 3, 3, [2, 0, 0, 0, 2, 0, 0, 0, 2]);
@@ -708,7 +708,7 @@ automorphism_group_generators(::AbstractLat)
 
 ### Examples
 
-```jldoctest
+```jldoctest; filter = r".*"
 julia> K, a = rationals_as_number_field();
 
 julia> Kt, t = K[:t];
@@ -751,7 +751,7 @@ is_locally_isometric(::AbstractLat, ::AbstractLat, p::AbsNumFieldOrderIdeal{AbsS
 
 ### Examples
 
-```jldoctest
+```jldoctest; filter = r".*"
 julia> K, a = rationals_as_number_field();
 
 julia> D = matrix(K, 3, 3, [2, 0, 0, 0, 2, 0, 0, 0, 2]);
@@ -792,7 +792,7 @@ maximal_integral_lattice(::AbstractSpace)
 
 ### Examples
 
-```jldoctest
+```jldoctest; filter = r".*"
 julia> K, a = rationals_as_number_field();
 
 julia> Kt, t = K[:t];

--- a/docs/src/manual/quad_forms/lattices.md
+++ b/docs/src/manual/quad_forms/lattices.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # Lattices
 

--- a/docs/src/start/index.md
+++ b/docs/src/start/index.md
@@ -1,3 +1,9 @@
+```@meta
+CurrentModule = Hecke
+DocTestSetup = quote
+    using Hecke
+end
+```
 # Getting started
 
 To use Hecke, a julia version of 1.0 is necessary (the latest stable julia version will do).

--- a/docs/src/start/index.md
+++ b/docs/src/start/index.md
@@ -12,12 +12,19 @@ julia> Pkg.add("Hecke")
 
 Here is a quick example of using Hecke to define a number field and compute its class group::
 
-```@repl
-using Hecke
-Qx, x = QQ["x"];
-f = x^2 - 2*3*5*7;
-K, a = number_field(f, "a");
-OK = maximal_order(K);
-C, mC = class_group(OK);
-C
+```jldoctest
+julia> using Hecke
+
+julia> Qx, x = QQ[:x];
+
+julia> f = x^2 - 2*3*5*7;
+
+julia> K, a = number_field(f, :a);
+
+julia> OK = maximal_order(K);
+
+julia> C, mC = class_group(OK);
+
+julia> C
+(Z/2)^2
 ```

--- a/docs/src/start/index.md
+++ b/docs/src/start/index.md
@@ -1,8 +1,6 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # Getting started
 

--- a/docs/src/tutorials/index.md
+++ b/docs/src/tutorials/index.md
@@ -1,7 +1,5 @@
 ```@meta
 CurrentModule = Hecke
-DocTestSetup = quote
-    using Hecke
-end
+DocTestSetup = Hecke.doctestsetup()
 ```
 # Tutorials

--- a/docs/src/tutorials/index.md
+++ b/docs/src/tutorials/index.md
@@ -1,1 +1,7 @@
+```@meta
+CurrentModule = Hecke
+DocTestSetup = quote
+    using Hecke
+end
+```
 # Tutorials

--- a/src/AlgAss/StructureConstantAlgebra.jl
+++ b/src/AlgAss/StructureConstantAlgebra.jl
@@ -156,7 +156,7 @@ $K$-linear map $A \to L$.
 julia> L, = quadratic_field(2);
 
 julia> structure_constant_algebra(L)
-(Structure constant algebra of dimension 2 over QQ, Map: structure constant algebra -> real quadratic field)
+(Structure constant algebra of dimension 2 over QQ, Map: structure constant algebra -> L)
 ```
 """
 function structure_constant_algebra(K::SimpleNumField)

--- a/src/Hecke.jl
+++ b/src/Hecke.jl
@@ -761,6 +761,12 @@ function build_doc(; doctest=false, strict=false, format=:vitepress)
   end
 end
 
+# Hecke needs some complicated setup to get the printing right. This provides a
+# helper function to set this up consistently.
+function doctestsetup()
+  return :(using Hecke; Hecke.AbstractAlgebra.set_current_module(@__MODULE__))
+end
+
 #html_build = Ref(false)
 #
 #function build_doc(html::Bool = false)

--- a/src/Map/MapType.jl
+++ b/src/Map/MapType.jl
@@ -154,7 +154,7 @@ julia> f(QQ(1//3))
 1
 
 julia> println(f)
-Map: QQ -> GF(2)
+Map: QQ -> F
 
 julia> f = MapFromFunc(QQ, F, x -> F(numerator(x)) * inv(F(denominator(x))), y -> QQ(lift(ZZ, y)),)
 Map defined by a julia-function with inverse
@@ -165,7 +165,7 @@ julia> preimage(f, F(1))
 1
 
 julia> println(f)
-Map: QQ -> GF(2)
+Map: QQ -> F
 
 ```
 """

--- a/src/Misc/Poly.jl
+++ b/src/Misc/Poly.jl
@@ -911,7 +911,7 @@ julia> F, _ = finite_field(5)
 (Prime field of characteristic 5, 0)
 
 julia> Ft, _ = F["t"]
-(Univariate polynomial ring in t over GF(5), t)
+(Univariate polynomial ring in t over F, t)
 
 julia> cyclotomic_polynomial(15, Ft)
 t^8 + 4*t^7 + t^5 + 4*t^4 + t^3 + 4*t + 1

--- a/src/NumField/ComplexEmbeddings/Generic.jl
+++ b/src/NumField/ComplexEmbeddings/Generic.jl
@@ -11,12 +11,12 @@ julia> K, a = quadratic_field(-3);
 
 julia> complex_embeddings(K)
 2-element Vector{AbsSimpleNumFieldEmbedding}:
- Complex embedding corresponding to 0.00 + 1.73 * i of imaginary quadratic field
- Complex embedding corresponding to 0.00 - 1.73 * i of imaginary quadratic field
+ Complex embedding corresponding to 0.00 + 1.73 * i of K
+ Complex embedding corresponding to 0.00 - 1.73 * i of K
 
 julia> complex_embeddings(K, conjugates = false)
 1-element Vector{AbsSimpleNumFieldEmbedding}:
- Complex embedding corresponding to 0.00 + 1.73 * i of imaginary quadratic field
+ Complex embedding corresponding to 0.00 + 1.73 * i of K
 ```
 """
 complex_embeddings(K::NumField)
@@ -33,8 +33,8 @@ julia> K, a = quadratic_field(3);
 
 julia> real_embeddings(K)
 2-element Vector{AbsSimpleNumFieldEmbedding}:
- Complex embedding corresponding to -1.73 of real quadratic field
- Complex embedding corresponding to 1.73 of real quadratic field
+ Complex embedding corresponding to -1.73 of K
+ Complex embedding corresponding to 1.73 of K
 ```
 """
 function real_embeddings(K::NumField)
@@ -180,8 +180,8 @@ julia> e = complex_embeddings(k)[1];
 
 julia> extend(e, ktoK)
 2-element Vector{AbsSimpleNumFieldEmbedding}:
- Complex embedding corresponding to -0.81 + 0.59 * i of cyclotomic field of order 5
- Complex embedding corresponding to -0.81 - 0.59 * i of cyclotomic field of order 5
+ Complex embedding corresponding to -0.81 + 0.59 * i of K
+ Complex embedding corresponding to -0.81 - 0.59 * i of K
 ```
 """
 function extend(e::NumFieldEmb, f::NumFieldHom)

--- a/src/NumField/InfinitePlaces.jl
+++ b/src/NumField/InfinitePlaces.jl
@@ -60,8 +60,8 @@ julia> K,  = quadratic_field(-5);
 
 julia> embeddings(complex_places(K)[1])
 2-element Vector{AbsSimpleNumFieldEmbedding}:
- Complex embedding corresponding to 0.00 + 2.24 * i of imaginary quadratic field
- Complex embedding corresponding to 0.00 - 2.24 * i of imaginary quadratic field
+ Complex embedding corresponding to 0.00 + 2.24 * i of K
+ Complex embedding corresponding to 0.00 - 2.24 * i of K
 ```
 """
 function embeddings(p::InfPlc)
@@ -173,7 +173,7 @@ julia> infinite_place(complex_embedding(K, 2.24))
 Infinite place of
 Real quadratic field defined by x^2 - 5
 corresponding to
-Complex embedding corresponding to 2.24 of real quadratic field
+Complex embedding corresponding to 2.24 of K
 ```
 """
 function infinite_place(e::NumFieldEmb)
@@ -192,8 +192,8 @@ julia> K,  = quadratic_field(5);
 
 julia> infinite_places(K)
 2-element Vector{InfPlc{AbsSimpleNumField, AbsSimpleNumFieldEmbedding}}:
- Infinite place corresponding to (Complex embedding corresponding to -2.24 of real quadratic field)
- Infinite place corresponding to (Complex embedding corresponding to 2.24 of real quadratic field)
+ Infinite place corresponding to (Complex embedding corresponding to -2.24 of K)
+ Infinite place corresponding to (Complex embedding corresponding to 2.24 of K)
 ```
 """
 function infinite_places(K::NumField)
@@ -212,8 +212,8 @@ julia> K,  = quadratic_field(5);
 
 julia> infinite_places(K)
 2-element Vector{InfPlc{AbsSimpleNumField, AbsSimpleNumFieldEmbedding}}:
- Infinite place corresponding to (Complex embedding corresponding to -2.24 of real quadratic field)
- Infinite place corresponding to (Complex embedding corresponding to 2.24 of real quadratic field)
+ Infinite place corresponding to (Complex embedding corresponding to -2.24 of K)
+ Infinite place corresponding to (Complex embedding corresponding to 2.24 of K)
 ```
 """
 real_places(K::NumField) = place_type(K)[infinite_place(i) for i in real_embeddings(K)]
@@ -230,7 +230,7 @@ julia> K,  = quadratic_field(-5);
 
 julia> complex_places(K)
 1-element Vector{InfPlc{AbsSimpleNumField, AbsSimpleNumFieldEmbedding}}:
- Infinite place corresponding to (Complex embedding corresponding to 0.00 + 2.24 * i of imaginary quadratic field)
+ Infinite place corresponding to (Complex embedding corresponding to 0.00 + 2.24 * i of K)
 ```
 """
 complex_places(K::NumField) = [p for p in infinite_places(K) if is_complex(p)]
@@ -260,7 +260,7 @@ julia> restrict(p, K)
 Infinite place of
 Real quadratic field defined by x^2 - 3
 corresponding to
-Complex embedding corresponding to -1.73 of real quadratic field
+Complex embedding corresponding to -1.73 of K
 ```
 """
 restrict(p::InfPlc, K::NumField) = infinite_place(restrict(_embedding(p), K))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -266,7 +266,7 @@ else
   # Run the doctests
   if v"1.10-" <= VERSION < v"1.11-"
     @info "Running doctests (Julia version is 1.10)"
-    DocMeta.setdocmeta!(Hecke, :DocTestSetup, :(using Hecke); recursive = true)
+    DocMeta.setdocmeta!(Hecke, :DocTestSetup, Hecke.doctestsetup(); recursive = true)
     doctest(Hecke)
   else
     @info "Not running doctests (Julia version must be 1.10)"


### PR DESCRIPTION
Same reasoning as in https://github.com/oscar-system/Oscar.jl/pull/4747. In particular, all `@repl` blocks in Hecke doc pages are always run when building the Oscar docs, independent of if the particular page is visible in the Oscar docs or not.

As a bonus, this uncovered some errors that were not known before, as `@repl` happily continues when encountering an error. (see my comments below for details)

This PR reduces the time spent on the first call of a session to `Oscar.build_doc()` from 273sec to 135sec on my machine, and for follow-up runs in the same session from 26sec to 18sec.