### PR TITLE
Implemented point counting for elliptic curves in characteristic 3.

### DIFF
--- a/test/EllCrv/Finite.jl
+++ b/test/EllCrv/Finite.jl
@@ -105,38 +105,45 @@
 
   @testset "Point counting for ordinary curves in characteristic 2 (Subfield Curves)" begin
     _, X = polynomial_ring(GF(2), "X")
-    R,t = finite_field(X^32 + X^15 + X^9 + X^7 + X^4 + X^3 + 1, "t") # conway polynomial
+    R,t = finite_field(X^32 + X^15 + X^9 + X^7 + X^4 + X^3 + 1, "t") # Conway polynomial
     # alpha is a generator of an F_4 subfield
     alpha = t^30 + t^29 + t^24 + t^21 + t^20 + t^19 + t^18 + t^17 + t^14 + t^9 + t^8 + t^6 + t^5 + t^4 + t^3 + t+ 1
     E = elliptic_curve(R, [1,0,0,0,alpha])
     @test 4295048640 == @inferred Hecke._order_ordinary_char2(E)
 
-    E = elliptic_curve(GF(2,50), [1,0,0,0,1])
+    E = elliptic_curve(GF(2, 50), [1,0,0,0,1])
     @test 1125899954494568 == @inferred Hecke._order_ordinary_char2(E)
 
-    E = elliptic_curve(GF(2,100), [1,0,0,0,1])
+    E = elliptic_curve(GF(2, 100), [1,0,0,0,1])
     @test ZZ("1267650600228229382588845215376") == @inferred Hecke._order_ordinary_char2(E)
 
-    E = elliptic_curve(GF(2,150), [1,0,0,0,1])
+    E = elliptic_curve(GF(2, 150), [1,0,0,0,1])
     @test ZZ("1427247692705959881058233219127481757976150136") == @inferred Hecke._order_ordinary_char2(E)
 
-    E = elliptic_curve(GF(2,200), [1,0,0,0,1])
+    E = elliptic_curve(GF(2, 200), [1,0,0,0,1])
     @test ZZ("1606938044258990275541962092343697546215565682541130425732128") == @inferred Hecke._order_ordinary_char2(E)
+
+    # test the coordinates transform
+    # y^2 + xy + t*y = x^3 + t^2*x^2 + t^2*x + t, where t is the generator for F_16
+    # j-invariant is 1
+    R, t = finite_field(2, 4)
+    E = elliptic_curve(R, [1, t^2, t, t^2, t])
+    @test 16 == @inferred Hecke._order_ordinary_char2(E)
   end
 
-  @testset "AGM (Large Exponent)" begin
+  @testset "AGM in characteristic 2 (Large Exponent)" begin
     function test_agm_subfield(d, N)
       RB,x = finite_field(2, d, "X")
       q = 2^d
 
-      t_1 = Hecke._trace_frobenius_char2_agm(x);
+      t_1 = Hecke._trace_of_frobenius_char2_agm(x)
       t_prev = 2; t_cur = t_1
       for n in 2:N
         t_cur, t_prev = t_1*t_cur - q*t_prev, t_cur
 
         R,_ = finite_field(2, d*n, "Y")
         z = embed(RB, R)(x)
-        t = Hecke._trace_frobenius_char2_agm(z);
+        t = Hecke._trace_of_frobenius_char2_agm(z)
 
         if t != t_cur
           println("Wrong frobenius trace for $z over $R ($x over $RB)")
@@ -147,25 +154,25 @@
       return true
     end
 
-    # check the comment in _trace_frobenius_char2_agm
+    # check the comment in _trace_of_frobenius_char2_agm
     # we cannot go past the exponent 92 currently
     @test test_agm_subfield(3, 30)
     @test test_agm_subfield(4, 20)
     @test test_agm_subfield(5, 15)
   end
 
-  @testset "AGM (Exhaustive d=3..6)" begin
-    # do a bruteforce enumeration: for a fixed exponent d, enumerate all (non-zero) a_6
-    # compare _trace_frobenius_char2_agm to the trace computed from order_via_exhaustive_search
+  @testset "AGM in characteristic 2 (Exhaustive d=3..6)" begin
+    # do a brute-force enumeration: for a fixed exponent d, enumerate all (non-zero) a_6
+    # compare _trace_of_frobenius_char2_agm to the trace computed from order_via_exhaustive_search
     # note that the order_via_exhaustive_search is pretty slow, so we limit ourselves in the range of d
     function test_agm_exhaustive(max_degree)::Bool
       for d in 3:max_degree
         R = GF(2, d, "t")
         q = order(R)
         for a6 in R
-          if a6^4 == a6 continue end
+          a6^4 == a6 && continue
           E = elliptic_curve(R, [1,0,0,0,a6])
-          if q + 1 - Hecke._trace_frobenius_char2_agm(a6) != Hecke.order_via_exhaustive_search(E)
+          if q + 1 - Hecke._trace_of_frobenius_char2_agm(a6) != Hecke.order_via_exhaustive_search(E)
             println("Wrong point count for ordinary curve $E over $R")
             return false
           end
@@ -178,14 +185,14 @@
   end
 
   @testset "Point counting for ordinary curves in characteristic 2 (Exhaustive d=1..6)" begin
-    # do a bruteforce enumeration: for a fixed exponent d, enumerate all (non-zero) a_6
+    # do a brute-force enumeration: for a fixed exponent d, enumerate all a_2 and non-zero a_6
     # compare _order_ordinary_char2 to order_via_exhaustive_search
     # note that the order_via_exhaustive_search is pretty slow, so we need to limit ourselves in the range of d
     function test_ordinary_exhaustive(max_degree)::Bool
       for d in 1:max_degree
         R = GF(2, d, "t")
         for a6 in R
-          if iszero(a6) continue end
+          iszero(a6) && continue
           for a2 in R
             E = elliptic_curve(R, [1,a2,0,0,a6])
             if Hecke._order_ordinary_char2(E) != Hecke.order_via_exhaustive_search(E)
@@ -258,7 +265,7 @@
   end
 
   @testset "Point counting for supersingular curves in characteristic 2 (Exhaustive d=1..4)" begin
-    # do a bruteforce enumeration: for a fixed exponent d, enumerate all a_3,a_4,a_6 with a_3 non-zero
+    # do a brute-force enumeration: for a fixed exponent d, enumerate all a_3,a_4,a_6 with a_3 non-zero
     # compare _order_supersingular_char2 to order_via_exhaustive_search
     # note that the order_via_exhaustive_search is pretty slow, so we need to limit ourselves in the range of d
     function test_supersingular_exhaustive(max_degree)::Bool
@@ -270,6 +277,169 @@
           for (a4, a6) in Iterators.product(R, R)
             E = elliptic_curve(R, [0,0,a3,a4,a6])
             if Hecke._order_supersingular_char2(E) != Hecke.order_via_exhaustive_search(E)
+              println("Wrong point count for supersingular curve $E over $R")
+              return false
+            end
+          end
+        end
+      end
+      return true
+    end
+
+    @test test_supersingular_exhaustive(4)
+  end
+
+  @testset "Point counting for ordinary curves in characteristic 3 (Subfield Curves)" begin
+    _, X = polynomial_ring(GF(3), "X")
+    R,t = finite_field(X^32 + 2*X^12 + 2*X^11 + 2*X^6 + X^5 + 2*X^4 + X^3 + X + 2 , "t") # Conway polynomial
+    # alpha is a generator of an F_9 subfield
+    alpha = t^31 + t^29 + t^28 + t^27 + t^26 + 2*t^23 + t^22 + t^21 + 2*t^20 + 2*t^19 + 2*t^17 + t^16 + t^14 + 2*t^11 + t^10 + t^8 + t^7 + t^6 + t^5 + 2*t^4 + t^2 + t
+    E = elliptic_curve(R, [0,-1,0,0,R(1)/alpha])
+    @test ZZ("1853020134712320") == @inferred Hecke._order_ordinary_char3(E)
+
+    E = elliptic_curve(GF(3, 50), [0,-1,0,0,1])
+    @test ZZ("717897987691032781755375") == @inferred Hecke._order_ordinary_char3(E)
+
+    E = elliptic_curve(GF(3, 50), [0,-1,0,0,-1])
+    @test ZZ("717897987693209835025932") == @inferred Hecke._order_ordinary_char3(E)
+
+    # test the coordinates transform
+    # y^2 + 2*t*xy + 2*t*y = x^3 + (2*t^2+1)*x^2 + (t^2+2t)*x + (t^3+2), where t is the generator for F_81
+    # j-invariant is 1
+    R, t = finite_field(3, 4)
+    E = elliptic_curve(R, [2*t, 2*t^2+1 ,2*t, t^2+2*t, t^3+2])
+    @test 75 == @inferred Hecke._order_ordinary_char3(E)
+  end
+
+  @testset "AGM in characteristic 3 (Large Exponent)" begin
+    function test_agm_subfield(d, N)
+      RB,x = finite_field(3, d, "X")
+      q = 3^d
+
+      t_1 = Hecke._trace_of_frobenius_char3_agm(x)
+      t_prev = 2; t_cur = t_1
+      for n in 2:N
+        t_cur, t_prev = t_1*t_cur - q*t_prev, t_cur
+
+        R,_ = finite_field(3, d*n, "Y")
+        z = embed(RB, R)(x)
+        t = Hecke._trace_of_frobenius_char3_agm(z)
+
+        if t != t_cur
+          println("Wrong frobenius trace for $z over $R ($x over $RB)")
+          return false
+        end
+      end
+
+      return true
+    end
+
+    # check the comment in _trace_of_frobenius_char3_agm
+    # we cannot go past the exponent 58 currently
+    @test test_agm_subfield(3, 18)
+    @test test_agm_subfield(4, 12)
+    @test test_agm_subfield(5, 10)
+  end
+
+  @testset "AGM in characteristic 3 (Exhaustive d=3..6)" begin
+    # do a brute-force enumeration: for a fixed exponent d, enumerate all (non-zero) a_6
+    # compare _trace_of_frobenius_char3_agm to the trace computed from order_via_exhaustive_search
+    # note that the order_via_exhaustive_search is pretty slow, so we limit ourselves in the range of d
+    function test_agm_exhaustive(max_degree)::Bool
+      for d in 3:max_degree
+        R = GF(3, d, "t")
+        q = order(R)
+        for a6 in R
+          a6^9 == a6 && continue
+          E = elliptic_curve(R, [0,1,0,0,a6])
+          if q + 1 - Hecke._trace_of_frobenius_char3_agm(-inv(a6)) != Hecke.order_via_exhaustive_search(E)
+            println("Wrong point count for ordinary curve $E over $R")
+            return false
+          end
+        end
+      end
+      return true
+    end
+
+    @test test_agm_exhaustive(6)
+  end
+
+  @testset "Point counting for supersingular curves in characteristic 3" begin
+    function _order_of(K::Field, a4, a6)::ZZRingElem
+      return Hecke._order_supersingular_char3(elliptic_curve(elem_type(K)[K(0),K(0),K(0),K(a4),K(a6)]))
+    end
+
+    # the representatives of all isogeny classes with small d
+
+    R2, t = finite_field(3, 2)  # d = 2 mod 4
+    # y^2 = x^3 - x + 1     | 1 fourth power: gamma = 1, Tr(1) = -1   | q + 1 - sqrt(q)
+    @test 7 == @inferred _order_of(R2, -1, 1)
+    # y^2 = x^3 - x         | 1 fourth power: gamma = 1, Tr(0) = 0    | q + 1 + 2*sqrt(q)
+    @test 16 == @inferred _order_of(R2, -1, 0)
+    # y^2 = x^3 - t^2*x + 1 | t^2 square: gamma = t, Tr(t^(-3)) = -1  | q + 1 + sqrt(q)
+    @test 13 == @inferred _order_of(R2, -t^2, 1)
+    # y^2 = x^3 - t^2*x     | t^2 square: gamma = t, Tr(0) = 0        | q + 1 - 2*sqrt(q)
+    @test 4 == @inferred _order_of(R2, -t^2, 0)
+    # y^2 = x^3 - t*x       | t not a square                          | q + 1
+    @test 10 == @inferred _order_of(R2, -t, 0)
+
+    R3, t = finite_field(3, 3)  # d = 3 mod 4
+    # y^2 = x^3 - x         | 1 fourth power: gamma = 1, Tr(0) = 0    | q + 1
+    @test 28 == @inferred _order_of(R3, -1, 0)
+    # y^2 = x^3 - x - t^2   | 1 fourth power: gamma = 1, Tr(-t^2) = 1 | q + 1 - sqrt(3*q)
+    @test 19 == @inferred _order_of(R3, -1, -t^2)
+    # y^2 = x^3 - x + t^2   | 1 fourth power: gamma = 1, Tr(t^2) = -1 | q + 1 + sqrt(3*q)
+    @test 37 == @inferred _order_of(R3, -1, t^2)
+    # y^2 = x^3 - t*x       | t not a square                          | q + 1
+    @test 28 == @inferred _order_of(R3, -t, 0)
+
+    R4, t = finite_field(3, 4) # d = 0 mod 4
+    # y^2 = x^3 - x + 1     | 1 fourth power: gamma = 1, Tr(1) = 1    | q + 1 + sqrt(q)
+    @test 91 == @inferred _order_of(R4, -1, 1)
+    # y^2 = x^3 - x         | 1 fourth power: gamma = 1, Tr(0) = 0    | q + 1 - 2*sqrt(q)
+    @test 64 == @inferred _order_of(R4, -1, 0)
+    # y^2 = x^3 - t^2*x + t^4 | t^2 square: gamma = t, Tr(t) = 1      | q + 1 - sqrt(q)
+    @test 73 == @inferred _order_of(R4, -t^2, t^4)
+    # y^2 = x^3 - t^2*x     | t^2 square: gamma = t, Tr(0) = 0        | q + 1 + 2*sqrt(q)
+    @test 100 == @inferred _order_of(R4, -t^2, 0)
+    # y^2 = x^3 - t*x       | t not a square                          | q + 1
+    @test 82 == @inferred _order_of(R4, -t, 0)
+
+    R5, t = finite_field(3, 5)  # d = 1 mod 4
+    # y^2 = x^3 - x         | 1 fourth power: gamma = 1, Tr(0) = 0    | q + 1
+    @test 244 == @inferred _order_of(R5, -1, 0)
+    # y^2 = x^3 - x - 1     | 1 fourth power: gamma = 1, Tr(-1) = 1   | q + 1 + sqrt(3*q)
+    @test 271 == @inferred _order_of(R5, -1, -1)
+    # y^2 = x^3 - x + 1     | 1 fourth power: gamma = 1, Tr(1) = -1   | q + 1 - sqrt(3*q)
+    @test 217 == @inferred _order_of(R5, -1, 1)
+    # y^2 = x^3 - t*x       | t not a square                          | q + 1
+    @test 244 == @inferred _order_of(R5, -t, 0)
+
+    # test the coordinates transform
+    # y^2 + xy = x^3 - x^2 + x + 1
+    E1 = elliptic_curve(R2, [1,-1,0,1,1])
+    @test @inferred Hecke._order_supersingular_char3(E1) == @inferred Hecke.order_via_exhaustive_search(E1)
+    E2 = elliptic_curve(R3, [1,-1,0,1,1])
+    @test @inferred Hecke._order_supersingular_char3(E2) == @inferred Hecke.order_via_exhaustive_search(E2)
+    E3 = elliptic_curve(R4, [1,-1,0,1,1])
+    @test @inferred Hecke._order_supersingular_char3(E3) == @inferred Hecke.order_via_exhaustive_search(E3)
+    E4 = elliptic_curve(R5, [1,-1,0,1,1])
+    @test @inferred Hecke._order_supersingular_char3(E4) == @inferred Hecke.order_via_exhaustive_search(E4)
+  end
+
+  @testset "Point counting for supersingular curves in characteristic 3 (Exhaustive d=1..4)" begin
+    # do a brute-force enumeration: for a fixed exponent d, enumerate all a_4,a_6 with a_4 non-zero
+    # compare _order_supersingular_char3 to order_via_exhaustive_search
+    # note that the order_via_exhaustive_search is pretty slow, so we need to limit ourselves in the range of d
+    function test_supersingular_exhaustive(max_degree)::Bool
+      for d in 1:max_degree
+        R = GF(3, d, "t")
+        for a4 in R
+          iszero(a4) && continue
+
+          for a6 in R
+            E = elliptic_curve(R, [0,0,0,a4,a6])
+            if Hecke._order_supersingular_char3(E) != Hecke.order_via_exhaustive_search(E)
               println("Wrong point count for supersingular curve $E over $R")
               return false
             end


### PR DESCRIPTION
Implemented point counting for elliptic curves in characteristic 3
- supersingular curves are handled through explicit isomorphism class computation (see http://arxiv.org/abs/2601.21756)
- the case of j in F_9 is handled via "Subfield Curve" approach; for j in F_3 we have explicit formulae, otherwise we use the embedding of F_9 into F_q to get the isomorphic curve defined over F_9
- otherwise we use AGM method from "An AGM-Type Elliptic Curve Point Counting Algorithm in Characteristic Three" by Gustavsen and Ranestad.

Also includes some style changes in point counting in characteristic 2, some extra tests, and some refactoring