### PR TITLE
Add workaround for GLIBCXX issue with julia 1.6

### DIFF
--- a/.github/workflows/CILong.yml
+++ b/.github/workflows/CILong.yml
@@ -35,6 +35,7 @@ jobs:
           # be able to properly deal with PRs / merges
           fetch-depth: 2
       - name: "Set up Julia"
+        id: setup-julia
         uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
@@ -48,6 +49,9 @@ jobs:
         run: |
           sed -i -e "s/\[deps\]/[deps]\nGAP = \"c863536a-3901-11e9-33e7-d5cd0df7b904\"/" test/Project.toml
           sed -i -e "s/\[deps\]/[deps]\nPolymake = \"d720cf60-89b5-51f5-aff5-213f193123e7\"/" test/Project.toml
+      - name: "workaround libstdc++ issue for julia 1.6"
+        if: matrix.julia-version == '~1.6.0-0' # && runner.os == 'Linux'
+        run: rm -f ${{ steps.setup-julia.outputs.julia-bindir }}/../lib/julia/libstdc++.so.6
       - name: "Run long tests"
         uses: julia-actions/julia-runtest@v1
         env:

--- a/.github/workflows/oscar.yml
+++ b/.github/workflows/oscar.yml
@@ -67,6 +67,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: "Set up Julia"
+        id: setup-julia
         uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
@@ -99,6 +100,9 @@ jobs:
                                            varname=\"oscar_run_doctests\",
                                            filename=\"${GITHUB_ENV}\");"
 
+      - name: "workaround libstdc++ issue for julia 1.6"
+        if: matrix.julia-version == '~1.6.0-0' # && runner.os == 'Linux'
+        run: rm -f ${{ steps.setup-julia.outputs.julia-bindir }}/../lib/julia/libstdc++.so.6
       - name: "Run tests"
         run: |
           echo '${{ env.oscar_run_tests }}'


### PR DESCRIPTION
Same as https://github.com/Nemocas/Nemo.jl/pull/2088.
This should fix the downstream tests. As this may happen with all of Polymake.jl (at least in theory), it is safest to do just in all CI jobs that may run Polymake.jl.