### PR TITLE
Tweaks for  Hermitian genera

### DIFF
--- a/src/QuadForm/Herm/Genus.jl
+++ b/src/QuadForm/Herm/Genus.jl
@@ -1641,10 +1641,14 @@ Given a global genus symbol `G` for hermitian lattices over $E/K$, return a herm
 lattice over $E/K$ which admits `G` as global genus symbol.
 """
 function representative(G::HermGenus)
+  if isdefined(G, :representative)
+    return G.representative
+  end
   if !is_integral(G)
     s = denominator(_scale(G))
     L = representative(rescale(G, s))
     L = rescale(L, 1//s)
+    G.representative = L
     return L
   end
   P = _non_norm_primes(G.LGS)
@@ -1663,6 +1667,7 @@ function representative(G::HermGenus)
     @vprintln :Lattice 1 "Finding sublattice"
     M = locally_isometric_sublattice(M, L, p)
   end
+  G.representative = M
   return M
 end
 
@@ -1685,7 +1690,7 @@ _den(I::RelNumFieldOrderFractionalIdeal) = denominator(I)::ZZRingElem
       E::NumField,
       p::AbsNumFieldOrderIdeal{AbsSimpleNumField, AbsSimpleNumFieldElem},
       rank::Int,
-      det_val::Int,
+      det_val::Union{Int,Nothing},
       min_scale::Int,
       max_scale::Int
     ) -> Vector{HermLocalGenus}
@@ -1693,14 +1698,14 @@ _den(I::RelNumFieldOrderFractionalIdeal) = denominator(I)::ZZRingElem
 Return all local genus symbols for hermitian lattices over the algebra `E`, with base
 field $K$, at the prime ideal`p` of $\mathcal O_K$. Each of them has rank equal to
 `rank`, scale $\mathfrak P$-valuations bounded between `min_scale` and `max_scale`
-and determinant `p`-valuations equal to `det_val`, where $\mathfrak P$ is a prime
+and determinant `p`-valuations equal to `det_val` (if not `nothing`), where $\mathfrak P$ is a prime
 ideal of $\mathcal O_E$ lying above `p`.
 """
-function hermitian_local_genera(E, p, rank::Int, det_val::Int, min_scale::Int, max_scale::Int)
+function hermitian_local_genera(E, p, rank::Int, det_val::Union{Int,Nothing}, min_scale::Int, max_scale::Int)
   is_ramified = Hecke.is_ramified(maximal_order(E), p)
   is_inert = !is_ramified && length(prime_decomposition(maximal_order(E), p)) == 1
   is_split = !is_ramified && !is_inert
-  if is_ramified
+  if is_ramified && !(det_val isa Nothing)
     # the valuation is with respect to p
     # but the scale is with respect to P
     # in the ramified case p = P**2 and thus
@@ -1723,7 +1728,7 @@ function hermitian_local_genera(E, p, rank::Int, det_val::Int, min_scale::Int, m
         push!(pgensymbol, (i, rkseq[i-min_scale + 1]))
       end
     end
-    if d == det_val
+    if (det_val isa Nothing) || d == det_val
       push!(scales_rks, pgensymbol)
     end
   end
@@ -1832,7 +1837,7 @@ end
       E::NumField,
       rank::Int,
       signatures::Dict{InfPlc, Int},
-      determinant::Union{RelNumFieldOrderIdeal, RelNumFieldOrderFractionalIdeal};
+      determinant::Union{RelNumFieldOrderIdeal, RelNumFieldOrderFractionalIdeal,Nothing}=nothing;
       min_scale::Union{RelNumFieldOrderIdeal, RelNumFieldOrderFractionalIdeal}=inv(denominator(determinant)*order(determinant)),
       max_scale::Union{RelNumFieldOrderIdeal, RelNumFieldOrderFractionalIdeal}=numerator(determinant),
     ) -> Vector{HermGenus}
@@ -1845,10 +1850,11 @@ function hermitian_genera(
     E::Hecke.RelSimpleNumField,
     rank::Int,
     signatures::Dict{<: InfPlc, Int},
-    determinant::Union{Hecke.RelNumFieldOrderIdeal, Hecke.RelNumFieldOrderFractionalIdeal};
+    determinant::Union{Hecke.RelNumFieldOrderIdeal, Hecke.RelNumFieldOrderFractionalIdeal,Nothing}=nothing;
     min_scale::Union{Hecke.RelNumFieldOrderIdeal, Hecke.RelNumFieldOrderFractionalIdeal}=inv(_den(determinant)*order(determinant)),
     max_scale::Union{Hecke.RelNumFieldOrderIdeal, Hecke.RelNumFieldOrderFractionalIdeal}=_num(determinant),
   )
+  b = !(determinant isa Nothing)
   @req rank >= 0 "Rank must be a non-negative integer"
   K = base_field(E)
   OE = maximal_order(E)
@@ -1861,24 +1867,30 @@ function hermitian_genera(
   # since E/K is quadratic, this is the case if and only if sigma(D) = D
   # and v_P(D) is even for all ramified primes of OE.
   A = automorphism_list(E)
-  if A[1](determinant) != A[2](determinant) || any(!is_even(valuation(determinant, P)) for P in support(different(OE)))
+  if  b && (A[1](determinant) != A[2](determinant) || any(!is_even(valuation(determinant, P)) for P in support(different(OE))))
     return genus_herm_type(E)[]
   end
   union!(bd, support(norm(min_scale)))
   union!(bd, support(norm(max_scale)))
-  union!(bd, support(norm(determinant)))
+  b && union!(bd, support(norm(determinant)))
   sort!(bd; by = (x -> minimum(x)))
   local_symbols = Vector{local_genus_herm_type(E)}[]
   res = genus_herm_type(E)[]
 
   mins = norm(min_scale)
   maxs = norm(max_scale)
-  ds = norm(determinant)
+  if b
+    ds = norm(determinant)
+  end
   for p in bd
-    det_val = valuation(ds, p)
     minscale_p = valuation(mins, p)
     maxscale_p = valuation(maxs, p)
-    det_val = div(det_val, 2)
+    if !(determinant isa Nothing)
+      det_val = valuation(ds, p)
+      det_val = div(det_val, 2)
+    else
+      det_val = nothing
+    end
     if !is_ramified(OE, p)
       minscale_p = div(minscale_p, 2)
       maxscale_p = div(maxscale_p, 2)

--- a/src/QuadForm/Herm/Genus.jl
+++ b/src/QuadForm/Herm/Genus.jl
@@ -1496,7 +1496,9 @@ Return the global genus symbol `G` of the hermitian lattice `L`. `G` satisfies:
   at the real infinite places of `K` which split into complex places of `E`.
 """
 @attr genus_herm_type(base_field(L)) function genus(L::HermLat)
-  return _genus(L)
+  g = _genus(L)
+  g.representative = L
+  return g
 end
 
 function _genus(L::HermLat)

--- a/src/QuadForm/Herm/Types.jl
+++ b/src/QuadForm/Herm/Types.jl
@@ -1,5 +1,33 @@
 ###############################################################################
 #
+#  Hermitian lattices
+#
+###############################################################################
+
+@attributes mutable struct HermLat{S, T, U, V, W} <: AbstractLat{S}
+  space::HermSpace{S, T, U, W}
+  pmat::V
+  gram::U
+  rational_span::HermSpace{S, T, U, W}
+  base_algebra::S
+  involution::W
+  automorphism_group_generators::Vector{U}
+  automorphism_group_order::ZZRingElem
+  generators
+  minimal_generators
+  norm
+  scale
+
+  function HermLat{S, T, U, V, W}() where {S, T, U, V, W}
+    z = new{S, T, U, V, W}()
+    return z
+  end
+end
+
+
+
+###############################################################################
+#
 #  Hermitian genera
 #
 ###############################################################################
@@ -33,6 +61,7 @@ mutable struct HermGenus{S, T, U, V}
   LGS::Vector{U}
   rank::Int
   signatures::V
+  representative::HermLat  # TODO: Make this type stable
 
   function HermGenus(E::S, r, LGS::Vector{U}, signatures::V) where {S, U, V}
     K = base_field(E)
@@ -43,32 +72,6 @@ mutable struct HermGenus{S, T, U, V}
       @assert r == rank(LGS[i])
     end
     z = new{S, eltype(primes), U, V}(E, primes, LGS, r, signatures)
-    return z
-  end
-end
-
-###############################################################################
-#
-#  Hermitian lattices
-#
-###############################################################################
-
-@attributes mutable struct HermLat{S, T, U, V, W} <: AbstractLat{S}
-  space::HermSpace{S, T, U, W}
-  pmat::V
-  gram::U
-  rational_span::HermSpace{S, T, U, W}
-  base_algebra::S
-  involution::W
-  automorphism_group_generators::Vector{U}
-  automorphism_group_order::ZZRingElem
-  generators
-  minimal_generators
-  norm
-  scale
-
-  function HermLat{S, T, U, V, W}() where {S, T, U, V, W}
-    z = new{S, T, U, V, W}()
     return z
   end
 end

--- a/src/QuadForm/Lattices.jl
+++ b/src/QuadForm/Lattices.jl
@@ -1081,7 +1081,7 @@ function trace_lattice_with_isometry_and_transfer_data(H::AbstractLat{T}; alpha:
   # We only consider full rank lattices for simplicity
   @req degree(H) == rank(H) "Lattice must be of full rank"
   @req parent(beta) === E "beta must be an element of the base algebra of H"
-  @req (beta == QQ(1) || norm(beta) == 1) "beta must be of norm 1"
+  #@req (beta == QQ(1) || norm(beta) == 1) "beta must be of norm 1"
   @req !is_zero(alpha) "alpha must be non zero"
 
   n = degree(H)
@@ -1098,7 +1098,7 @@ function trace_lattice_with_isometry_and_transfer_data(H::AbstractLat{T}; alpha:
   end
 
   @req H isa HermLat "H must be hermitian or defined over the integers"
-  @req maximal_order(E) == equation_order(E) "Equation order and maximal order must coincide"
+  #@req maximal_order(E) == equation_order(E) "Equation order and maximal order must coincide"
 
   # This function perform the trace construction on the level of the
   # ambient spaces - we just need to transport the lattice

--- a/test/QuadForm/Herm/Genus.jl
+++ b/test/QuadForm/Herm/Genus.jl
@@ -580,6 +580,9 @@ end
     @test prod([fractional_ideal(prime(g))^(sum([rank(g,i)*scale(g,i) for i in 1:length(g)])) for g in G.LGS]) == inv(135*maximal_order(base_field(E)))
   end
 
+  gh = hermitian_genera(E, 8, sig; min_scale = E(1)*maximal_order(E), max_scale = E(1)*maximal_order(E))
+  @test length(gh)==2
+
   @test_throws ArgumentError hermitian_genera(E, -1, sig, DE)
   @test_throws ArgumentError hermitian_genera(E, 1, sig, DE, min_scale = 0*DE)
   @test_throws ArgumentError hermitian_genera(E, 1, sig, DE, max_scale = 0*DE)

--- a/test/QuadForm/Torsion.jl
+++ b/test/QuadForm/Torsion.jl
@@ -8,6 +8,7 @@
   S = lattice(ambient_space(L),basis_matrix(L)[1:1,:])
   @test order(discriminant_group(S)) == 4
   @test discriminant_group(S) === discriminant_group(S)
+  @test order(discriminant_group(S, 3))==1
 
   D4_gram = matrix(ZZ, [[2, 0, 0, -1],
                         [0, 2, 0, -1],


### PR DESCRIPTION
- Allow enumeration of hermitian genera with just giving min and max scale (no determinant)
- Add second keyword argument to discriminant_group as a shortcut for primary_part
 - Cache a representative of a hermitian genus
 - Allow evaluation of non-integral polynomials at TorQuadModuleHom
