### PR TITLE
Adjust test to future Nemo changes

### DIFF
--- a/test/QuadForm/Lattices.jl
+++ b/test/QuadForm/Lattices.jl
@@ -161,7 +161,7 @@
   L = root_lattice(:E, 8)
   R = @inferred fixed_ring(L)
   @test R == ZZ
-  @test R != base_ring(base_ring(L))
+  @test R == base_ring(L)
 
   # Use ZZRingElem in the automorphism group computation (issue 1054)
   Qx, x = QQ["x"]


### PR DESCRIPTION
We plan to remove all `base_ring` methods which currently return `Union{}`. Those changes in https://github.com/Nemocas/Nemo.jl/pull/2148 broke a test here which invoked `base_ring` on `ZZ`. Adjust the test to something more sensible.