### PR TITLE
fix: `extended_ade`

### DIFF
--- a/src/QuadForm/Quad/ZLattices.jl
+++ b/src/QuadForm/Quad/ZLattices.jl
@@ -3268,17 +3268,18 @@ function extended_ade(ADE::Symbol, n::Int)
     G[1,n+1] = -1
     G[n+1,1] = -1
   end
-  if ADE == :A && n > 0
+  if ADE == :A && n > 1
     G[1,2] = -1
     G[2,1] = -1
     G[1,n+1] = -1
     G[n+1,1] = -1
   end
-  if ADE == :A && n ==1 0
+  if ADE == :A && n == 1
     G[1,2]= -2
     G[2,1] = -2
   end
   if ADE == :D
+    @assert n >= 4
     G[1,n] = -1
     G[n,1] = -1
   end

--- a/test/QuadForm/Quad/ZLattices.jl
+++ b/test/QuadForm/Quad/ZLattices.jl
@@ -821,3 +821,16 @@ end
   @test rank(L + L2) == 0
   @test order(q + q2) == 1
 end
+
+@testset "Fix extended ADE lattices" begin
+  for n in 1:6
+    _, v = Hecke.extended_ade(:A, n)
+    @test all(isone, v)
+  end
+  for n in 4:10
+    _, v = Hecke.extended_ade(:D, n)
+    @test all(isone, view(v, 1:1, 1:3))
+    @test all(==(2), view(v, 1:1, 4:n))
+    @test isone(v[1, n+1])
+  end
+end


### PR DESCRIPTION
The extended $A_1$-lattice needs a particular treatment and this was not done previously because of the condition in line 3271. And as far as I know, the extended $D_n$-lattices are defined only for $n \geq 4$.