### PR TITLE
feat: add maximal ideals for algebras and orders

### DIFF
--- a/src/AlgAssAbsOrd/Ideal.jl
+++ b/src/AlgAssAbsOrd/Ideal.jl
@@ -1983,41 +1983,35 @@ end
 
 # Computes any maximal integral ideal with left order O (if side = :left) or
 # right order O (if side = :right) which contains p.
+function maximal_integral_ideal(O::AlgAssAbsOrd, p::IntegerUnion; side)
+  return maximal_integral_ideal(O, p, side)
+end
+
+function maximal_integral_ideal(O::AlgAssAbsOrd, p::IntegerUnion, side::Symbol)
+  P, = prime_ideals_over(O, p) # pick any prime ideal
+  return __maximal_integral_ideal(O, P, p, side)
+end
+
+# Computes any maximal integral ideal with left order O (if side = :left) or
+# right order O (if side = :right) which contains p.
 # Assumes (so far?) that the algebra is simple and O is maximal.
-function maximal_integral_ideal(O::AlgAssAbsOrd, p::Union{ ZZRingElem, Int }, side::Symbol)
-  A = algebra(O)
-  @assert is_simple(A)
-  @assert is_maximal(O)
 
-  P = prime_ideals_over(O, p)[1] # if the algebra is simple, then there is exactly one prime lying over p
+function maximal_integral_ideals(O::AlgAssAbsOrd, p::Union{ ZZRingElem, Int }; side::Symbol)
+  lP = prime_ideals_over(O, p) # if the algebra is simple, then there is exactly one prime lying over p
+  return reduce(vcat, [__maximal_integral_ideals(O, lP[i], p, side) for i in 1:length(lP)])
+end
 
-  # P is the Jacobson radical of O/pO, so O/P is a simple algebra
-  B, OtoB = quo(O, P, p)
-  C, CtoB = _as_algebra_over_center(B)
-  D, CtoD = _as_matrix_algebra(C)
-
-  n = degree(D)
-  if isone(n)
-    return P
-  end
-
-  N = QQMatrix(basis_matrix(P))
-  t = zero_matrix(QQ, 1, degree(O))
-  # Now we only need to lift a basis for diag(1, ..., 1, 0)*D (side = :left) or
-  # D*diag(1, ..., 1, 0) (side = :right) since these are maximal ideals of D.
-  if side == :left
-    jMax = n - 1
-    iMax = n
-  elseif side == :right
-    jMax = n
-    iMax = n - 1
-  else
-    error("Option :$(side) for side not implemented")
-  end
-  for j = 1:jMax
-    jn = (j - 1)*n
-    for i = 1:iMax
-      b = (OtoB\(CtoB(CtoD\D[jn + i])))
+function __construct_maximal_ideal(O, OtoB, CtoB, CtoD, basisofcenter, side, t, N, I)
+  D = codomain(CtoD)
+  for bb in basis(maximal_ideal(D; side))
+    if length(basisofcenter) > 1
+      for e in basisofcenter # element of B
+        b = (OtoB\(e * CtoB(CtoD\bb)))
+        elem_to_mat_row!(t, 1, elem_in_algebra(b, copy = false))
+        N = vcat(N, deepcopy(t))
+      end
+    else
+      b = (OtoB\(CtoB(CtoD\bb)))
       elem_to_mat_row!(t, 1, elem_in_algebra(b, copy = false))
       N = vcat(N, deepcopy(t))
     end
@@ -2025,13 +2019,65 @@ function maximal_integral_ideal(O::AlgAssAbsOrd, p::Union{ ZZRingElem, Int }, si
   N = sub(_hnf_integral(N, :lowerleft), nrows(N) - degree(O) + 1:nrows(N), 1:degree(O))
 
   M = ideal(algebra(O), O, N; side, M_in_hnf=true)
-  if side == :left
-    M.left_order = O # O is maximal
-  else
-    M.right_order = O
+  if is_known(is_maximal, O) && is_maximal(O)
+    if side == :left
+      M.left_order = O # O is maximal
+    else
+      M.right_order = O
+    end
   end
   return M
 end
+
+function __maximal_integral_ideal(O::AlgAssAbsOrd, P, p::Union{ ZZRingElem, Int }, side::Symbol)
+  A = algebra(O)
+
+  # P is the Jacobson radical of O/pO, so O/P is a simple algebra
+  B, OtoB = quo(O, P, p)
+  C, CtoB = _as_algebra_over_center(B)
+  D, CtoD = _as_matrix_algebra(C)
+
+  # we need the center to accomodate a non-central A
+  _C, _CtoB = center(B)
+  basisofcenter = _CtoB.(basis(_C))
+
+  n = _matdeg(D)
+
+  if isone(n)
+    return P
+  end
+
+  t = zero_matrix(QQ, 1, degree(O))
+  N = QQMatrix(basis_matrix(P))
+
+  return __construct_maximal_ideal(O, OtoB, CtoB, CtoD, basisofcenter, side, t, N, maximal_ideal(D; side))
+end
+
+function __maximal_integral_ideals(O::AlgAssAbsOrd, P, p::Union{ ZZRingElem, Int }, side::Symbol)
+  A = algebra(O)
+
+  # P is the Jacobson radical of O/pO, so O/P is a simple algebra
+  B, OtoB = quo(O, P, p)
+  C, CtoB = _as_algebra_over_center(B)
+  D, CtoD = _as_matrix_algebra(C)
+
+  # we need the center to accomodate a non-central A
+  _C, _CtoB = center(B)
+  basisofcenter = _CtoB.(basis(_C))
+
+  n = _matdeg(D)
+
+  if isone(n)
+    return P
+  end
+
+  t = zero_matrix(QQ, 1, degree(O))
+  N = QQMatrix(basis_matrix(P))
+
+  return [__construct_maximal_ideal(O, OtoB, CtoB, CtoD, basisofcenter, side, t, N, I)
+            for I in maximal_ideals(D; side)]
+end
+
 
 # Constructs a maximal integral ideal M of O such that M\cap R = p and I\subseteq M,
 # where O is the left order (if side = :left) or right order (if side = :right)

--- a/src/AlgAssAbsOrd/Order.jl
+++ b/src/AlgAssAbsOrd/Order.jl
@@ -47,6 +47,8 @@ is_commutative(O::AlgAssAbsOrd) = is_commutative(algebra(O))
 
 is_maximal_known(O::AlgAssAbsOrd) = O.is_maximal != 0
 
+is_known(::typeof(is_maximal), O::AlgAssAbsOrd) = is_maximal_known(O)
+
 @inline is_maximal_known_and_maximal(O::AlgAssAbsOrd) = isone(O.is_maximal)
 
 @doc raw"""
@@ -194,7 +196,7 @@ end
 Returns the order of $A$ with basis matrix $M$. If `check` is set, it is checked
 whether $M$ defines an order.
 """
-function order(A::S, M::QQMatrix; check::Bool = true, cached::Bool = true) where {S <: AbstractAssociativeAlgebra{QQFieldElem}} 
+function order(A::S, M::QQMatrix; check::Bool = true, cached::Bool = true) where {S <: AbstractAssociativeAlgebra{QQFieldElem}}
   return order(A, ZZ, M; check, cached)
 end
 
@@ -431,7 +433,7 @@ end
 
 Returns `true` if the algebra element $x$ is in $O$ and `false` otherwise.
 """
-function in(x, O::AlgAssAbsOrd)
+function in(x::AbstractAssociativeAlgebraElem, O::AlgAssAbsOrd)
   @assert parent(x) === algebra(O)
   return _check_elem_in_order(x, O, Val(true))
 end

--- a/test/AlgAss/Ideal.jl
+++ b/test/AlgAss/Ideal.jl
@@ -163,4 +163,23 @@
     a = @inferred Hecke.right_principal_generator(J)
     @test a * A == J
   end
+
+  let
+    for q in [2, 3, 4]
+      for n in [1, 2, 3]
+        A = matrix_algebra(GF(q), n)
+        for side in [:right, :left]
+          J = Hecke.maximal_ideal(A; side = side)
+          @test Hecke._test_ideal_sidedness(J, side)
+          @test dim(J) == n*(n-1)
+          Js = Hecke.maximal_ideals(A; side = side)
+          @test length(Js) == divexact(q^n - 1, q - 1)
+          @test allunique(Js)
+          @test all(x -> Hecke._test_ideal_sidedness(x, side) && dim(x) == n*(n-1), Js)
+        end
+        @test_throws ArgumentError Hecke.maximal_ideal(A; side = :bla)
+        @test_throws ArgumentError Hecke.maximal_ideals(A; side = :bla)
+      end
+    end
+  end
 end

--- a/test/AlgAssAbsOrd/Ideal.jl
+++ b/test/AlgAssAbsOrd/Ideal.jl
@@ -217,4 +217,31 @@
     @test !Hecke.is_full_rank(I)
     @test is_zero(I^2)
   end
+
+  let # maximal integral ideal
+    ZG = integral_group_ring(QQ[small_group(36, 1)])
+    P = Hecke.maximal_integral_ideal(ZG, 2; side = :left)
+    @test ZG(2) in P
+    @test !(ZG(3) in P)
+    @test ZG * P == P
+    P = Hecke.maximal_integral_ideal(ZG, 3; side = :right)
+    @test ZG(3) in P
+    @test !(ZG(2) in P)
+    @test P * ZG == P
+
+    ZG = integral_group_ring(QQ[small_group(20, 1)])
+    Ps = Hecke.maximal_integral_ideals(ZG, 2; side = :left)
+    for P in Ps
+      @test ZG(2) in P
+      @test !(ZG(3) in P)
+      @test ZG * P == P
+    end
+
+    Ps = Hecke.maximal_integral_ideals(ZG, 3; side = :right)
+    for P in Ps
+      @test ZG(3) in P
+      @test !(ZG(2) in P)
+      @test P * ZG == P
+    end
+  end
 end


### PR DESCRIPTION
- add `maximal_ideal[s]` for full matrix algebras over finite fields
- adjust `maximal_integral_ideal` for orders in non-simple, non-central algebras
