### PR TITLE
fix: `enumerate_definite_genus` saves the first computed lattice

### DIFF
--- a/src/QuadForm/Quad/ZGenusRep.jl
+++ b/src/QuadForm/Quad/ZGenusRep.jl
@@ -719,8 +719,7 @@ function enumerate_definite_genus(
   end
 
   spins = spinor_genera_in_genus(first(res))
-  if length(spins) > 1
-    !add_spinor_generators && continue
+  if (length(spins) > 1) && add_spinor_generators
     for LL in spins
       keep = callback(LL)
       if !keep


### PR DESCRIPTION
Also add in the documentation the existence of the (non-exported) function `load_genus` and remembers to divide the mass by the number of spinor genera.