### PR TITLE
define `modord(a, 1) = 1`

### DIFF
--- a/src/Misc/Integer.jl
+++ b/src/Misc/Integer.jl
@@ -8,11 +8,12 @@ is_commutative(::ZZRing) = true
 
 @doc raw"""
     modord(a::ZZRingElem, m::ZZRingElem) -> Int
-    modord(a::Integer, m::Integer)
+    modord(a::Integer, m::Integer) -> Int
 
   The multiplicative order of a modulo $m$ (not a good algorithm).
 """
 function modord(a::ZZRingElem, m::ZZRingElem)
+  is_one(m) && return 1
   gcd(a, m) != 1 && error("1st argument not a unit")
   i = 1
   b = a % m
@@ -24,6 +25,7 @@ function modord(a::ZZRingElem, m::ZZRingElem)
 end
 
 function modord(a::Integer, m::Integer)
+  is_one(m) && return 1
   gcd(a, m) != 1 && error("1st argument not a unit")
   i = 1
   b = a % m

--- a/test/Misc/Integer.jl
+++ b/test/Misc/Integer.jl
@@ -3,6 +3,8 @@
 
     @test is_commutative(ZZ)
 
+    @test modord(3,1) == 1
+
     @test modord(2,3) == 2
 
     @test modord(ZZ(2),ZZ(3)) == ZZ(2)


### PR DESCRIPTION
(Currently `modord(a, 1)` runs into an infinite loop.)

The definition makes sense if one interprets the mult. order of a mod m as the smallest positive integer d such that m divides a^d-1.