### PR TITLE
Added in-place operations for elliptic curve points

### DIFF
--- a/src/EllCrv/EllCrv.jl
+++ b/src/EllCrv/EllCrv.jl
@@ -659,7 +659,7 @@ end
 @doc raw"""
     infinity(E::EllipticCurve) -> EllipticCurvePoint
 
-Return the point at infinity with project coordinates $[0 : 1 : 0]$.
+Return the point at infinity with projective coordinates $(0 : 1 : 0)$.
 """
 function infinity(E::EllipticCurve{T}) where T
   infi = EllipticCurvePoint{T}(E)
@@ -869,61 +869,7 @@ julia> P + P
 ```
 """
 function +(P::EllipticCurvePoint{T}, Q::EllipticCurvePoint{T}) where T
-  parent(P) != parent(Q) && error("Points must live on the same curve")
-
-  # Is P = infinity or Q = infinity?
-  if P.is_infinite
-      return Q
-  elseif Q.is_infinite
-      return P
-  end
-
-  E = P.parent
-
-  # Distinguish between long and short form
-  if E.short
-    if P[1] != Q[1]
-        m = divexact(Q[2] - P[2], Q[1] - P[1])
-        x = m^2 - P[1] - Q[1]
-        y = m * (P[1] - x) - P[2]
-    elseif P[2] != Q[2]
-        return infinity(E)
-    elseif P[2] != 0
-        _, _, _, a4 = a_invariants(E)
-        m = divexact(3*(P[1])^2 + a4, 2*P[2])
-        x = m^2 - 2*P[1]
-        y = m* (P[1] - x) - P[2]
-    else
-        return infinity(E)
-    end
-
-    Erg = E([x, y], check = false)
-
-  else
-  a1, a2, a3, a4, a6 = a_invariants(E)
-
-    # Use [Cohen, p. 270]
-    if P[1] == Q[1]
-      if Q[2] == -a1*P[1] - a3 - P[2] # then P = -Q
-        return infinity(E)
-      elseif P[2] == Q[2] # then P = Q
-        m = divexact(3*((P[1])^2) + 2*a2*P[1] + a4 - a1*P[2], 2*P[2] + a1*P[1] + a3)
-        x = -P[1] - Q[1] - a2 + a1*m + m^2
-        y = -P[2] - m*(x - P[1]) - a1*x - a3
-      else # then P != +-Q
-        m = divexact(Q[2] - P[2], Q[1] - P[1])
-        x = -P[1] - Q[1] - a2 + a1*m + m^2
-        y = -P[2] - m*(x - P[1]) - a1*x - a3
-      end
-    else # now P != +-Q
-      m = divexact(Q[2] - P[2], Q[1] - P[1])
-      x = -P[1] - Q[1] - a2 + a1*m + m^2
-      y = -P[2] - m*(x - P[1]) - a1*x - a3
-    end
-
-    Erg = E([x, y], check = false)
-  end
-  return Erg
+  return add!(infinity(parent(P)),P,Q)
 end
 
 #@doc raw"""
@@ -932,7 +878,7 @@ end
 #Subtract two points on an elliptic curve.
 #"""
 function -(P::EllipticCurvePoint{T}, Q::EllipticCurvePoint{T}) where T
-  return P + (-Q)
+  return sub!(infinity(parent(P)),P,Q)
 end
 
 ################################################################################
@@ -947,20 +893,7 @@ end
 #Compute the inverse of the point $P$ on an elliptic curve.
 #"""
 function -(P::EllipticCurvePoint)
-  E = P.parent
-
-  if !is_finite(P)
-    return infinity(E)
-  end
-
-  if E.short == true
-    Q = E([P[1], -P[2]], check = false)
-  else
-    a1,_, a3 = a_invariants(E)
-    Q = E([P[1], -a1*P[1] - a3 - P[2]], check = false)
-  end
-
-  return Q
+  return neg!(infinity(parent(P)), P)
 end
 
 function iszero(P::EllipticCurvePoint)
@@ -1005,30 +938,265 @@ end
 Compute the point $nP$.
 """
 function *(n::S, P::EllipticCurvePoint) where S<:Union{Integer, ZZRingElem}
-  B = infinity(P.parent)
-  C = P
+  return mul!(infinity(parent(P)),n,P)
+end
 
-  if n >= 0
-      a = n
-  else
-      a = -n
+################################################################################
+#
+#  In-place operations
+#
+################################################################################
+
+# @doc raw"""
+#     set!(R::EllipticCurvePoint, P::EllipticCurvePoint)
+#
+# Copies the point $P$ onto the point $R$, mutating $R$. Points must have the same parent curve.
+# """
+function set!(R::EllipticCurvePoint{T}, P::EllipticCurvePoint{T}) where T
+  @req(parent(R) == parent(P), "Can only write to a point on the same curve")
+
+  R.is_infinite = P.is_infinite
+  if !P.is_infinite
+    R.coordx = P.coordx
+    R.coordy = P.coordy
+  end
+  return R
+end
+
+# @doc raw"""
+#     add!(R::EllipticCurvePoint, P::EllipticCurvePoint, Q::EllipticCurvePoint)
+#
+# Add two points on an elliptic curve, mutating $R$ to $P+Q$.
+# Allows for $R$ to be $P$ or $Q$ to reduce allocations.
+#
+# # Examples
+#
+# ```jldoctest
+# julia> E = elliptic_curve(QQ, [-43,166]);
+#
+# julia> P = E([3, 8]);
+#
+# julia> Q = E([-5,16]);
+#
+# julia> R = infinity(E);
+#
+# julia> add!(R, P, Q);
+#
+# julia> R
+# (3 : -8 : 1)
+# ```
+# """
+function add!(R::EllipticCurvePoint{T}, P::EllipticCurvePoint{T}, Q::EllipticCurvePoint{T}) where T
+  @req(parent(P) == parent(Q), "Points must live on the same curve")
+  @req(parent(R) == parent(P), "Can only write to a point on the same curve")
+
+  # Is P = infinity or Q = infinity?
+  if P.is_infinite
+    if R !== Q
+      set!(R,Q)
+    end
+    return R
+  elseif Q.is_infinite
+    if R !== P
+      set!(R,P)
+    end
+    return R
   end
 
-  while a != 0
-    if mod(a,2) == 0
-      a = div(a,2)
-      C = C + C
+  E = P.parent
+  local x,y # we'll compute the x-coord,y-coord of P+Q
+
+  # Distinguish between long and short form
+  if E.short
+    if P[1] != Q[1]
+      m = divexact(Q[2] - P[2], Q[1] - P[1])
+      x = m^2 - P[1] - Q[1]
+      y = m * (P[1] - x) - P[2]
+    elseif P[2] != Q[2]
+      # if P[1] == Q[1] and P[2] != Q[2], then P = -Q
+      R.is_infinite = true
+      return R
+    elseif P[2] != 0
+      # if P[i] == Q[i] for i=1,2 and P[2] != 0, then we compute P+P as
+      a4 = (a_invariants(E))[4]
+      m = divexact(3*(P[1])^2 + a4, 2*P[2])
+      x = m^2 - 2*P[1]
+      y = m*(P[1] - x) - P[2]
     else
-      a = a - 1
-      B = B + C
+      # if we get here, P=Q, and P[2]==0 implies 2*P=0
+      R.is_infinite = true
+      return R
+    end
+  else
+    a1, a2, a3, a4, a6 = a_invariants(E)
+    # Use [Cohen, p. 270]
+    if P[1] == Q[1]
+      if Q[2] == -a1*P[1] - a3 - P[2] # then P = -Q
+        R.is_infinite = true
+        return R
+      else # P != -Q
+        m = divexact(3*((P[1])^2) + 2*a2*P[1] + a4 - a1*P[2], 2*P[2] + a1*P[1] + a3)
+        x = -P[1] - Q[1] - a2 + a1*m + m^2
+        y = -P[2] - m*(x - P[1]) - a1*x - a3
+      end
+    else # now P != +-Q
+      m = divexact(Q[2] - P[2], Q[1] - P[1])
+      x = -P[1] - Q[1] - a2 + a1*m + m^2
+      y = -P[2] - m*(x - P[1]) - a1*x - a3
+    end
+  end
+
+  # Finally, update and return R
+  R.is_infinite = false
+  R.coordx = x
+  R.coordy = y
+
+  return R
+end
+
+# @doc raw"""
+#     neg!(R::EllipticCurvePoint, P::EllipticCurvePoint)
+#
+# Computes the inverse $-P$ of $P$ and mutates $R$ to $-P$.
+# Allows for $R$ to be $P$ to reduce allocations.
+#
+# # Examples
+#
+# ```jldoctest
+# julia> E = elliptic_curve(QQ, [-43, 166]);
+#
+# julia> P = E([3, 8]);
+#
+# julia> neg!(P,P)
+# (3 : -8 : 1)
+#
+# julia> P
+# (3 : -8 : 1)
+# ```
+# """
+function neg!(R::EllipticCurvePoint{T}, P::EllipticCurvePoint{T}) where T
+  @req(parent(R) == parent(P), "Can only write to a point on the same curve")
+
+  E = P.parent
+
+  if !is_finite(P)
+    R.is_infinite = true
+    return R
+  end
+
+  R.is_infinite = false
+
+  if E.short == true
+    R.coordx = P[1]
+    R.coordy = -P[2]
+  else
+    a1,_, a3 = a_invariants(E)
+    R.coordx = P[1]
+    R.coordy = -a1*P[1] - a3 - P[2]
+  end
+
+  return R
+end
+
+# @doc raw"""
+#     sub!(R::EllipticCurvePoint, P::EllipticCurvePoint, Q::EllipticCurvePoint)
+#
+# Computes the difference $P-Q$ and mutates $R$ to $P-Q$.
+#
+# # Examples
+#
+# ```jldoctest
+# julia> E = elliptic_curve(QQ, [-43, 166]);
+#
+# julia> P = E([3, 8]);
+#
+# julia> Q = E([-5,16]);
+#
+# julia> C = infinity(E);
+#
+# julia> sub!(P, P, Q)
+# (11 : -32 : 1)
+#
+# julia> P
+# (11 : -32 : 1)
+# ```
+# """
+function sub!(R::EllipticCurvePoint{T}, P::EllipticCurvePoint{T}, Q::EllipticCurvePoint{T}) where T
+
+  if P == Q
+    R.is_infinite = true
+    return R
+
+  elseif R === P
+    neg!(P, P)
+    return neg!(P, add!(P, P, Q))
+
+  else
+    set!(R, Q)
+    neg!(R, R)
+    return add!(R, P, R)
+  end
+
+end
+
+
+# @doc raw"""
+#     mul!(R::EllipticCurvePoint, n::Int, P::EllipticCurvePoint, C::EllipticCurvePoint = infinity(parent(P)))
+#
+# Compute the point $nP$ and mutate $R$ to $nP$.
+# Uses a buffer point $C$, which can be passed as an optional argument, and which will mutate under `mul!`.
+#
+# !!! info
+#     The point $P$ can be used for either the buffer point $C$ or for the result point $R$.
+#     However, $P$ can't be used for both $C$ and $R$ because the points become distinct in the computation
+#     of $nP$.
+#
+# # Examples
+#
+# ```jldoctest
+# julia> E = elliptic_curve(QQ, [-43, 166]);
+#
+# julia> P = E([3, 8]);
+#
+# julia> Q = E([-5,16]);
+#
+# julia> C = infinity(E);
+#
+# julia> mul!(Q, 24, P, C)
+# (11 : -32 : 1)
+#
+# julia> Q
+# (11 : -32 : 1)
+#
+# julia> C
+# (-5 : -16 : 1)
+# ```
+# """
+function mul!(R::EllipticCurvePoint, n::S, P::EllipticCurvePoint, C::EllipticCurvePoint = infinity(parent(P))) where S<:Union{Integer, ZZRingElem}
+  @req(parent(R) == parent(P), "Can only write to a point on the same curve")
+  @req(R !== C, "Result point R can not alias the buffer point C")
+
+  # Have to copy first, in case R === P
+  set!(C,P)
+  R.is_infinite = true
+
+  a = (n >= 0) ? n : -n
+
+  while a != 0
+    if !isodd(a)
+      a >>= 1
+      add!(C,C,C)
+    else
+      a += -1
+      add!(R,R,C)
     end
   end
 
   if n < 0
-    B = -B
+    neg!(R,R)
   end
 
-  return B
+  return R
 end
 
 ################################################################################

--- a/test/EllCrv/EllCrv.jl
+++ b/test/EllCrv/EllCrv.jl
@@ -218,8 +218,17 @@
 
     @test P == @inferred P + O
     @test !is_zero(P)
-    @test E43_a1([2, -4]) == P + P
-    @test E43_a1([QQFieldElem(-2, 9), QQFieldElem(1, 27)]) == P + P + P
+    R = infinity(E43_a1)
+    @test P == @inferred add!(R, P, O)
+    @test R == P
+
+    P_mut = E43_a1([QQ(-1), QQ(0)])
+    P2 = @inferred P + P
+    P3 = @inferred P + P + P
+    @test E43_a1([2, -4]) == P2
+    @test E43_a1([QQFieldElem(-2, 9), QQFieldElem(1, 27)]) == P3
+    @test P2 == @inferred add!(P_mut, P_mut, P_mut)
+    @test P3 == @inferred add!(P_mut, P_mut, P)
 
     P = @inferred E116_1_a1([K(0), -K(a)])
     @test E116_1_a1([1, -1]) == @inferred P + P
@@ -234,17 +243,23 @@
     @test Eshort([0, 0]) == @inferred P + P
     @test P == @inferred O + P
 
+    # inversion
     P = Eshort([2, 4])
+    R = infinity(Eshort)
     @test Eshort([2, -4]) == @inferred -P
+    @test Eshort([2, -4]) == @inferred neg!(R,P)
+    @test R == @inferred -P
+    @test P == @inferred neg!(R,R)
+
     P = infinity(Eshort)
     @test P == @inferred -P
+    @test infinity(Eshort) == @inferred neg!(P,P)
 
     P = E43_a1([-1, 0])
     @test E43_a1([-1, -1]) == @inferred -P
     P = infinity(E43_a1)
     @test P == @inferred -P
 
-    # inversion
     P = @inferred E116_1_a1([K(0), -K(a)])
     @test E116_1_a1([0, 0]) == @inferred -P
     P = infinity(E116_1_a1)
@@ -269,20 +284,65 @@
     @test @inferred ==(P2, P2)
     @test @inferred !==(P2, P1)
 
+    # copy coords
+    P = Eshort([2, 4])
+    R = Eshort([2, -4])
+    O = infinity(Eshort)
+    @test R == @inferred Hecke.set!(P, R)
+    @test P == R
+    @test O == @inferred Hecke.set!(P, O)
+    @test P == infinity(Eshort)
+    @test R == @inferred Hecke.set!(O, R)
+    @test O == R
+
+    # subtraction
+    P = E43_a1([-1, 0])
+    O = infinity(E43_a1)
+    @test O == @inferred P - P
+    @test O == @inferred sub!(P, P, P)
+    @test O == P
+
+    P = E116_1_a1([K(0), -K(a)])
+    Q = E116_1_a1([K(1), -a])
+    R = infinity(E116_1_a1)
+    @test E116_1_a1([1, -1]) == @inferred sub!(R, Q, P)
+    @test E116_1_a1([1, -1]) == R
+    @test P == @inferred sub!(R, Q, R)
+    @test E116_1_a1([1, -1]) == @inferred sub!(P, Q, P)
+    @test E116_1_a1([1, -1]) == P
+
     # scalar multiplication
+    P = Eshort([2,4])
+    N = @inferred -P
+    O = infinity(Eshort)
+    @test O == @inferred 0*P
+    @test P == @inferred 1*P
+    @test N == @inferred -1*P
+
     P1 = Eshort([2, 4])
     @test Eshort([0, 0]) == @inferred 2*P1
     @test infinity(Eshort) == @inferred 4*P1
+    R = infinity(Eshort)
+    @test Eshort([0, 0]) == @inferred mul!(R, 2, P1)
+    @test infinity(Eshort) == @inferred mul!(R, 2, R)
+    @test infinity(Eshort) == @inferred mul!(P1, 4, P1)
 
     P1 = E43_a1([-1, 0])
     @test E43_a1([QQFieldElem(11, 49), QQFieldElem(-363, 343)]) == @inferred 4*P1
+    R = infinity(E43_a1)
+    @test E43_a1([QQFieldElem(11, 49), QQFieldElem(-363, 343)]) == @inferred mul!(P1, 4, P1, R)
+    P1 = E43_a1([-1, 0])
+    @test E43_a1([QQFieldElem(11, 49), QQFieldElem(-363, 343)]) == @inferred mul!(R, 4, P1)
 
     P1 = E116_1_a1([K(0), -K(a)])
+    P2 = @inferred 2*P1
     @test E116_1_a1([K(0), K(0)]) == @inferred 4*P1
     @test infinity(E116_1_a1) == @inferred 5*P1
+    @test P2 == mul!(P1, 2, P1)
+    @test E116_1_a1([K(0), K(0)]) == @inferred mul!(P1, 2, P2)
+    @test E116_1_a1([K(0), K(0)]) == P1
 
     #division
-
     P1 = Eshort([2, 4])
     Q = (2*P1)//2
     @test Q == P1 || Q == -P1


### PR DESCRIPTION
Added the following in-place operations for elliptic curve points:
- `add!(R::EllipticCurvePoint{T}, P::EllipticCurvePoint{T}, Q::EllipticCurvePoint{T}) where T`
- `inv!(R::EllipticCurvePoint{T}, P::EllipticCurvePoint{T}) where T`
- `copy_coords!(R::EllipticCurvePoint{T}, P::EllipticCurvePoint{T}) where T`
- `sub!(R::EllipticCurvePoint{T}, P::EllipticCurvePoint{T}, Q::EllipticCurvePoint{T}) where T`
- `mul!(R::EllipticCurvePoint, n::S, P::EllipticCurvePoint, C::EllipticCurvePoint = infinity(parent(P))) where S<:Union{Integer, ZZRingElem}`

I'm not sure why the documentation for some of the original operations is commented out (e.g. `+`, `*`, `-`, ...). I imagine possibly because it can clutter the Julia documentation? If so, maybe some of these functions should have their documentation commented out as well.

One comment: all of the functions are implemented using direct field access for the `EllipticCurvePoint` struct. I'm not sure how frowned upon this is. Also, this introduces the behavior that the group identity can have nontrivial `coordx` and `coordy` fields.

I also deleted an unreachable `else` block in the original `+(P::EllipticCurvePoint{T}, Q::EllipticCurvePoint{T}) where T`.

TODO:
- add tests for the new functions

Comments are very welcome.