### PR TITLE
fix: allow non-commutative rings as images for relative number fields

### DIFF
--- a/src/Map/NumField.jl
+++ b/src/Map/NumField.jl
@@ -344,7 +344,7 @@ function map_data(K::RelSimpleNumField, L, ::Bool)
   return z
 end
 
-function _bubble_up(L, y::RingElement)
+function _bubble_up(L, y::NCRingElement)
   if parent(y) === L
     yy = y
   else
@@ -353,7 +353,7 @@ function _bubble_up(L, y::RingElement)
   return yy::elem_type(L)
 end
 
-function map_data_given_base_field_data(K::RelSimpleNumField, L, z, y::RingElement; check = true)
+function map_data_given_base_field_data(K::RelSimpleNumField, L, z, y::NCRingElement; check = true)
   yy = _bubble_up(L, y)
   if check
     yyy = evaluate(map_coefficients(w -> image(z, L, w), defining_polynomial(K), cached = false), yy)
@@ -511,7 +511,7 @@ function map_data(K::RelNonSimpleNumField, L, ::Bool)
   return z
 end
 
-function _bubble_up(L, y::Vector{<: RingElement})
+function _bubble_up(L, y::Vector{<: NCRingElement})
   if all(x -> parent(x) === L, y)
     yy = y
   else

--- a/test/Map/NumField.jl
+++ b/test/Map/NumField.jl
@@ -392,4 +392,15 @@
     h = id_hom(QQ)
     @test domain(h) === QQ === codomain(h)
   end
+
+  let
+    k, _ = quadratic_field(2);
+    kx, x = k[:x]
+    K, _ = number_field(x^2 - k(5))
+    A = matrix_algebra(k, 2)
+    f = hom(K, A, A(representation_matrix(gen(K))))
+    @test domain(f) === K
+    @test codomain(f) === A
+    @test f(gen(K)) == A(k[0 1; 5 0])
+  end
 end


### PR DESCRIPTION
Compare 5f72353 for the analogous commit for absolute number fields.