### PR TITLE
Add `vector_space_dim` for group algebras

### DIFF
--- a/src/AlgAss/AlgGrp.jl
+++ b/src/AlgAss/AlgGrp.jl
@@ -31,6 +31,20 @@ group(A::GroupAlgebra) = A.group
 
 has_one(A::GroupAlgebra) = true
 
+##To be removed
+struct InfiniteDimensionError <: Exception
+end
+
+##To be removed
+function Base.showerror(io::IO, err::InfiniteDimensionError)
+  println(io, "Infinite-dimensional vector space")
+end
+
+function vector_space_dim(A::GroupAlgebra{T, S, R}) where {T <: FieldElem, S, R}
+  isfinite(group(A)) || throw(InfiniteDimensionError())
+  return order(group(A))
+end
+
 function (A::GroupAlgebra{T, S, R})(c::Union{Vector, SRow}; copy::Bool = false) where {T, S, R}
   c isa Vector && length(c) != dim(A) && error("Dimensions don't match.")
   return GroupAlgebraElem{T, typeof(A)}(A, copy ? deepcopy(c) : c)

--- a/src/Hecke.jl
+++ b/src/Hecke.jl
@@ -53,7 +53,7 @@ import AbstractAlgebra:
   set_assertion_level,
   set_verbosity_level
 
-import AbstractAlgebra: Solve, coprime_base_steel
+import AbstractAlgebra: Solve, coprime_base_steel, vector_space_dim
 
 import LinearAlgebra: dot, nullspace, rank, ishermitian
 

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -939,6 +939,8 @@ export value_module_quadratic_form
 export vcat
 export vcat!
 export vectors_of_square_and_divisibility
+export InfiniteDimensionError #To be removed
+export vector_space_dim
 export volume
 export weil_pairing
 export wildanger_field

--- a/test/AlgAss/AlgGrp.jl
+++ b/test/AlgAss/AlgGrp.jl
@@ -37,6 +37,15 @@
     end
   end
 
+  @testset "Vector space dimension" begin
+    G1 = abelian_group(2,3)
+    G2 = abelian_group(0) 
+    R1 = group_algebra(QQ, G1)
+    R2 = group_algebra(QQ, G2)
+    @test vector_space_dim(R1) == 6
+    @test_throws InfiniteDimensionError vector_space_dim(R2)
+  end
+
   @testset "Decomposition for abelian group algebras" begin
     G = abelian_group([2,4,6])
     QG = QQ[G]


### PR DESCRIPTION
Add `vector_space_dim` for group algebras over fields. In the case the underlying group is infinite an `InfiniteDimensionError` is raised(to be moved to AA). This is rounding out oscar-system/Oscar.jl#5056.

cc @fingolfin 