### PR TITLE
CI: don't specify architecture

### DIFF
--- a/.github/workflows/CILong.yml
+++ b/.github/workflows/CILong.yml
@@ -23,8 +23,6 @@ jobs:
       matrix:
         julia-version:
           - '1.10'
-        julia-arch:
-          - x64
         os:
           - ubuntu-latest
 
@@ -68,8 +66,6 @@ jobs:
       matrix:
         julia-version:
           - '1.10'
-        julia-arch:
-          - x64
         os:
           - macOS-latest
 

--- a/.github/workflows/CILong.yml
+++ b/.github/workflows/CILong.yml
@@ -37,7 +37,6 @@ jobs:
         uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
-          arch: ${{ matrix.julia-arch }}
       - name: "Cache artifacts"
         uses: julia-actions/cache@v2
       - name: "Build package"

--- a/.github/workflows/CILong.yml
+++ b/.github/workflows/CILong.yml
@@ -78,7 +78,6 @@ jobs:
         uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
-          arch: ${{ matrix.julia-arch }}
       - name: "Cache artifacts"
         uses: julia-actions/cache@v2
       - name: "Build package"


### PR DESCRIPTION
Jobs complain that the requested arch does not work and taking the default would be better, see e.g. https://github.com/thofma/Hecke.jl/actions/runs/17233301753/job/48892203435?pr=1961#step:3:8