### PR TITLE
fix: mathematically wrong documentation in `QuadForm`

### DIFF
--- a/src/QuadForm/Lattices.jl
+++ b/src/QuadForm/Lattices.jl
@@ -1834,15 +1834,20 @@ end
     direct_sum(x::Vector{T}) where T <: AbstractLat -> T, Vector{AbstractSpaceMor}
 
 Given a collection of quadratic or hermitian lattices $L_1, \ldots, L_n$,
-return their direct sum $L := L_1 \oplus \ldots \oplus L_n$, together with
-the injections $L_i \to L$ (seen as maps between the corresponding ambient spaces).
+return their direct sum $L := L_1 \oplus \ldots \oplus L_n$ as modules, together
+with the injections $L_i \to L$ (seen as maps between the corresponding
+ambient spaces).
 
-For objects of type `AbstractLat`, finite direct sums and finite direct
-products agree and they are therefore called biproducts.
+For modules, finite direct sums and finite direct products agree and they are
+therefore called biproducts.
 If one wants to obtain `L` as a direct product with the projections $L \to L_i$,
 one should call `direct_product(x)`.
 If one wants to obtain `L` as a biproduct with the injections $L_i \to L$ and the
 projections $L \to L_i$, one should call `biproduct(x)`.
+
+!!! warning
+    The projections $L\to L_i$ are morphisms of modules but not of lattices,
+    since the associated quadratic/hermitian forms are not preserved.
 """
 function direct_sum(x::Vector{T};cached::Bool=true) where T <: AbstractLat
   W, inj = direct_sum(ambient_space.(x); cached)
@@ -1857,15 +1862,20 @@ direct_sum(x::Vararg{AbstractLat};cached::Bool=true) = direct_sum(collect(x);cac
     direct_product(x::Vector{T}) where T <: AbstractLat -> T, Vector{AbstractSpaceMor}
 
 Given a collection of quadratic or hermitian lattices $L_1, \ldots, L_n$,
-return their direct product $L := L_1 \times \ldots \times L_n$, together with
-the projections $L \to L_i$ (seen as maps between the corresponding ambient spaces).
+return their direct product $L := L_1 \times \ldots \times L_n$ as modules, together
+with the projections $L \to L_i$ (seen as maps between the corresponding
+ambient spaces).
 
-For objects of type `AbstractLat`, finite direct sums and finite direct
-products agree and they are therefore called biproducts.
+For modules, finite direct sums and finite direct products agree and they are
+therefore called biproducts.
 If one wants to obtain `L` as a direct sum with the injections $L_i \to L$,
 one should call `direct_sum(x)`.
 If one wants to obtain `L` as a biproduct with the injections $L_i \to L$ and the
 projections $L \to L_i$, one should call `biproduct(x)`.
+
+!!! warning
+    The projections $L\to L_i$ are morphisms of modules but not of lattices,
+    since the associated quadratic/hermitian forms are not preserved.
 """
 function direct_product(x::Vector{T};cached::Bool=true) where T <: AbstractLat
   W, proj = direct_product(ambient_space.(x); cached)
@@ -1880,16 +1890,20 @@ direct_product(x::Vararg{AbstractLat}) = direct_product(collect(x))
     biproduct(x::Vector{T}) where T <: AbstractLat -> T, Vector{AbstractSpaceMor}, Vector{AbstractSpaceMor}
 
 Given a collection of quadratic or hermitian lattices $L_1, \ldots, L_n$,
-return their biproduct $L := L_1 \oplus \ldots \oplus L_n$, together with
-the injections $L_i \to L$ and the projections $L \to L_i$ (seen as maps
+return their biproduct $L := L_1 \oplus \ldots \oplus L_n$ as modules, together
+with the injections $L_i \to L$ and the projections $L \to L_i$ (seen as maps
 between the corresponding ambient spaces).
 
-For objects of type `AbstractLat`, finite direct sums and finite direct
-products agree and they are therefore called biproducts.
+For modules, finite direct sums and finite direct products agree and they are
+therefore called biproducts.
 If one wants to obtain `L` as a direct sum with the injections $L_i \to L$,
 one should call `direct_sum(x)`.
 If one wants to obtain `L` as a direct product with the projections $L \to L_i$,
 one should call `direct_product(x)`.
+
+!!! warning
+    The projections $L\to L_i$ are morphisms of modules but not of lattices,
+    since the associated quadratic/hermitian forms are not preserved.
 """
 function biproduct(x::Vector{T}; cached::Bool=true) where T <: AbstractLat
   W, inj, proj = biproduct(ambient_space.(x); cached)

--- a/src/QuadForm/Quad/ZLattices.jl
+++ b/src/QuadForm/Quad/ZLattices.jl
@@ -257,16 +257,20 @@ end
     direct_sum(x::Vector{ZZLat}) -> ZZLat, Vector{AbstractSpaceMor}
 
 Given a collection of $\mathbb Z$-lattices $L_1, \ldots, L_n$,
-return their direct sum $L := L_1 \oplus \ldots \oplus L_n$,
+return their direct sum $L := L_1 \oplus \ldots \oplus L_n$ as modules,
 together with the injections $L_i \to L$.
 (seen as maps between the corresponding ambient spaces).
 
-For objects of type `ZZLat`, finite direct sums and finite direct products
-agree and they are therefore called biproducts.
+For modules, finite direct sums and finite direct products agree and
+they are therefore called biproducts.
 If one wants to obtain `L` as a direct product with the projections $L \to L_i$,
 one should call `direct_product(x)`.
 If one wants to obtain `L` as a biproduct with the injections $L_i \to L$ and
 the projections $L \to L_i$, one should call `biproduct(x)`.
+
+!!! warning
+    The projections $L\to L_i$ are morphisms of modules but not of lattices,
+    since the associated quadratic/hermitian forms are not preserved.
 """
 function direct_sum(x::Vector{ZZLat}; cached::Bool=true)
   W, inj = direct_sum(ambient_space.(x); cached)
@@ -281,16 +285,20 @@ direct_sum(x::Vararg{ZZLat}; cached=true) = direct_sum(collect(x); cached)
     direct_product(x::Vector{ZZLat}) -> ZZLat, Vector{AbstractSpaceMor}
 
 Given a collection of $\mathbb Z$-lattices $L_1, \ldots, L_n$,
-return their direct product $L := L_1 \times \ldots \times L_n$,
+return their direct product $L := L_1 \times \ldots \times L_n$ as modules,
 together with the projections $L \to L_i$.
 (seen as maps between the corresponding ambient spaces).
 
-For objects of type `ZZLat`, finite direct sums and finite direct products
-agree and they are therefore called biproducts.
+For modules, finite direct sums and finite direct products agree and
+they are therefore called biproducts.
 If one wants to obtain `L` as a direct sum with the injections $L_i \to L$,
 one should call `direct_sum(x)`.
 If one wants to obtain `L` as a biproduct with the injections $L_i \to L$ and
 the projections $L \to L_i$, one should call `biproduct(x)`.
+
+!!! warning
+    The projections $L\to L_i$ are morphisms of modules but not of lattices,
+    since the associated quadratic/hermitian forms are not preserved.
 """
 function direct_product(x::Vector{ZZLat}; cached::Bool=true)
   W, proj = direct_product(ambient_space.(x); cached)
@@ -305,16 +313,20 @@ direct_product(x::Vararg{ZZLat}; cached::Bool=true) = direct_product(collect(x);
     biproduct(x::Vector{ZZLat}) -> ZZLat, Vector{AbstractSpaceMor}, Vector{AbstractSpaceMor}
 
 Given a collection of $\mathbb Z$-lattices $L_1, \ldots, L_n$,
-return their biproduct $L := L_1 \oplus \ldots \oplus L_n$,
+return their biproduct $L := L_1 \oplus \ldots \oplus L_n$ as modules,
 together with the injections $L_i \to L$ and the projections $L \to L_i$.
 (seen as maps between the corresponding ambient spaces).
 
-For objects of type `ZZLat`, finite direct sums and finite direct products
-agree and they are therefore called biproducts.
+For modules, finite direct sums and finite direct products agree and
+they are therefore called biproducts.
 If one wants to obtain `L` as a direct sum with the injections $L_i \to L$,
 one should call `direct_sum(x)`.
 If one wants to obtain `L` as a direct product with the projections $L \to L_i$,
 one should call `direct_product(x)`.
+
+!!! warning
+    The projections $L\to L_i$ are morphisms of modules but not of lattices,
+    since the associated quadratic/hermitian forms are not preserved.
 """
 function biproduct(x::Vector{ZZLat}; cached::Bool=true)
   W, inj, proj = biproduct(ambient_space.(x); cached)

--- a/src/QuadForm/Spaces.jl
+++ b/src/QuadForm/Spaces.jl
@@ -716,15 +716,19 @@ end
     direct_sum(x::Vector{T}) where T <: AbstractSpace -> T, Vector{AbstractSpaceMor}
 
 Given a collection of quadratic or hermitian spaces $V_1, \ldots, V_n$,
-return their direct sum $V := V_1 \oplus \ldots \oplus V_n$,
+return their direct sum $V := V_1 \oplus \ldots \oplus V_n$ as vector spaces,
 together with the injections $V_i \to V$.
 
-For objects of type `AbstractSpace`, finite direct sums and finite direct
-products agree and they are therefore called biproducts.
+For vector spaces, finite direct sums and finite direct products agree and
+they are therefore called biproducts.
 If one wants to obtain `V` as a direct product with the projections $V \to V_i$,
 one should call `direct_product(x)`.
 If one wants to obtain `V` as a biproduct with the injections $V_i \to V$ and
 the projections $V \to V_i$, one should call `biproduct(x)`.
+
+!!! warning
+    The projections $V\to V_i$ are linear but do not define morphisms of
+    quadratic/hermitian spaces, since the associated forms are not preserved.
 """
 function direct_sum(x::Vector{T}; cached::Bool=true) where T <: AbstractSpace
   V, inj, = _biproduct(x; cached)
@@ -738,15 +742,19 @@ direct_sum(x::Vararg{AbstractSpace}; cached::Bool=true) = direct_sum(collect(x);
     direct_product(x::Vector{T}) where T <: AbstractSpace -> T, Vector{AbstractSpaceMor}
 
 Given a collection of quadratic or hermitian spaces $V_1, \ldots, V_n$,
-return their direct product $V := V_1 \times \ldots \times V_n$,
+return their direct product $V := V_1 \times \ldots \times V_n$ as vector spaces,
 together with the projections $V \to V_i$.
 
-For objects of type `AbstractSpace`, finite direct sums and finite direct
-products agree and they are therefore called biproducts.
+For vector spaces, finite direct sums and finite direct products agree and
+they are therefore called biproducts.
 If one wants to obtain `V` as a direct sum with the injections $V_i \to V$,
 one should call `direct_sum(x)`.
 If one wants to obtain `V` as a biproduct with the injections $V_i \to V$ and
 the projections $V \to V_i$, one should call `biproduct(x)`.
+
+!!! warning
+    The projections $V\to V_i$ are linear but do not define morphisms of
+    quadratic/hermitian spaces, since the associated forms are not preserved.
 """
 function direct_product(x::Vector{T};cached::Bool=true) where T <: AbstractSpace
   V, _, proj = _biproduct(x; cached)
@@ -760,15 +768,19 @@ direct_product(x::Vararg{AbstractSpace}; cached::Bool=true) = direct_product(col
     biproduct(x::Vector{T}) where T <: AbstractSpace -> T, Vector{AbstractSpaceMor}, Vector{AbstractSpaceMor}
 
 Given a collection of quadratic or hermitian spaces $V_1, \ldots, V_n$,
-return their biproduct $V := V_1 \oplus \ldots \oplus V_n$, together
-with the injections $V_i \to V$ and the projections $V \to V_i$.
+return their biproduct $V := V_1 \oplus \ldots \oplus V_n$ as vector spaces,
+together with the injections $V_i \to V$ and the projections $V \to V_i$.
 
-For objects of type `AbstractSpace`, finite direct sums and finite direct
-products agree and they are therefore called biproducts.
+For vector spaces, finite direct sums and finite direct products agree and
+they are therefore called biproducts.
 If one wants to obtain `V` as a direct sum with the injections $V_i \to V$,
 one should call `direct_sum(x)`.
 If one wants to obtain `V` as a direct product with the projections $V \to V_i$,
 one should call `direct_product(x)`.
+
+!!! warning
+    The projections $V\to V_i$ are linear but do not define morphisms of
+    quadratic/hermitian spaces, since the associated forms are not preserved.
 """
 function biproduct(x::Vector{T}; cached::Bool=true) where T <: AbstractSpace
   return _biproduct(x; cached)

--- a/src/QuadForm/Torsion.jl
+++ b/src/QuadForm/Torsion.jl
@@ -2145,15 +2145,19 @@ end
     direct_sum(x::Vector{TorQuadModule}) -> TorQuadModule, Vector{TorQuadModuleMap}
 
 Given a collection of torsion quadratic modules $T_1, \ldots, T_n$, return
-their direct sum $T := T_1\oplus \ldots \oplus T_n$, together with the
-injections $T_i \to T$.
+their direct sum $T := T_1\oplus \ldots \oplus T_n$ as finite abelian groups,
+together with the injections $T_i \to T$.
 
-For objects of type `TorQuadModule`, finite direct sums and finite direct products
-agree and they are therefore called biproducts.
+For abelian groups, finite direct sums and finite direct products agree and
+they are therefore called biproducts.
 If one wants to obtain `T` as a direct product with the projections $T \to T_i$,
 one should call `direct_product(x)`.
 If one wants to obtain `T` as a biproduct with the injections $T_i \to T$ and the
 projections $T \to T_i$, one should call `biproduct(x)`.
+
+!!! warning
+    The projections $T\to T_i$ are group homomomorphisms but do not define
+    morphisms of torsion quadratic modules.
 """
 function direct_sum(x::Vector{TorQuadModule};cached=false)
   T, inj, = _biproduct(x, proj=false; cached)
@@ -2167,15 +2171,19 @@ direct_sum(x::Vararg{TorQuadModule};cached=false) = direct_sum(collect(x);cached
     direct_product(x::Vector{TorQuadModule}) -> TorQuadModule, Vector{TorQuadModuleMap}
 
 Given a collection of torsion quadratic modules $T_1, \ldots, T_n$, return
-their direct product $T := T_1\times \ldots \times T_n$, together with the
-projections $T \to T_i$.
+their direct product $T := T_1\times \ldots \times T_n$ as abelian groups,
+together with the projections $T \to T_i$.
 
-For objects of type `TorQuadModule`, finite direct sums and finite direct products
-agree and they are therefore called biproducts.
+For abelian groups, finite direct sums and finite direct products agree and
+they are therefore called biproducts.
 If one wants to obtain `T` as a direct sum with the inctions $T_i \to T$,
 one should call `direct_sum(x)`.
 If one wants to obtain `T` as a biproduct with the injections $T_i \to T$ and the
 projections $T \to T_i$, one should call `biproduct(x)`.
+
+!!! warning
+    The projections $T\to T_i$ are group homomomorphisms but do not define
+    morphisms of torsion quadratic modules.
 """
 function direct_product(x::Vector{TorQuadModule};cached=false)
   T, _, proj = _biproduct(x; cached)
@@ -2189,15 +2197,19 @@ direct_product(x::Vararg{TorQuadModule};cached=false) = direct_product(collect(x
     biproduct(x::Vector{TorQuadModule}) -> TorQuadModule, Vector{TorQuadModuleMap}, Vector{TorQuadModuleMap}
 
 Given a collection of torsion quadratic modules $T_1, \ldots, T_n$, return
-their biproduct $T := T_1\oplus \ldots \oplus T_n$, together with the
-injections $T_i \to T$ and the projections $T \to T_i$.
+their biproduct $T := T_1\oplus \ldots \oplus T_n$ as abelian groups, together
+with the injections $T_i \to T$ and the projections $T \to T_i$.
 
-For objects of type `TorQuadModule`, finite direct sums and finite direct products
-agree and they are therefore called biproducts.
+For abelian groups, finite direct sums and finite direct products agree and
+they are therefore called biproducts.
 If one wants to obtain `T` as a direct sum with the inctions $T_i \to T$,
 one should call `direct_sum(x)`.
 If one wants to obtain `T` as a direct product with the projections $T \to T_i$,
 one should call `direct_product(x)`.
+
+!!! warning
+    The projections $T\to T_i$ are group homomomorphisms but do not define
+    morphisms of torsion quadratic modules.
 """
 function biproduct(x::Vector{TorQuadModule};cached=false)
   return _biproduct(x;cached)


### PR DESCRIPTION
When I changed the `direct_sum`, `direct_product` and `biproduct` few years ago, the documentation I wrote was actually incorrect. I think there should be a plan of reworking the entire direct sum infrastructure. Waiting for that, I thought it would be nice to at least make the documentation of these functions more mathematically correct.