### PR TITLE
Make `is_integral` and `is_algebraic_integer` more consistent

### DIFF
--- a/src/Misc/QQBar.jl
+++ b/src/Misc/QQBar.jl
@@ -86,3 +86,10 @@ function roots(f::PolyRingElem{QQBarFieldElem})
   return rts
 end
 
+@doc doc"""
+    is_integral(a::QQBarFieldElem) -> Bool
+
+Returns whether $a$ is integral, that is, whether the minimal polynomial of $a$
+has integral coefficients.
+"""
+is_integral(a::QQBarFieldElem) = is_algebraic_integer(a)

--- a/src/NumField/Elem.jl
+++ b/src/NumField/Elem.jl
@@ -32,15 +32,16 @@ end
 #
 ################################################################################
 
-is_integral(a::QQFieldElem) = isone(denominator(a))
+is_algebraic_integer(a::QQFieldElem) = isone(denominator(a))
+
+is_integral(a::QQFieldElem) = is_algebraic_integer(a)
 
 @doc doc"""
-    is_integral(a::NumFieldElem) -> Bool
+    is_algebraic_integer(x::NumFieldElem)
 
-Returns whether $a$ is integral, that is, whether the minimal polynomial of $a$
-has integral coefficients.
+Return whether $x$ is an algebraic integer.
 """
-function is_integral(a::NumFieldElem)
+function is_algebraic_integer(a::NumFieldElem)
   K = parent(a)
   if is_maximal_order_known(K)
     OK = maximal_order(K)
@@ -54,6 +55,14 @@ function is_integral(a::NumFieldElem)
   end
   return true
 end
+
+@doc doc"""
+    is_integral(a::NumFieldElem) -> Bool
+
+Returns whether $a$ is integral, that is, whether the minimal polynomial of $a$
+has integral coefficients.
+"""
+is_integral(a::NumFieldElem) = is_algebraic_integer(a)
 
 ################################################################################
 #

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -449,6 +449,7 @@ export is_GLZ_conjugate
 export is_abelian
 export is_absolute
 export is_absolutely_irreducible
+export is_algebraic_integer
 export is_anti_isometric_with_anti_isometry
 export is_anti_isometry
 export is_automorphous


### PR DESCRIPTION
I noticed that `is_algebraic_integer` for `QQBarFieldElem` is actually defined in Nemo and directly calls a Flint method named `qqbar_is_algebraic_integer`. So, I decided to make `is_algebraic_integer` the "base function".

fixes #1908