### PR TITLE
Make ideal method stricter

### DIFF
--- a/src/Misc/PIDIdeal.jl
+++ b/src/Misc/PIDIdeal.jl
@@ -54,7 +54,7 @@ function ideal(R::PolyRing{<:FieldElem}, x::RingElement, y::RingElement...)
   return _ideal_pid(R, x, y...)
 end
 
-function ideal(R::PolyRing{<:FieldElem}, xs::AbstractVector{T}) where T<:RingElement
+function ideal(R::PolyRing{<:FieldElem}, xs::Vector)
   return _ideal_pid(R, xs)
 end
 


### PR DESCRIPTION
They redirect to _ideal_pid so the argument lists should match.

Also remove some unreachable code.

Motivated by https://github.com/Nemocas/AbstractAlgebra.jl/pull/2108 which runs into an ambiguity error for `ideal(::QQPolyRing, ::Vector{Any})`.