### PR TITLE
Fix some more JET warnings

### DIFF
--- a/src/AlgAss/Types.jl
+++ b/src/AlgAss/Types.jl
@@ -179,20 +179,18 @@ end
       A.base_ring = K
       A.group = G
       A.group_to_base = Dict{elem_type(G), Int}()
-      if !sparse
-        @assert is_finite(G)
-        d = order(Int, G)
-        A.base_to_group = Vector{elem_type(G)}(undef, d)
-      else
-        A.base_to_group = Vector{elem_type(G)}(undef, 1)
-      end
 
       if A.sparse
+        A.base_to_group = Vector{elem_type(G)}(undef, 1)
         el = _identity_elem(G)
         A.group_to_base[el] = 1
         A.base_to_group[1] = el
         A.sparse_one = sparse_row(K, [(1,one(K))])
       else
+        @assert is_finite(G)
+        d = order(Int, G)
+        A.base_to_group = Vector{elem_type(G)}(undef, d)
+
         # dense
         A.mult_table = zeros(Int, d, d)
         i = 2

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -119,8 +119,6 @@ end
 @deprecate iseq is_eq
 @deprecate isequation_order is_equation_order
 @deprecate isequivalent is_equivalent
-@deprecate isfinite_gen is_finite_gen
-@deprecate isfinite_snf is_finite_snf
 @deprecate isfixed_point_free is_fixed_point_free
 @deprecate isfree is_free
 @deprecate isfree_a4_fabi is_free_a4_fabi
@@ -246,8 +244,6 @@ end
 
 @deprecate Zgenera integer_genera
 @deprecate Zlattice integer_lattice
-
-@deprecate real_field real_number_field
 
 @deprecate points_with_x points_with_x_coordinate
 


### PR DESCRIPTION
Remove some deprecations where both old and new names are not used
anywhere. Also adjust GroupAlgebra constructor so that JET can
'see' that e.g. d is defined by the time it is used.
