### PR TITLE
fix: avoid calling a nondefined `getindex` function

### DIFF
--- a/src/QuadForm/Herm/GenusRep.jl
+++ b/src/QuadForm/Herm/GenusRep.jl
@@ -216,9 +216,11 @@ function neighbours(
     adjust_gens_mod_p = dense_matrix_type(k)[map_entries(hext, T*g*Tinv) for g in genUL]
     adjust_gens_mod_p = dense_matrix_type(k)[x for x in adjust_gens_mod_p if length(unique!(diagonal(x))) != 1]
     if length(adjust_gens_mod_p) > 0
+      use_auto = true
       _LO = line_orbits(adjust_gens_mod_p)
       LO = Vector{eltype(k)}[x[1] for x in _LO]
     else
+      use_auto = false
       LO = enumerate_lines(k, n)
     end
     maxlines = length(LO)
@@ -259,7 +261,7 @@ function neighbours(
 
   for i in 1:maxlines
     vain[] > stop_after && break
-    if algorithm == :orbit
+    if algorithm == :orbit && use_auto
       w = LO[i]
     elseif algorithm == :random
       w = rand(LO)

--- a/src/QuadForm/Herm/GenusRep.jl
+++ b/src/QuadForm/Herm/GenusRep.jl
@@ -218,6 +218,7 @@ function neighbours(
     if length(adjust_gens_mod_p) > 0
       _LO = line_orbits(adjust_gens_mod_p)
       LO = Vector{eltype(k)}[x[1] for x in _LO]
+      maxlines = length(LO)
     else
       LO = enumerate_lines(k, n)
       if length(LO) <= 50000

--- a/src/QuadForm/Herm/GenusRep.jl
+++ b/src/QuadForm/Herm/GenusRep.jl
@@ -216,14 +216,18 @@ function neighbours(
     adjust_gens_mod_p = dense_matrix_type(k)[map_entries(hext, T*g*Tinv) for g in genUL]
     adjust_gens_mod_p = dense_matrix_type(k)[x for x in adjust_gens_mod_p if length(unique!(diagonal(x))) != 1]
     if length(adjust_gens_mod_p) > 0
-      use_auto = true
       _LO = line_orbits(adjust_gens_mod_p)
       LO = Vector{eltype(k)}[x[1] for x in _LO]
     else
-      use_auto = false
       LO = enumerate_lines(k, n)
+      if length(LO) <= 50000
+        algorithm = :exhaustive
+        maxlines = length(LO)
+      else
+        algorithm = :random
+        maxlines = min(rand_neigh, length(LO))
+      end
     end
-    maxlines = length(LO)
     @vprintln :GenRep 1 "$(maxlines) orbits of lines to try"
   else
     LO = enumerate_lines(k, n)
@@ -261,7 +265,7 @@ function neighbours(
 
   for i in 1:maxlines
     vain[] > stop_after && break
-    if algorithm == :orbit && use_auto
+    if algorithm == :orbit
       w = LO[i]
     elseif algorithm == :random
       w = rand(LO)


### PR DESCRIPTION
I have written a `getindex` function locally for `LineEnumCtx` but I am not sure we want it, so instead I keep track of whether or not we have used the automorphisms (sometimes all isometries are given by scalar multiplication so we have to fallback to a regular `enumerate_lines`... We should not `collect` it since it could consist of many lines).