### PR TITLE
Upper Bounds for Arbs

### DIFF
--- a/src/RieSrf/UpperBound.jl
+++ b/src/RieSrf/UpperBound.jl
@@ -1,0 +1,26 @@
+function arb_maximum(vectofarbs::Vector{RealFieldElem})::Tuple{RealFieldElem,Bool}
+  if length(vectofarbs) <= 1
+    if length(vectofarbs) == 0
+      error("Empty list")
+      return (0,false)
+    else
+      return (vectofarbs[1],true)
+    end
+  end
+  midpoint_vect = []
+  for i in 1:length(vectofarbs)
+    push!(midpoint_vect,midpoint(vectofarbs[i]))
+  end
+  maxpoint = 1
+  for i in 2:length(vectofarbs)
+    if midpoint_vect[i] > midpoint_vect[maxpoint]
+      maxpoint = i
+    end
+  end
+  for i in 1:length(vectofarbs)
+    if i != maxpoint && overlaps(vectofarbs[i],vectofarbs[maxpoint])
+      return (vectofarbs[maxpoint],false)
+    end
+  end
+  return (vectofarbs[maxpoint],true)
+end


### PR DESCRIPTION
In RieSrf, a maximum of Arbs is often taken which is not exact. Here, we are providing a function to solve this issue. A simple maximum function is implemented which returns a maximum together with a bool, stating whether the maximum is exact.

@simonbrandhorst and me also thought of a fast upper bound function which returns an exact upper bound. This should be a number which is close to the supremum, but fast to determine exactly so that it should be better for most computations in RieSrf.