### PR TITLE
feat: enumeration of even root lattices/symbols

### DIFF
--- a/src/QuadForm/Quad/ZLattices.jl
+++ b/src/QuadForm/Quad/ZLattices.jl
@@ -777,6 +777,93 @@ function _root_lattice_E(n::Int)
   return matrix(QQ, G)
 end
 
+@doc raw"""
+    root_symbols(n::Int) -> Vector{Vector{Tuple{Symbol, Int}}}
+
+Return the list of all ADE root symbols, up to permutation,
+whose combined rank is ``n``.
+
+# Examples
+```jldoctest
+julia> root_symbols(3)
+3-element Vector{Tuple{Symbol, Int}}:
+ [(:A, 3)]
+ [(:A, 2), (:A, 1)]
+ [(:A, 1), (:A, 1), (:A, 1)]
+```
+"""
+function root_symbols(n::Int)
+  result = Vector{Tuple{Symbol, Int}}[]
+  for p in AllParts(n)
+    tmp = Vector{Tuple{Symbol, Int}}[]
+    for i in p
+      symb = Tuple{Symbol, Int}[]
+      push!(symb, (:A, i))
+      if i >= 4
+        push!(symb, (:D, i))
+      end
+      if i in 6:8
+        push!(symb, (:E, i))
+      end
+      push!(tmp, symb)
+    end
+    for i in cartesian_product_iterator(tmp; inplace=false)
+      push!(result, i)
+    end
+  end
+  return result
+end
+
+"""
+    root_lattices(n::Int) -> Vector{ZZLat}
+
+Return the list of all even root lattices, up to isomorphism, of rank ``n``.
+
+# Examples
+```jldoctest
+julia> rls = root_lattices(5)
+9-element Vector{ZZLat}:
+ Integer lattice of rank 5 and degree 5
+ Integer lattice of rank 5 and degree 5
+ Integer lattice of rank 5 and degree 5
+ Integer lattice of rank 5 and degree 5
+ Integer lattice of rank 5 and degree 5
+ Integer lattice of rank 5 and degree 5
+ Integer lattice of rank 5 and degree 5
+ Integer lattice of rank 5 and degree 5
+ Integer lattice of rank 5 and degree 5
+
+julia> gram_matrix(rls[8]) # This is A5
+[ 2   -1    0    0    0]
+[-1    2   -1    0    0]
+[ 0   -1    2   -1    0]
+[ 0    0   -1    2   -1]
+[ 0    0    0   -1    2]
+```
+"""
+function root_lattices(n::Int)
+  result = ZZLat[]
+  for p in AllParts(n)
+    tmp = Vector{QQMatrix}[]
+    for i in p
+      lat = QQMatrix[]
+      push!(lat, Hecke._root_lattice_A(i))
+      if i >= 4
+        push!(lat, Hecke._root_lattice_D(i))
+      end
+      if i in 6:8
+        push!(lat, Hecke._root_lattice_E(i))
+      end
+      push!(tmp, lat)
+    end
+    for i in cartesian_product_iterator(tmp; inplace=true)
+      g = diagonal_matrix(i)
+      push!(result, integer_lattice(; gram=g))
+    end
+  end
+  return result
+end
+
 ################################################################################
 #
 #  Hyperbolic plane

--- a/src/QuadForm/Quad/ZLattices.jl
+++ b/src/QuadForm/Quad/ZLattices.jl
@@ -786,10 +786,11 @@ whose combined rank is ``n``.
 # Examples
 ```jldoctest
 julia> root_symbols(3)
-3-element Vector{Tuple{Symbol, Int}}:
- [(:A, 3)]
- [(:A, 2), (:A, 1)]
+3-element Vector{Vector{Tuple{Symbol, Int64}}}:
  [(:A, 1), (:A, 1), (:A, 1)]
+ [(:A, 2), (:A, 1)]
+ [(:A, 3)]
+
 ```
 """
 function root_symbols(n::Int)
@@ -811,7 +812,7 @@ function root_symbols(n::Int)
       push!(result, i)
     end
   end
-  return result
+  return sort!(result)
 end
 
 """
@@ -833,12 +834,8 @@ julia> rls = root_lattices(5)
  Integer lattice of rank 5 and degree 5
  Integer lattice of rank 5 and degree 5
 
-julia> gram_matrix(rls[8]) # This is A5
-[ 2   -1    0    0    0]
-[-1    2   -1    0    0]
-[ 0   -1    2   -1    0]
-[ 0    0   -1    2   -1]
-[ 0    0    0   -1    2]
+julia> all(L -> L == root_sublattice(L), rls)
+true
 ```
 """
 function root_lattices(n::Int)

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -819,9 +819,11 @@ export ring_of_integers
 export ring_of_multipliers
 export root
 export root_lattice
+export root_lattices
 export root_lattice_recognition
 export root_lattice_recognition_fundamental
 export root_sublattice
+export root_symbols
 export roots
 export rres
 export rresx

--- a/test/QuadForm/Quad/ZLattices.jl
+++ b/test/QuadForm/Quad/ZLattices.jl
@@ -872,3 +872,12 @@ end
     @test isone(v[1, n+1])
   end
 end
+
+@testset "Enumeration of even root lattices" begin
+  rl = Vector{ZZLat}[root_lattices(i) for i in 1:9]
+  @test length.(rl) == [1, 2, 3, 6, 9, 16, 24, 40, 58]
+
+  rs10 = Set.(root_symbols(10))
+  rl10 = Set.(first.(root_lattice_recognition.(root_lattices(10))))
+  @test rs10 == rl10
+end

--- a/test/QuadForm/Quad/ZLattices.jl
+++ b/test/QuadForm/Quad/ZLattices.jl
@@ -877,7 +877,7 @@ end
   rl = Vector{ZZLat}[root_lattices(i) for i in 1:9]
   @test length.(rl) == [1, 2, 3, 6, 9, 16, 24, 40, 58]
 
-  rs10 = Set.(root_symbols(10))
-  rl10 = Set.(first.(root_lattice_recognition.(root_lattices(10))))
-  @test rs10 == rl10
+  rs6 = Set.(root_symbols(6))
+  rl6 = Set.(first.(root_lattice_recognition.(root_lattices(6))))
+  @test issetequal(rs6, rl6)
 end


### PR DESCRIPTION
Contained in https://github.com/oscar-system/Oscar.jl/pull/5151, but it does not require to use OSCAR so I moved it here.