### PR TITLE
Add `isinteger` and `is_rational` for `AbsNonSimpleNumFieldElem`

### DIFF
--- a/src/NumField/Elem.jl
+++ b/src/NumField/Elem.jl
@@ -69,7 +69,7 @@ return `false`.
 """
 function isinteger(a::AbsNonSimpleNumFieldElem)
   is_constant(data(a)) || return false
-  return is_one(denominator(constant_coefficient(data(a))))
+  return isinteger(constant_coefficient(data(a)))
 end
 
 @doc raw"""

--- a/src/NumField/Elem.jl
+++ b/src/NumField/Elem.jl
@@ -57,6 +57,31 @@ end
 
 ################################################################################
 #
+#  Integer and rational
+#
+################################################################################
+
+@doc raw"""
+    isinteger(a::AbsNonSimpleNumFieldElem)
+
+Return `true` if the given number field element is an integer, i.e., in ZZ, otherwise
+return `false`.
+"""
+function isinteger(a::AbsNonSimpleNumFieldElem)
+  is_constant(data(a)) || return false
+  return is_one(denominator(constant_coefficient(data(a))))
+end
+
+@doc raw"""
+    is_rational(a::AbsNonSimpleNumFieldElem)
+
+Return `true` if the given number field element is a rational number, i.e., in QQ,
+otherwise `false`.
+"""
+is_rational(a::AbsNonSimpleNumFieldElem) = is_constant(data(a))
+
+################################################################################
+#
 #  Random elements from arrays of number field elements
 #
 ################################################################################

--- a/src/NumField/NfAbs/NonSimple.jl
+++ b/src/NumField/NfAbs/NonSimple.jl
@@ -1207,6 +1207,3 @@ function (K::QQField)(a::AbsNonSimpleNumFieldElem)
   return constant_coefficient(data(a))
 end
 
-function is_rational(a::AbsNonSimpleNumFieldElem)
-  return is_constant(data(a))
-end

--- a/test/NfAbs/Elem.jl
+++ b/test/NfAbs/Elem.jl
@@ -63,6 +63,25 @@ end
   @test Hecke.is_integral(QQFieldElem(1, 2)*b[1]) == false
 end
 
+@testset "Is integer or rational" begin
+  Qx, x = QQ["x"]
+  f = x^2 + 1//2
+  K, a = number_field(f, "a")
+
+  @test Hecke.is_integer(2*a^2) == true
+  @test Hecke.is_integer(a^2) == false
+  @test Hecke.is_rational(a^2) == true
+  @test Hecke.is_rational(a) == false
+
+  g = x^3 + 3
+  L, b = number_field([f, g], "b")
+
+  @test Hecke.is_integer(2*b[1]^2) == true
+  @test Hecke.is_integer(b[1]^2) == false
+  @test Hecke.is_rational(b[1]^2) == true
+  @test Hecke.is_rational(b[1]) == false
+end
+
 @testset "Compositum" begin
   Qx, x = QQ["x"]
   f = x^2 + 1

--- a/test/NfAbs/NonSimple.jl
+++ b/test/NfAbs/NonSimple.jl
@@ -174,9 +174,7 @@
     Qx, x = QQ["x"]
     K, (a, b) = number_field([x^2 - 2, x^3 - 3])
     @test (@inferred QQ(2*a^0)) == 2*one(QQ)
-    @test @inferred is_rational(2*a^0)
     @test_throws ArgumentError QQ(a)
-    @test @inferred !is_rational(a)
   end
 
   K, (a,) = @inferred number_field([x])


### PR DESCRIPTION
Apparently `is_rational` was defined already but not callable from outside the module. 

fixes #1909 