### PR TITLE
Fix performance of `sparse_row(::ZZRing,::Int,::ZZRingElem)`

### DIFF
--- a/src/Sparse/Row.jl
+++ b/src/Sparse/Row.jl
@@ -119,7 +119,7 @@ end
 @doc raw"""
     sparse_row(R::NCRing, idx::Int, coeff::T; check::Bool=true) where {T}
 
-Constructs a sparse row with at most one non-zero entry `coeff` in 
+Constructs a sparse row with at most one non-zero entry `coeff` in
 position `idx`.
 """
 function sparse_row(R::NCRing, idx::Int, coeff; check::Bool=true)
@@ -132,13 +132,13 @@ function sparse_row(R::NCRing, idx::Int, coeff::NCRingElem; check::Bool=true)
   return SRow(parent(coeff), Int[idx], elem_type(R)[coeff]; check=false)
 end
 
-# For ZZRingElems this has to be overwritten, because the values are stored differently. 
+# For ZZRingElems this has to be overwritten, because the values are stored differently.
 function sparse_row(R::ZZRing, idx::Int, coeff::RingElem; check::Bool=true)
   parent(coeff) === R || return sparse_row(R, idx, R(coeff); check)
   check && is_zero(coeff) && return sparse_row(R)
   arr = ZZRingElem_Array(1)
   arr[1] = coeff
-  return sparse_row(R, Int[idx], arr)
+  return SRow(R, Int[idx], arr)
 end
 
 function Base.empty!(A::SRow)


### PR DESCRIPTION
Before:
```julia-repl
julia> R=ZZ; v=R(1);

julia> @btime sparse_row($R, [(1,$v)])
  124.772 ns (9 allocations: 416 bytes)
Sparse row with positions [1] and values ZZRingElem[1]

julia> @btime sparse_row($R, [1],[$v])
  107.479 ns (11 allocations: 464 bytes)
Sparse row with positions [1] and values ZZRingElem[1]

julia> @btime sparse_row($R, 1, $v)
  178.194 ns (14 allocations: 528 bytes)
Sparse row with positions [1] and values ZZRingElem[1]

julia> @btime sparse_row($R, 1, $v; check=false)
  175.253 ns (14 allocations: 528 bytes)
Sparse row with positions [1] and values ZZRingElem[1]
```

After:
```julia-repl
julia> @btime sparse_row($R, 1, $v)
  96.549 ns (7 allocations: 208 bytes)
Sparse row with positions [1] and values ZZRingElem[1]

julia> @btime sparse_row($R, 1, $v; check=false)
  96.796 ns (7 allocations: 208 bytes)
Sparse row with positions [1] and values ZZRingElem[1]
```

CC @HechtiDerLachs 

Resolves https://github.com/oscar-system/Oscar.jl/issues/5371 (well, the last bit, the bulk was done by @HechtiDerLachs thanks)