### PR TITLE
Remove redundant `quo` methods for `ZZRing` and an integer

### DIFF
--- a/src/Misc/Integer.jl
+++ b/src/Misc/Integer.jl
@@ -584,17 +584,6 @@ function radical(a::T) where {T<:Integer}
   return T(radical(ZZRingElem(a)))
 end
 
-function quo(::ZZRing, a::ZZRingElem)
-  R, f = residue_ring(ZZ, a)
-  return R, f
-end
-
-function quo(::ZZRing, a::Integer)
-  R, f = residue_ring(ZZ, a)
-  return R, f
-end
-
-
 ^(a::AbsNumFieldOrderIdeal, n::IntegerUnion) = Nemo._generic_power(a, n)
 
 #^(a::RelNumFieldOrderIdeal, n::IntegerUnion)  = Nemo._generic_power(a, n)


### PR DESCRIPTION
AbstractAlgebra already defines this generically (and better, as it supports a `cached` argument):

    function quo(R::Ring, a::RingElement; cached::Bool = true)
       S, f = residue_ring(R, a; cached = cached)
       return S, f
    end