### PR TITLE
Avoid re-computing derivatives

### DIFF
--- a/src/EllCrv/Heights.jl
+++ b/src/EllCrv/Heights.jl
@@ -796,15 +796,25 @@ function CPS_dvev_complex(E::EllipticCurve{T}, v::V, prec::Int = 100) where T wh
   F = b6*x^4 + 2*b4*x^3 + b2*x^2 + 4*x
   G = -b8*x^4 - 2*b6*x^3 - b4*x^2 + 1
 
-  E_fg = function (u::AcbFieldElem, eta::ArbFieldElem)
-    fsum = sum([eta^i//factorial(i)*abs(derivative(f, i)(u)) for i in (1:3)])
-    gsum = sum([eta^i//factorial(i)*abs(derivative(g, i)(u)) for i in (1:4)])
+  function taylor(pol::PolyRingElem, u::AcbFieldElem, eta::ArbFieldElem)
+    s = zero(eta)
+    d = degree(pol)
+    for i in 1:d
+      pol = derivative(pol)
+      s += eta^i//factorial(i)*abs(pol(u))
+    end
+    return s
+  end
+
+  function E_fg(u::AcbFieldElem, eta::ArbFieldElem)
+    fsum = taylor(f, u, eta)
+    gsum = taylor(g, u, eta)
     return max(fsum, gsum)
   end
 
-  E_FG = function (u::AcbFieldElem, eta::ArbFieldElem)
-    Fsum = sum([eta^i//factorial(i)*abs(derivative(F, i)(u)) for i in (1:4)])
-    Gsum = sum([eta^i//factorial(i)*abs(derivative(G, i)(u)) for i in (1:4)])
+  function E_FG(u::AcbFieldElem, eta::ArbFieldElem)
+    Fsum = taylor(F, u, eta)
+    Gsum = taylor(G, u, eta)
     return max(Fsum, Gsum)
   end
 


### PR DESCRIPTION
This used a special derivative method for computing the i-th derivative. In theory this could be written down directly, but in practice the method for doing that invokes the usual unary derivative method multiple times. So instead of 4 derivatives it computed 1+2+3+4=10.

~~The real motivation is to eventually allow us to phase out the Nemo method `derivative(::AcbPolyRingElem, ::Int)` at some point.~~

UPDATE: or perhaps we keep that and optimize it... still, it seems sensible to make this code change.
The reason I dislike the above is method is that *also* have `function derivative(x::ComplexPolyRingElem, prec::Int = precision(Balls))`. So this is very confusing. But perhaps the latter is what really should be changed, turning the `prec` argument into a kwarg...

UPDATE 2: in fact I now made https://github.com/Nemocas/Nemo.jl/pull/2229 after I realized we also have `derivative(x::ZZPolyRingElem, n::Int)` and a bunch more, just no general definition.