### PR TITLE
Preparation for OSCAR `isometry_group_via_heuristics`

### DIFF
--- a/src/QuadForm/Enumeration.jl
+++ b/src/QuadForm/Enumeration.jl
@@ -987,8 +987,8 @@ function _short_vectors_gram_integral(::Type{S}, _G, lb, ub, elem_type::Type{U} 
   return V
 end
 
-function _short_vectors_gram_integral(::Type{S}, _G, ub, elem_type::Type{U} = ZZRingElem; hard=false, is_lll_reduced_known::Bool=false) where {S, U}
-  return _short_vectors_gram_integral(S, _G, ZZRingElem(0), ub, U; hard, is_lll_reduced_known)
+function _short_vectors_gram_integral(::Type{S}, _G, ub, elem_type::Type{U} = ZZRingElem; kwargs...) where {S, U}
+  return _short_vectors_gram_integral(S, _G, ZZRingElem(0), ub, U; kwargs...)
 end
 
 function _shortest_vectors_gram_integral(::Type{S}, _G; is_lll_reduced_known::Bool=false) where {S}

--- a/src/QuadForm/Quad/ZLattices.jl
+++ b/src/QuadForm/Quad/ZLattices.jl
@@ -372,7 +372,7 @@ function assert_has_automorphisms(
   try_small::Bool=true,
   depth::Int=-1,
   bacher_depth::Int=0,
-  known_short_vectors=(ZZRingElem(0), Tuple{Vector{ZZRingElem}, QQFieldElem}[]),
+  known_short_vectors=(0, []),
 )
 
   if !redo && isdefined(L, :automorphism_group_generators)
@@ -426,12 +426,10 @@ function assert_has_automorphisms(
     # Make the Gram matrix small
     Glll, T = lll_gram_with_transform(res[1])
     res[1] = Glll
-    sv = eltype(sv)[(solve(T, v[1]; side=left), v[2]) for v in sv]
   else
     T = one(res[1])
   end
   known_short_vectors = (alpha, sv)
-
   C = ZLatAutoCtx(res)
   fl = false
   if try_small


### PR DESCRIPTION
- Lattices with a fixed basis matrix which is LLL-reduced remembers it (so we can avoid repeating the computation and pass it to relevant functions... we allow to redo an LLL-reduction though,  if one wants to change reduction parameters for instance)
- computations of automorphism group generators and order remember that we have already computed an LLL-reduced basis (currently, it recomputes an LLL-reduction which does not make sense)
- allow to input a list of all short vectors (up to sign) of bounded square if they have been previously computed
- allow to specify a lower bound in `_short_vectors_gram_integral`

Related to the heuristics that we are trying to fine-tune in https://github.com/oscar-system/Oscar.jl/pull/5434.