### PR TITLE
Some improvments to AGM algorithms for point counting

### DIFF
--- a/src/EllCrv/FinitePointCount.jl
+++ b/src/EllCrv/FinitePointCount.jl
@@ -689,8 +689,11 @@ end
 #
 ################################################################################
 
-# TODO: This should probably be part of Nemo, where we can do things more efficiently
-#   by working with padic_poly coefficients directly (instead of going through p-adic "coefficients")
+# NOTE: residue_field(R) creates a non-cached finite field and a map using it.
+#   In our context, the finite field element comes from outside, and although we
+#   create a qadic_field with the same residue field, the field objects differ,
+#   causing preimage(f::MapFromFunc, y) to fail its assertions.
+#   Thus we lift from the residue field to the qadic field manually.
 function _qadic_from_residue_element(R::QadicField, x::T; precision::Int=precision(R)) where T <: FinFieldElem
   z = R(precision=precision)
   for i in 0:degree(R)-1
@@ -862,7 +865,7 @@ function _trace_of_frobenius_char2_agm(a6::T) where T <: FinFieldElem
   # WARNING: FLINT pr: https://github.com/flintlib/flint/pull/2550
   # WARNING: for now we err for the exponent bigger than 91 (flint limit)
   d >= 92 && error("Currently exponents above 91 are not supported")
-  Qq,_ = qadic_field(2, d, precision=N)
+  Qq,_ = qadic_field(2, d, precision=N, cached=false)
 
   # TODO: we should implement a lift from F_q to Q_q (in Nemo) directly
   # TODO: instead of going through full padic coefficients
@@ -1052,8 +1055,8 @@ function _trace_of_frobenius_char3_agm(j::T) where T <: FinFieldElem
   # WARNING: FLINT pr: https://github.com/flintlib/flint/pull/2550
   # WARNING: for now we err for the exponent bigger than 57 (flint limit)
   d >= 58 && error("Currently exponents above 57 are not supported")
-  Q = qadic_field(3, d, precision=N)[1]
-  z = polynomial_ring(Q, "z")[2]
+  Q = qadic_field(3, d, precision=N, cached=false)[1]
+  z = polynomial_ring(Q, "z", cached=false)[2]
 
   # we are solving (z + 6)^3 − (z^2 + 3*z + 9)*D_k^3 = 0
   # j(E_{D_k}) = j(\mathcal{E}^k) mod 3^{k+1}

--- a/src/LocalField/Conjugates.jl
+++ b/src/LocalField/Conjugates.jl
@@ -1,10 +1,10 @@
 #XXX: valuation(Q(0)) == 0 !!!!!
 
-# silently assumes that f \in Z_q[X]
-# silently assumes that the lift is possible, that is v_p(f(r)) > 2*v_p(f'(r))
-#   see "Handbook of Elliptic and Hyperelliptic Curve Cryptography", lemma 12.8
-# since we assume the test for Newton Lift precondition to be done by the caller
-#   the derivative was already computed, so we can take it as an input argument
+# Assumes f has integral coefficients (i.e., f in Z_q[X])
+# Assumes the lift is possible, i.e., v_p(f(r)) > 2*v_p(f'(r));
+#   see "Handbook of Elliptic and Hyperelliptic Curve Cryptography", Lemma 12.8.
+# Takes the derivative df as input for efficiency (caller typically needs it
+#   anyway to verify the Newton lift precondition).
 function _newton_lift(f::PolyRingElem{QadicFieldElem}, df::PolyRingElem{QadicFieldElem}, r::QadicFieldElem, prec::Int = precision(parent(r)), starting_prec::Int = 2)
   Q = parent(r)
 
@@ -91,8 +91,10 @@ end
 @doc raw"""
     roots(Q::QadicField, f::ZZPolyRingElem; max_roots::Int = degree(f)) -> Vector{QadicFieldElem}
 
-The roots of $f$ in $Q$. Currently only simple roots are supported: that is
-if $f(a)=0$ then $f'(a) \neq 0$.
+The roots of $f$ in $Q$. The current implementation uses Newton lifting from
+the residue field, so only simple roots (in the residue field) are considered:
+a root $r$ in the residue field with $f(r) = 0$ is lifted to a root in $Q$
+only if $f'(r) \neq 0$.
 """
 function roots(Q::QadicField, f::ZZPolyRingElem; max_roots::Int = degree(f))
   k, mk = residue_field(Q)

--- a/test/LocalField/Poly.jl
+++ b/test/LocalField/Poly.jl
@@ -113,17 +113,15 @@
     X = polynomial_ring(ZZ, "X")[2]
     Y = polynomial_ring(Q, "Y")[2]
 
+    R, QtoR = residue_field(Q)
+    a = gen(R)
+
     # For X^4-1 we have 4 roots:
-    # 1, -1, and a^3+a^2+1, -(a^3+a^2+1), where a is the generator of the residue field
+    # 1, -1, and a^3+a^2+1, -(a^3+a^2+1)
     f1 = X^4-1
 
     # lift a^3+a^2+1
-    # TODO: we have _qadic_from_residue_element in src/EllCrv/FinitePointCount.jl
-    # TODO: we should move this to Nemo and use better api
-    z = Q()
-    setcoeff!(z, 3, ZZ(1))
-    setcoeff!(z, 2, ZZ(1))
-    setcoeff!(z, 0, ZZ(1))
+    z = preimage(QtoR, a^3 + a^2 + 1)
 
     z_lift = @inferred newton_lift(f1, z)
     @test is_zero(f1(z_lift))
@@ -132,16 +130,8 @@
     # Now consider (we write with precision 2)
     # sqrt(3*a^2 + a + 1) = a^3 + (1 + 3^1)*a^2 + (1 + 2*3^1)*a + (2 + 2*3^1)
     # Thus, starting from residue field, we may lift a^3 + a^2 + a + 2 as a solution to Y^2 - (a+1)
-    # As above, we write a for the generator of the residue field
-    c = Q()
-    setcoeff!(c, 1, ZZ(1))
-    setcoeff!(c, 0, ZZ(1))
-
-    z = Q()
-    setcoeff!(z, 3, ZZ(1))
-    setcoeff!(z, 2, ZZ(1))
-    setcoeff!(z, 1, ZZ(1))
-    setcoeff!(z, 0, ZZ(2))
+    c = preimage(QtoR, a + 1)
+    z = preimage(QtoR, a^3 + a^2 + a + 2)
 
     f2 = Y^2 - c
     z_lift = @inferred newton_lift(f2, z)


### PR DESCRIPTION
* Updated (qadic) Newton lift to handle polynomials in Z_q[x] directly too
  - renamed the existing implementation to `_newton_lift` and made it use q-adic $f$ and $f'$
  - added comments about implicit assumptions of the implementation (most notably the condition on the valuation of $f'(r)$)
  - `newton_lift` now accepts `f::Union{PolyRingElem{ZZRingElem}, PolyRingElem{QadicFieldElem}}` as input

* Tweaked `roots(Q::QadicField, f::ZZPolyRingElem; max_roots)` 
  - the docstring is now more explicit about simple roots
  - tweaked implementation to *ignore* non-simple roots (since in this case the answer doesn't make any sense and is completely wrong)
  - it now uses `_newton_lift` (the derivative is computed once, and both $f$ and $f'$ are converted to q-adic polynomials once)
  - added some extra tests for both `roots` and `newton_lift` to have as an extra contract for the requirements 

* Tweaked AGM implementation in characteristic 3 to use `newton_lift` with q-adic polynomial
For tests, I have tweaked the implementation to disable Conway polynomial check and to use generator of the residue field as a_6 coefficient (this way, since we cache q-adic fields, I can guarantee that the tests will use the same value)

For q=3^500

before:

```
julia> @time Hecke._trace_of_frobenius_char3_agm(t)
  3.720018 seconds (9.72 M allocations: 1.624 GiB, 0.47% gc time)
```

after:

```
julia> @time Hecke._trace_of_frobenius_char3_agm(t)
  1.218319 seconds (4.01 M allocations: 407.004 MiB, 1.14% gc time)
```

