### PR TITLE
fix: add verification in sparse row constructor

### DIFF
--- a/src/Sparse/Row.jl
+++ b/src/Sparse/Row.jl
@@ -65,6 +65,20 @@ ConformanceTests.equality(A::SRow, B::SRow) = A == B
 #
 ################################################################################
 
+function _assert_is_unique_sorted(pos)
+  local f
+  for (i, p) in enumerate(pos)
+    if i == 1
+      f = p
+    else
+      if p == f
+        error("positions must be unique")
+      end
+      f = p
+    end
+  end
+end
+
 @doc raw"""
     sparse_row(R::Ring) -> SRow
 
@@ -84,6 +98,7 @@ function sparse_row(R::NCRing, A::Vector{Tuple{Int, T}}; sort::Bool = true) wher
   if sort && length(A) > 1
     A = Base.sort(A, lt=(a,b) -> isless(a[1], b[1]))
   end
+  _assert_is_unique_sorted(a[1] for a in A)
   return SRow(R, A)
 end
 
@@ -97,6 +112,7 @@ function sparse_row(R::NCRing, A::Vector{Tuple{Int, Int}}; sort::Bool = true)
   if sort && length(A) > 1
     A = Base.sort(A, lt=(a,b) -> isless(a[1], b[1]))
   end
+  _assert_is_unique_sorted(a[1] for a in A)
   return SRow(R, A)
 end
 
@@ -132,6 +148,7 @@ function sparse_row(R::NCRing, pos::Vector{Int}, val::AbstractVector{T}; sort::B
     pos = pos[p]
     val = val[p]
   end
+  _assert_is_unique_sorted(pos)
   if T === elem_type(R)
     return SRow(R, pos, val)
   else

--- a/test/Sparse/Row.jl
+++ b/test/Sparse/Row.jl
@@ -15,14 +15,22 @@
   D = @inferred sparse_row(R, [(1, ZZRingElem(1)), (2, ZZRingElem(2))])
   @test D isa SRow{ZZRingElem}
   @test D isa sparse_row_type(R)
+  @test_throws ErrorException sparse_row(R, [(1, ZZRingElem(1)), (1, ZZRingElem(2))])
+  @test_throws ErrorException sparse_row(ZZ, [(1, ZZRingElem(1)), (1, ZZRingElem(2))])
+
 
   E = @inferred sparse_row(R, [(1, 1), (2, 2)])
   @test E isa SRow{ZZRingElem}
   @test E isa sparse_row_type(R)
+  @test_throws ErrorException sparse_row(R, [(1, 1), (1, 2)])
+  @test_throws ErrorException sparse_row(ZZ, [(1, 1), (1, 2)])
 
   F = @inferred sparse_row(R, [1, 2], [ZZRingElem(1), ZZRingElem(2)])
   @test F isa SRow{ZZRingElem}
   @test F isa sparse_row_type(R)
+  @test_throws ErrorException sparse_row(R, [2, 2], [ZZRingElem(1), ZZRingElem(2)])
+  @test_throws ErrorException sparse_row(ZZ, [2, 2], [ZZRingElem(1), ZZRingElem(2)])
+  @test_throws ErrorException sparse_row(ZZ, [2, 2], [ZZRingElem(1), ZZRingElem(2)])
 
   # Equality
 


### PR DESCRIPTION
Positions need to be unique

(I tried to make it as cheap as possible, but we could also add a `check` to eliminate the check completely.)
