### PR TITLE
Add workflow for changelog script

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,11 @@
+name: Changelog
+on:
+  workflow_dispatch:
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dummy step
+        shell: bash
+        run: true


### PR DESCRIPTION
All this change does is add a dummy workflow, which allows the larger PR to be tested without having to merge it in first.

[skip ci]