### PR TITLE
CI: test against julia 1.12 and 1.13-nightly

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,6 +28,8 @@ jobs:
         julia-version:
           - '1.10'
           - '1.11'
+          - '1.12'
+          - '1.13-nightly'
           - 'nightly'
         os:
           - ubuntu-latest


### PR DESCRIPTION
The new 1.12 job should be added to the list of "required" jobs.