### PR TITLE
Use map_coefficients instead of soon-to-be-forbidden coercion

### DIFF
--- a/src/NumField/NfAbs/Elem.jl
+++ b/src/NumField/NfAbs/Elem.jl
@@ -391,7 +391,7 @@ function factor_trager(f::PolyRingElem{AbsSimpleNumFieldElem})
 #    d = mapreduce(x->denominator(x, A), lcm, coefficients(g), init = ZZRingElem(1))
 #    @vtime :PolyFactor 2 N = norm_mod(g*d, Zx)
 #    N = Hecke.Globals.Qx(N) * QQFieldElem(1, d)^degree(K)
-    @vtime :PolyFactor 2 N = map_coefficients(identity,norm(g); parent=Qx)
+    @vtime :PolyFactor 2 N = map_coefficients(identity, norm(g); parent=Qx)
   else
     @vtime :PolyFactor 2 N = norm_mod(g, Zx)
     @hassert :PolyFactor 1 N == map_coefficients(identity, norm(g); parent=Zx)

--- a/src/NumField/NfAbs/Elem.jl
+++ b/src/NumField/NfAbs/Elem.jl
@@ -373,6 +373,7 @@ function factor_trager(f::PolyRingElem{AbsSimpleNumFieldElem})
   K = base_ring(Kx)
 
   Zx = Hecke.Globals.Zx
+  Qx = Hecke.Globals.Qx
   @vtime :PolyFactor Np = norm_mod(g, p, Zx)
   while is_constant(Np) || !is_squarefree(map_coefficients(F, Np, cached = false))
     k = k + 1
@@ -390,10 +391,10 @@ function factor_trager(f::PolyRingElem{AbsSimpleNumFieldElem})
 #    d = mapreduce(x->denominator(x, A), lcm, coefficients(g), init = ZZRingElem(1))
 #    @vtime :PolyFactor 2 N = norm_mod(g*d, Zx)
 #    N = Hecke.Globals.Qx(N) * QQFieldElem(1, d)^degree(K)
-    @vtime :PolyFactor 2 N = Hecke.Globals.Qx(norm(g))
+    @vtime :PolyFactor 2 N = map_coefficients(identity,norm(g); parent=Qx)
   else
     @vtime :PolyFactor 2 N = norm_mod(g, Zx)
-    @hassert :PolyFactor 1 N == Zx(norm(g))
+    @hassert :PolyFactor 1 N == map_coefficients(identity, norm(g); parent=Zx)
   end
 
   while is_constant(N) || !is_squarefree(N)


### PR DESCRIPTION
Soon Nemo will be updated so that "coercion" of polynomials has to be effected via `map_coefficients`; this update is intended to avoid consequent problems in Hecke.