### PR TITLE
Rigorous integration along straight lines

### DIFF
--- a/src/RieSrf/PeriodMatrix.jl
+++ b/src/RieSrf/PeriodMatrix.jl
@@ -92,8 +92,10 @@ function big_period_matrix(RS::RiemannSurface)
   bound_temp = Vector{ArbFieldElem}()
   for path in paths
     for subpath in get_subpaths(path)
-      if path_type(subpath) == 0
+      if path_type(subpath) == 0 && RS.integration_method == "rigorous"
         compute_ellipse_bound_rigorous(subpath, dif_basis, int_group_rs, RS)
+      elseif path_type(subpath) == 0 && RS.integration_method == "heuristic"
+        compute_ellipse_bound_heuristic(subpath, embedded_differentials, int_group_rs, RS)
       else 
         compute_ellipse_bound_heuristic(subpath, embedded_differentials, int_group_rs, RS)
       end
@@ -343,7 +345,6 @@ end
 ###  Disney-Hogg, and Wuqian Effie Gao, as presented in https://arxiv.org/pdf/2208.12377. The implementation 
 ###  here is Strategy 1 from this paper.
 function compute_ellipse_bound_rigorous(subpath, dif_basis, int_group_rs, RS)
-
   subpath.integration_scheme_index = length(int_group_rs)
 
   v_start = start_point(subpath)

--- a/src/RieSrf/RiemannSurface.jl
+++ b/src/RieSrf/RiemannSurface.jl
@@ -139,6 +139,10 @@ mutable struct RiemannSurface
   # A list of bounds used duting computations
   bounds::Vector{ArbFieldElem}
 
+  #String specifying the integration method used when integrating differential forms.
+  #The options are "heuristic" and "rigorous". It is set to "heuristic" by default
+  integration_method::String
+
   #A collection of fields and error bounds needed to ensure correctness
   #TODO: Check which ones are actually used and necessary. Optimize this.
   prec::Int
@@ -153,13 +157,13 @@ mutable struct RiemannSurface
 
   #The constructor for a Riemann surface object
 
-  function RiemannSurface(f::MPolyRingElem, v::T, prec = 100) where T<:Union{PosInf, InfPlc}
-    RS = RiemannSurface(f, prec)
+  function RiemannSurface(f::MPolyRingElem, v::T, prec = 100; integration_method::String = "rigorous") where T<:Union{PosInf, InfPlc}
+    RS = RiemannSurface(f, prec, integration_method)
     RS.embedding = v
     return RS
   end
 
-  function RiemannSurface(f::MPolyRingElem, prec = 100)
+  function RiemannSurface(f::MPolyRingElem, prec = 100; integration_method::String = "rigorous")
 
     k = base_ring(f)
     kx, x = rational_function_field(k, "x")
@@ -189,6 +193,10 @@ mutable struct RiemannSurface
     RS.basis_of_differentials = diff_base
     g = length(diff_base)
     RS.genus = g
+    if integration_method != "heuristic" && integration_method != "rigorous"
+      error("invalid integration method. Valid options are \"rigorous\" or \"heuristic\"")
+    end
+    RS.integration_method = integration_method
 
     mpoly_kxy = parent(f)
     mpoly_x, mpol_y = gens(mpoly_kxy)

--- a/test/RieSrf/RiemannSurface.jl
+++ b/test/RieSrf/RiemannSurface.jl
@@ -33,6 +33,6 @@
   small_period_matrix(RS)
 
   f = x^8 + 2 * x^7 + 2 * x^6 + x^5 - 10 * x + 1 + x^3 * y^2 - y^3 + 2 * y^8
-  RS = RiemannSurface(f)
+  RS = RiemannSurface(f, integration_method = "heuristic")
   small_period_matrix(RS)
 end


### PR DESCRIPTION
For straight lines, added a function which computes a rigorous bound for integrands on ellipses. Previously this was heuristic. The computation of this bound is based on [https://arxiv.org/pdf/2208.12377](url) .