### PR TITLE
Remove canonical_unit(x::LocalFieldElem)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,7 +28,7 @@ GAPExt = "GAP"
 PolymakeExt = "Polymake"
 
 [compat]
-AbstractAlgebra = "^0.44.7"
+AbstractAlgebra = "^0.44.13"
 Dates = "1.6"
 Distributed = "1.6"
 GAP = "0.13"

--- a/src/LocalField/Elem.jl
+++ b/src/LocalField/Elem.jl
@@ -13,8 +13,6 @@ function Base.show(io::IO, a::LocalFieldElem)
   print(io, AbstractAlgebra.obj_to_string(a, context = io))
 end
 
-canonical_unit(x::LocalFieldElem) = x
-
 ################################################################################
 #
 #  Deepcopy


### PR DESCRIPTION
AA 0.44.13 provides a generic default method, which also
handles zero correctly.
