### PR TITLE
`dim` does not exist for all coefficient rings

### DIFF
--- a/src/AlgAss/AlgGrp.jl
+++ b/src/AlgAss/AlgGrp.jl
@@ -37,7 +37,7 @@ group(A::GroupAlgebra) = A.group
 has_one(A::GroupAlgebra) = true
 
 function (A::GroupAlgebra{T, S, R})(c::Union{Vector, SRow}; copy::Bool = false) where {T, S, R}
-  c isa Vector && length(c) != dim(A) && error("Dimensions don't match.")
+  c isa Vector && length(c) != order(group(A)) && error("Dimensions don't match.")
   return GroupAlgebraElem{T, typeof(A)}(A, copy ? deepcopy(c) : c)
 end
 

--- a/src/AlgAss/Types.jl
+++ b/src/AlgAss/Types.jl
@@ -222,7 +222,7 @@ end
           end
         end
 
-        @assert all(A.mult_table[1, i] == i for i in 1:dim(A))
+        @assert all(A.mult_table[1, i] == i for i in 1:d)
       end
 
       return A


### PR DESCRIPTION
Hot fix for a bug reported by @CassandraKoenen on Slack:
```
julia> R, _ = polynomial_ring(QQ, ["x"])
(Multivariate polynomial ring in 1 variable over QQ, QQMPolyRingElem[x])

julia> G = matrix_group(matrix(QQ, [-1 0;0 -1]))
Matrix group of degree 2
  over rational field

julia> group_algebra(R,G)
ERROR: MethodError: no method matching vector_space_dim(::GroupAlgebra{QQMPolyRingElem, MatrixGroup{QQFieldElem, QQMatrix}, MatrixGroupElem{QQFieldElem, QQMatrix}})
[...]
```
Now one can build the group algebra, but I fear that a lot of the (generic) algebra code assumes that `dim` is the "length" of the coefficients of an element. So one cannot multiply elements in this algebra for example:
```
julia> RG = group_algebra(R,G)
Group algebra
  of matrix group of degree 2 over QQ
  over multivariate polynomial ring in 1 variable over QQ

julia> one(RG) * one(RG)
ERROR: MethodError: no method matching vector_space_dim(::GroupAlgebra{QQMPolyRingElem, MatrixGroup{…}, MatrixGroupElem{…}})
[...]

julia> RG[1]
ERROR: MethodError: no method matching vector_space_dim(::GroupAlgebra{QQMPolyRingElem, MatrixGroup{…}, MatrixGroupElem{…}})
[...]
```

@thofma was this intentional?
