### PR TITLE
Make multivariate evaluation more explicit

### DIFF
--- a/src/EllCrv/Isogeny.jl
+++ b/src/EllCrv/Isogeny.jl
@@ -349,7 +349,9 @@ function push_through_isogeny(f::Isogeny, v::RingElem)
   pol1 = phi(x) - psi_sq(x)*y
   pol2 = v(x)
   L = factor(resultant(pol1, pol2, 1))
-  return prod([f for (f,e) in L], init = one(Rxy))(0,gen(parent(phi)))
+  sf_pol = prod([f for (f,e) in L], init = one(Rxy))
+  S = parent(phi)
+  return evaluate(sf_pol, elem_type(S)[zero(S),gen(S)])
 end
 
 #TODO Need check that we don't need to compose with an automorphism to get the actual dual. Currently we will get the dual up


### PR DESCRIPTION
In order to get https://github.com/Nemocas/Nemo.jl/pull/2182 and https://github.com/Nemocas/AbstractAlgebra.jl/pull/2364 in a mergeable state, some multivariate evaluation calls need to be adjusted. This is the first I found in Hecke. I'll adjust this PR if I find more.