### PR TITLE
Em/favicon version pathing

### DIFF
--- a/docs/src/.vitepress/config.mts
+++ b/docs/src/.vitepress/config.mts
@@ -21,7 +21,7 @@ export default defineConfig({
       {
         rel: "apple-touch-icon",
         sizes: "180x180",
-        href: "/assets/modular/apple-touch-icon.png",
+        href: `${baseTemp.base}/assets/modular/apple-touch-icon.png`,
       },
     ],
     [
@@ -30,7 +30,7 @@ export default defineConfig({
         rel: "icon",
         type: "image/png",
         sizes: "32x32",
-        href: "/assets/modular/favicon-32x32.png",
+        href: `${baseTemp.base}/assets/modular/favicon-32x32.png`,
       },
     ],
     [
@@ -39,10 +39,10 @@ export default defineConfig({
         rel: "icon",
         type: "image/png",
         sizes: "16x16",
-        href: "/assets/modular/favicon-16x16.png",
+        href: `${baseTemp.base}/assets/modular/favicon-16x16.png`,
       },
     ],
-    ['link', { rel: 'icon', href: '/assets/modular/favicon.ico' }],
+    ['link', { rel: 'icon', href: `${baseTemp.base}/assets/modular/favicon.ico` }],
     ['script', {src: '/versions.js'}],
     ['script', {src: `${baseTemp.base}warner.js`}],
     ['script', {src: `${baseTemp.base}siteinfo.js`}]

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -24,7 +24,7 @@ hero:
 features:
   - title: What is Hecke?
     details: Hecke is a software package for computational algebraic number theory. It is written in the Julia programming language and makes use of the computer algebra packages Nemo.jl and AbstractAlgebra.jl.
-    link: /#Features
+    link: /#features
 
   - title: OSCAR
     details: Hecke is part of the OSCAR computer algebra system, which covers algebraic geometry, group theory, and polyhedral geometry in addition to number theory and commutative algebra.


### PR DESCRIPTION
Changed favicon href pathing from "/assets/modular/favicon.ico" to " \`${baseTemp.base}/assets/modular/favicon.ico\`" and similar.
(Currently getting a 404 error loading favicon icons. I think this is because the directories prepend the version to paths, e.g. /stable/assets/modular/favicon.ico. This is an attempt to fix this -- although I couldn't figure out how to test it on a local build.)