### PR TITLE
fix `norm(f::PolyRingElem{AbsSimpleNumFieldElem})`

### DIFF
--- a/src/NumField/NfAbs/Elem.jl
+++ b/src/NumField/NfAbs/Elem.jl
@@ -265,6 +265,7 @@ function norm(f::PolyRingElem{AbsSimpleNumFieldElem})
     h = nf_poly_to_xy(f, Qxy, Qx)
     N = resultant(T, h)
   end
+  N.parent = parent(defining_polynomial(base_ring(parent(f))))
   return inflate(N, i)
 end
 

--- a/test/NfAbs/Elem.jl
+++ b/test/NfAbs/Elem.jl
@@ -169,11 +169,8 @@ end
   F, _ = number_field(xQ^2-2)
   Fx, xF = F["x"]
   d = degree(F)
-  for i in 1:11
-    f = xF^i + xF^(i+1)
-    nf = norm(f)
-    cand = xQ^(i*d) * norm(xF+1)
-    @test change_base_ring(QQ, nf, parent = Qx) == change_base_ring(QQ, cand, parent = Qx)
+  for i in 0:11
+    @test norm(xF^i + xF^(i+1)) == xQ^(i*d) * norm(xF+1)
   end
 end
 


### PR DESCRIPTION
resolves #1878 

The new test looks complicated.
Apparently each `norm` result may or may not get a newly created parent, and we do not know whether such a result is compatible with other polynomials.
```
julia> Qx, x = polynomial_ring(QQ, "x");

julia> F, _ = number_field(x^2-2);

julia> Fx, x = polynomial_ring(F, "x");

julia> parent(norm(x^2+1)) == parent(norm(x^2+1))
true

julia> parent(norm(x^2+x)) == parent(norm(x^2+x))
false
```
Is this behaviour intended?
Wouldn't it be better to set the parent of `norm(f)` to `base_ring(defining_polynomial(base_ring(parent(f))))`?

Another point:
In order to write a test, getting a norm with a given parent seems to be nontrivial.
For example, the following does not work.
```
julia> f = x^2 + x
x^2 + x

julia> n = norm(x^2 + x);

julia> parent(Qx(n)) == Qx
false
```
This is because of the method `(a::QQPolyRing)(b::QQPolyRingElem) = b` (from Nemo.jl), which ignores the parent.
Is this behaviour intended?