### PR TITLE
feat: add more operations for divisors

### DIFF
--- a/src/GenOrd/FractionalIdeal.jl
+++ b/src/GenOrd/FractionalIdeal.jl
@@ -151,6 +151,13 @@ end
 Base.:*(A::T, B::T) where T <: GenOrdFracIdl = prod(A, B)
 
 
+function Base.:(+)(a::T, b::T) where T <: GenOrdFracIdl
+  d = lcm(denominator(a), denominator(b))
+  ma = divexact(d, denominator(a))
+  mb = divexact(d, denominator(b))
+  return GenOrdFracIdl(order(a)(ma)*numerator(a) + order(b)(mb) * numerator(b),d)
+end
+
 ################################################################################
 #
 #  Powering
@@ -161,7 +168,7 @@ function Base.:^(A::GenOrdFracIdl, a::Int)
 
   O = order(A)
   if a == 0
-    B = GenOrdFracIdl(ideal(order(A), 1), O.R(1))
+    B = GenOrdFracIdl(ideal(order(A), one(O)), O.R(1))
     return B
   end
 

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -917,6 +917,7 @@ export trailing_coefficient
 export transform
 export transform_rstu
 export triangularize
+export trivial_divisor
 export trivial_morphism
 export trred
 export trred_matrix

--- a/test/FunField/Divisor.jl
+++ b/test/FunField/Divisor.jl
@@ -9,7 +9,7 @@ import Hecke: divisor
 @testset "Divisors" begin
 
     @testset "Algebraic function field over rationals (1)" begin
-      
+
       F, a = function_field(y^2 - x^3 - 1)
       Ofin = finite_maximal_order(F)
       Oinf = infinite_maximal_order(F)
@@ -18,97 +18,102 @@ import Hecke: divisor
       p2 = @inferred ideal(Ofin, x-2, Ofin(a + 3))
       facs = @inferred factor(ideal(Oinf, base_ring(Oinf)(1//x)))
       p3 = collect(facs)[1][1]
- 
+
       D1 = divisor(p1)
       D2 = divisor(p2)
       D3 = divisor(p3)
       @test_throws ArgumentError divisor(zero(F))
 
+      @test 0*D1 == 0*D2
+
+      @test trivial_divisor(F) == 0 * D1
+      @test degree(trivial_divisor(F)) == 0
+
       D = 3*D3 - D1
       Do = @inferred divisor(inv(p1), p3^3)
-      
+
       #Elliptic curve group law
       @test is_principal(D1 + D2 - 2*D3)
       @test is_zero(D - D)
-      
+
       @test D == Do
       @test @inferred valuation(D, p3) == 3
       @test @inferred valuation(D, p1) == -1
       @test @inferred valuation(D, p2) == 0
-      
+
       @test @inferred degree(D) == 2
-      
+
       @test @inferred dimension(D) == 2
       @test @inferred index_of_speciality(D) == 0
-      
+
       DD = 3*D
       @test !(DD > D)
       @test (D + D2 > D)
-      
+
       L = @inferred riemann_roch_space(DD)
       @test length(L) == 6
-      
+
       for f in L
         @test is_effective(divisor(f) + DD)
       end
-      
+
       D_z = zero_divisor(F(x-3))
       D_p = pole_divisor(F(x-3))
       @test is_effective(D_z)
       @test !is_effective(D)
       @test (D_z - D_p) == divisor(F(x-3))
-      
+
       @test @inferred function_field(D) == F
       Dfin, Dinf = ideals(D)
       @test divisor(Dfin) + divisor(Dinf) == D
-      
+
       Df = different_divisor(F)
       @test degree(Df) == 4
       @test @inferred dimension(Df - 6*divisor(p3)) == 0
       @test @inferred index_of_speciality(Df-6*divisor(p3)) == 2
-      
+
       KF = canonical_divisor(F)
       @test @inferred degree(KF) == 0
       @test @inferred genus(F) == 1
 
     end
-   
+
     @testset "Algebraic function field over rationals (2)" begin
-      
+
       F, a = function_field(y^4 - 3*y + x^6 +x^2 - 1)
       Ofin = finite_maximal_order(F)
       Oinf = infinite_maximal_order(F)
 
       p1 = @inferred ideal(Ofin, x-2)
-      
+
       facs = @inferred factor(ideal(Oinf, base_ring(Oinf)(1//x)))
       p3 = collect(facs)[1][1]
 
       D = 3*divisor(p3) - divisor(p1)
       D2 = @inferred divisor(inv(p1), p3^3)
-      
+
       @test D == D2
       @test @inferred valuation(D, p3) == 3
       @test @inferred valuation(D, p1) == -1
-      
+
       @test degree(D) == 2
-      
+
       @test @inferred dimension(D) == 1
       @test @inferred index_of_speciality(D) == 5
-      
+
       @test @inferred function_field(D) == F
       Dfin, Dinf = ideals(D)
       @test divisor(Dfin) + divisor(Dinf) == D
-      
+
       Df = different_divisor(F)
       @test @inferred degree(Df) == 20
       @test @inferred dimension(Df-6*divisor(p3)) == 4
       @test @inferred index_of_speciality(Df-6*divisor(p3)) == 2
-      
+
       KF = canonical_divisor(F)
       @test @inferred degree(KF) == 12
       @test @inferred genus(F) == 7
-      
+
       L = @inferred basis_of_differentials(F)
       for df in L
         @test is_effective(divisor(df.f) + KF)

--- a/test/GenOrd/Ideal.jl
+++ b/test/GenOrd/Ideal.jl
@@ -87,4 +87,6 @@ let
   F, a = function_field(y^2+x)
   O = integral_closure(kt, F)
   @test hash(fractional_ideal(a*O)) == hash(fractional_ideal(a*O))
+
+  @test fractional_ideal(a * O) + fractional_ideal(a * O) == fractional_ideal(a * O)
 end


### PR DESCRIPTION
- `gcd` for divisors
- `trivial_divisor`
- fix bug with `0 * D`

@BD-00 this makes your example work with
```
function _compose(a::node{Divisor}, b::node{Divisor}, check = false)
  if check && !iszero(gcd(a.content, b.content))
    error("input not coprime")
  end
  return node{Divisor}(a.content + b.content, a, b)
end
```