### PR TITLE
Fixed is_supersingular for elliptic curves

### DIFF
--- a/test/EllCrv/Finite.jl
+++ b/test/EllCrv/Finite.jl
@@ -127,6 +127,40 @@
       @test @inferred is_ordinary(E) == true
     end
 
+    # brute-force check for small primes:
+    # it is trivial to factor supersingular_polynomial, and check all the candidates for j-invariant
+    p = 2
+    for _ in 1:10
+      K = GF(p,2)
+      jss = roots(change_base_ring(K, supersingular_polynomial(p)))
+      for jc in K
+        E = elliptic_curve_from_j_invariant(jc)
+        expected_supersingular = jc in jss
+        @test @inferred is_supersingular(E) == expected_supersingular
+      end
+      p = next_prime(p)
+    end
+
+    K = GF(103)
+    E = elliptic_curve_from_j_invariant(K(24))
+    @test @inferred is_supersingular(E) == true
+
+    K = GF(15485863)
+    @test @inferred !is_supersingular(elliptic_curve_from_j_invariant(K(0)))
+    @test @inferred is_supersingular(elliptic_curve_from_j_invariant(K(1728)))
+
+    K = GF(15485917)
+    @test @inferred !is_supersingular(elliptic_curve_from_j_invariant(K(0)))
+    @test @inferred !is_supersingular(elliptic_curve_from_j_invariant(K(1728)))
+
+    K = GF(15485927)
+    @test @inferred is_supersingular(elliptic_curve_from_j_invariant(K(0)))
+    @test @inferred is_supersingular(elliptic_curve_from_j_invariant(K(1728)))
+
+    K = GF(15485933)
+    @test @inferred is_supersingular(elliptic_curve_from_j_invariant(K(0)))
+    @test @inferred !is_supersingular(elliptic_curve_from_j_invariant(K(1728)))
+
     K = GF(193, 3)
     a = gen(K)
     E = elliptic_curve_from_j_invariant(a)


### PR DESCRIPTION
The Sutherland algorithm used roots() which discards multiplicities, causing is_supersingular to return false for supersingular curves where Phi_2(j, Y) has repeated roots. Fixed by using factor() to count roots with multiplicity.

Fixed embedding of j in F_{p^2}: it was using Native.GF resulting in _embed_into_p2 failing to match embed (plus it was embedding wrong field).

Fixed path length to match Sutherland's paper

Added early-out for j equal to 0 or 1728 (since we then have trivial condition on p)

Added more is_supersingular tests: exhaustive check for first 10 primes enumerating all j candidates from F_{p^2} and comparing is_supersingular result with known supersingular j values (roots of supersingular_polynomial()); quick tests for j=0,1728 against large primes

EDIT: i did a quick check, adding bruteforce test on master:
2246 failed with 
```
MethodError: no method matching embed(::FqField, ::FqPolyRepField)
  The function `embed` exists, but no method is defined for this combination of argument types.

  Closest candidates are:
    embed(::T, ::T) where T<:FinField
     @ Nemo ~/.julia/packages/Nemo/xSaoQ/src/embedding/embedding.jl:365
    embed(::ZZLat, ::ZZGenus)
     @ Hecke ~/math/software/Hecke.jl/src/QuadForm/Quad/ZGenus.jl:2857
    embed(::ZZLat, ::ZZGenus, ::Bool)
     @ Hecke ~/math/software/Hecke.jl/src/QuadForm/Quad/ZGenus.jl:2857
    ...

  Stacktrace:
   [1] _embed_into_p2(j::FqFieldElem, L::FqPolyRepField)
     @ Hecke ~/math/software/Hecke.jl/src/EllCrv/Finite.jl:301
```
this is about "Fixed embedding of j in F_{p^2}"
and after fixing this - 14 failed with returning wrong result for is_supersingular check