### PR TITLE
Make `conj` and `conjugate` synonymous

### DIFF
--- a/docs/src/manual/algebras/quaternion.md
+++ b/docs/src/manual/algebras/quaternion.md
@@ -22,7 +22,7 @@ quaternion_algebra(::Field, ::Any, ::Any)
 ## Arithmetic of elements
 
 ```@docs
-conjugate(a::AssociativeAlgebraElem)
+conj(a::AssociativeAlgebraElem)
 ```
 
 ```@docs; canonical=false

--- a/src/AlgAss/AlgQuat.jl
+++ b/src/AlgAss/AlgQuat.jl
@@ -225,7 +225,7 @@ function standard_involution(A::QuaternionAlgebra{T}) where {T}
 end
 
 @doc raw"""
-    conjugate(a::AssociativeAlgebraElem{_, QuaternionAlgebra})
+    conj(a::AssociativeAlgebraElem{_, QuaternionAlgebra})
                                  -> AssociativeAlgebraElem{_, QuaternionAlgebra}
 
 Return the image of $a$ under the canonical involution of the quaternion
@@ -237,11 +237,11 @@ algebra.
 julia> Q = quaternion_algebra(QQ, -1, -1); a = Q([1, 1, 1, 1])
 1 + i + j + k
 
-julia> conjugate(a)
+julia> conj(a)
 1 - i - j - k
 ```
 """
-function conjugate(a::AssociativeAlgebraElem{T, QuaternionAlgebra{T}}) where {T}
+function conj(a::AssociativeAlgebraElem{T, QuaternionAlgebra{T}}) where {T}
   return standard_involution(parent(a))(a)
 end
 

--- a/src/Aliases.jl
+++ b/src/Aliases.jl
@@ -1,5 +1,6 @@
 # alternative names for some functions from Base
 @alias trace tr
+@alias conjugate conj
 
 # alternative names for some functions from LinearAlgebra
 # we don't use the `@alias` macro here because we provide custom


### PR DESCRIPTION
I stumbled over the fact that for number fields conjugation is called `conj` (as in `Base`), but for quaternions it is `conjugate`.

I hope the alias does not cause some horrible fall-out.
