### PR TITLE
docs/Project.toml: set sources path for Hecke

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -8,3 +8,6 @@ Nemo = "2edaba10-b0f1-5616-af89-8c11ac63239a"
 
 [compat]
 DocumenterVitepress = "0.1.10"
+
+[sources]
+Hecke = {path = ".."}


### PR DESCRIPTION
This makes it a tad more convenient to build the docs "manually" and should have no downside for e.g. `Hecke.build_doc`
