### PR TITLE
Ellcrv: rewrite BSGS

### DIFF
--- a/src/EllCrv/Finite.jl
+++ b/src/EllCrv/Finite.jl
@@ -69,7 +69,20 @@ end
 #
 ################################################################################
 
-# section 4.3.4
+function _point_order_from_multiple(P::EllipticCurvePoint{<:FinFieldElem}, M::ZZRingElem, facM::Fac{ZZRingElem})
+  ord = ZZ(1)
+
+  for (p, e) in facM
+    Q = divexact(M, p^e)*P
+    while !is_infinite(Q)
+      ord *= p
+      Q = p * Q
+    end
+  end
+
+  return ord
+end
+
 @doc raw"""
     elem_order_bsgs(P::EllipticCurvePoint) -> ZZRingElem
 
@@ -77,88 +90,65 @@ Calculate the order of a point $P$ on an elliptic curve given over a finite
 field using Baby-step Giant-step (BSGS).
 """
 function elem_order_bsgs(P::EllipticCurvePoint{T}) where T<:FinFieldElem
-  R = base_field(P.parent)
+  is_infinite(P) && return ZZ(1)
+
+  R = base_field(parent(P))
   p = characteristic(R)
   p == 0 && error("Base field must be finite")
-  q = order(R) # R = F_q
 
-  # step 1
-  Q = Int(q + 1) * P
+  q = order(R)
+  d = degree(R)
 
-  # step 2
-  m = Int(ceil(Int(q)^(1//4)))
+  # Q is at the center of Hasse Interval
+  # |E| = q + 1 - t, so Q = [t]P
+  Q = (q + 1)*P
 
-  list_points = []
-  for j = 0:m
-    S = j*P
-    push!(list_points, S)
+  # m = ceil(q^{1/4})
+  # we will use stride of 2m for giant steps. Let H = [2m]P
+  # for a giant step k in [-m, m] we check Q + [k]H = +- [j]P for j = 0..m
+  #   that is: if t = +-j - 2mk
+  # each such window is of length 2m + 1: consecutive windows overlap at one value
+  # in total we check 4m^2 values: we need 4*m^2 >= 4*sqrt(q)
+  m_zz = isqrt(isqrt(q))
+  if mod(d, 4) != 0 # if q is not a 4-th power, we need to update m for ceiling
+    m_zz += 1
   end
 
-  # step 3
-  k = -m
-  H = (2*m)*P
-  M = ZZ(0) # initialize M, so that it is known after the while loop
+  # we need to allocate m baby steps, if m doesn't fit into Int we have no chance to do so
+  !fits(Int, m_zz) && error("Elliptic curve group order is too large for BSGS")
+  m = Int(m_zz)
 
-  while k < m + 1
-    Snew = Q + (k*H)
-
-    i = 1
-    while i < m + 2 # is there a match?
-      if Snew == list_points[i]
-        M = q + 1 + (2*m*k) - (i-1)
-
-        if M != 0
-          i = m + 2 # leave both while loops
-          k = m + 1
-        else
-          i = i + 1 # search on if M == 0
-        end
-
-      elseif Snew == -(list_points[i])
-        M = q + 1 + (2*m*k) + (i-1) # step 4
-
-        if M != 0
-          i = m + 2 # leave both while loops
-          k = m + 1
-        else
-          i = i + 1 # search on if M == 0
-        end
-      else
-        i = i + 1
-      end
-    end
-
-    k = k + 1
+  # Baby steps: j*P for j = 0..m
+  baby = Dict{typeof(P), Int}()
+  S = infinity(parent(P))
+  for j in 0:m
+    baby[S] = j
+    S = S + P
   end
 
-  # step 5
-  gotostep5 = true
-  while gotostep5
-    fac = factor(M)
-    primefactors = []
-    for i in fac
-      push!(primefactors, i[1])
-    end
-    r = length(primefactors)
+  # Giant steps: we use stride H = (2m)*P, and check if Q + [k]H is a baby step
+  stride = 2*m_zz
+  H = stride*P
+  M = ZZ(0)
 
-    # step 6
-    i = 1
-    while i < (r + 1)
-      U = Int(divexact(M, primefactors[i]))*P
-      if U.is_infinite == true
-        M = divexact(M, primefactors[i])
-        i = r + 2  # leave while-loop
-      else
-        i = i + 1
-      end
+  for k in -m:m
+    Snew = Q + k*H
+
+    j = get(baby, Snew, -1)
+    if j >= 0
+      M = q + 1 + stride*k - j
+      !is_zero(M) && break # non-trivial multiple of order
     end
 
-    if i == r + 1  # then (M/p_i)P != oo for all i
-      gotostep5 = false
+    j = get(baby, -Snew, -1)
+    if j >= 0
+      M = q + 1 + stride*k + j
+      !is_zero(M) && break # non-trivial multiple of order
     end
   end
 
-  return abs(ZZ(M))
+  @assert !is_zero(M) "BSGS failed to find a multiple of the order"
+  return _point_order_from_multiple(P, M, factor(M))
 end
 
 @doc raw"""
@@ -188,31 +178,18 @@ julia> order(P, fac)
 ```
 """
 function order(P::EllipticCurvePoint{T}) where T<:FinFieldElem
+  # TODO: should we maybe check if order was factored already?
+  #   in this case _point_order_from_multiple should be faster
   return elem_order_bsgs(P)
 end
 
 function order(P::EllipticCurvePoint{T}, fac::Fac{ZZRingElem}) where T<:FinFieldElem
-  return _order_elem_via_fac(P, fac)
+  return _point_order_from_multiple(P, evaluate(fac), fac)
 end
 
-function _order_elem_via_fac(P::EllipticCurvePoint{<:FinFieldElem}, fn = _order_factored(parent(P)))
+function _order_elem_via_fac(P::EllipticCurvePoint{<:FinFieldElem})
   E = parent(P)
-  n = order(E)
-  o = one(ZZ)
-  for (p, e) in fn
-    q = p^e
-    m = divexact(n, q)
-    Q = m*P # order dividing q = p^e
-    for i in 0:e
-      if is_infinite(Q)
-        break
-      else
-        o = o * p
-        Q = p * Q
-      end
-    end
-  end
-  return o
+  return _point_order_from_multiple(P, order(E), _order_factored(E))
 end
 
 ################################################################################

--- a/src/EllCrv/Finite.jl
+++ b/src/EllCrv/Finite.jl
@@ -83,40 +83,53 @@ function _point_order_from_multiple(P::EllipticCurvePoint{<:FinFieldElem}, M::ZZ
   return ord
 end
 
-@doc raw"""
-    elem_order_bsgs(P::EllipticCurvePoint) -> ZZRingElem
+# d is known divisor of the *group* order
+function _point_order_bsgs(P_in::EllipticCurvePoint{<:FinFieldElem}, d::ZZRingElem)
+  is_infinite(P_in) && return ZZ(1)
 
-Calculate the order of a point $P$ on an elliptic curve given over a finite
-field using Baby-step Giant-step (BSGS).
-"""
-function elem_order_bsgs(P::EllipticCurvePoint{T}) where T<:FinFieldElem
-  is_infinite(P) && return ZZ(1)
-
-  R = base_field(parent(P))
+  R = base_field(parent(P_in))
   p = characteristic(R)
   p == 0 && error("Base field must be finite")
-
   q = order(R)
-  d = degree(R)
 
-  # Q is at the center of Hasse Interval
-  # |E| = q + 1 - t, so Q = [t]P
-  Q = (q + 1)*P
-
-  # m = ceil(q^{1/4})
-  # we will use stride of 2m for giant steps. Let H = [2m]P
-  # for a giant step k in [-m, m] we check Q + [k]H = +- [j]P for j = 0..m
-  #   that is: if t = +-j - 2mk
-  # each such window is of length 2m + 1: consecutive windows overlap at one value
-  # in total we check 4m^2 values: we need 4*m^2 >= 4*sqrt(q)
-  m_zz = isqrt(isqrt(q))
-  if mod(d, 4) != 0 # if q is not a 4-th power, we need to update m for ceiling
-    m_zz += 1
+  # Initially we have Hasse interval, which is centered at q+1
+  # We set m = ceil(q^{1/4}) (half of the square root of interval length)
+  #   and use stride 2m for giant steps
+  # |E| = q + 1 - t, so the center is Q = [q+1]P = [t]P
+  # Let H = [2m]P
+  # Baby steps: we compute [j]P for j = 0..m
+  # Giant steps: for k = -m..m check if Q + [k]H is +- [j]P
+  # Note that we check both plus and minus, effectively having 2m+1 baby steps
+  # So for a giant step k we check if t = +-j - 2m*k
+  # Each such window is of length 2m + 1: consecutive windows overlap at one value
+  # and in total we check 4m^2 values: we need 4*m^2 >= 4*sqrt(q)
+  #
+  # If a divisor d of group order is known, we can further optimize search:
+  #   we consider [d]P instead: its order divides |E|/d
+  # Thus we can shrink our search interval:
+  # [L, R] -> [floor(L/d), ceil(R/d)]
+  # We still want to have a centered search:
+  #   center = (q+1)/d, and Q = center * [d]P
+  # Half-width of original interval is bounded by 2*floor(sqrt(q)) + 2
+  # After scaling by d, it is bound by 1 + (2*floor(sqrt(q)) + 2) / d
+  # This gives us a bound for m^2
+  local P, center, m_zz
+  if d > 1
+    P = d*P_in
+    is_infinite(P) && return _point_order_from_multiple(P_in, d, factor(d))
+    center = div(q + 1, d)
+    m_zz = 1 + isqrt(1 + div(2*isqrt(q) + 2, d))
+  else
+    P = P_in
+    center = q + 1
+    m_zz = 1 + isqrt(isqrt(q))
   end
 
   # we need to allocate m baby steps, if m doesn't fit into Int we have no chance to do so
   !fits(Int, m_zz) && error("Elliptic curve group order is too large for BSGS")
   m = Int(m_zz)
+
+  Q = center*P
 
   # Baby steps: j*P for j = 0..m
   baby = Dict{typeof(P), Int}()
@@ -136,19 +149,34 @@ function elem_order_bsgs(P::EllipticCurvePoint{T}) where T<:FinFieldElem
 
     j = get(baby, Snew, -1)
     if j >= 0
-      M = q + 1 + stride*k - j
+      M = center + stride*k - j
       !is_zero(M) && break # non-trivial multiple of order
     end
 
     j = get(baby, -Snew, -1)
     if j >= 0
-      M = q + 1 + stride*k + j
+      M = center + stride*k + j
       !is_zero(M) && break # non-trivial multiple of order
     end
   end
 
   @assert !is_zero(M) "BSGS failed to find a multiple of the order"
-  return _point_order_from_multiple(P, M, factor(M))
+
+  # TODO: we should combine factorizations
+  if d > 1
+    M = M*d
+  end
+  return _point_order_from_multiple(P_in, M, factor(M))
+end
+
+@doc raw"""
+    elem_order_bsgs(P::EllipticCurvePoint) -> ZZRingElem
+
+Calculate the order of a point $P$ on an elliptic curve given over a finite
+field using Baby-step Giant-step (BSGS).
+"""
+function elem_order_bsgs(P::EllipticCurvePoint{T}) where T<:FinFieldElem
+  return _point_order_bsgs(P, ZZ(1))
 end
 
 @doc raw"""

--- a/src/EllCrv/FinitePointCount.jl
+++ b/src/EllCrv/FinitePointCount.jl
@@ -458,24 +458,33 @@ julia> order(E)
 100
 ```
 """
+
 @attr ZZRingElem function order(E::EllipticCurve{T}) where T<:FinFieldElem
   R = base_field(E)
   p = characteristic(R)
-  q = order(R)
-
   p == 0 && error("Characteristic must be nonzero")
 
+  q = order(R)
+
+  # for very small fields, use exhaustive search
+  # NOTE: we cannot use BSGS with q <= 49
+  q < 100 && return order_via_exhaustive_search(E)
+
+  # handle j = 0: this also covers supersingular curves in characteristic 2 and 3
   j_invariant(E) == 0 && return _order_j_0(E)
+
+  # for p = 2, 3 we have efficient AGM implementation
   p == 2 && return _order_ordinary_char2(E)
   p == 3 && return _order_ordinary_char3(E)
+
+  # j = 1728
   j_invariant(E) == R(1728) && return _order_j_1728(E)
 
-  # TODO: we did rewrite BSGS so now it always returns one number (but has extra constraints)
-  # TODO: we will add it back in next commit, introducing proper dispatch mechanism
-  # A = order_via_bsgs(E)
-  # if length(A) == 1
-  #   return ZZ(A[1])
-  # end
+  # BSGS for medium sized field
+  # TODO: 10^5 is very safe threshold, can be higher
+  # TODO: when/if we add p-adic methods this will need to be tweaked
+  q < 100000 && return order_via_bsgs(E)
+
   return order_via_schoof(E)
 end
 

--- a/src/EllCrv/FinitePointCount.jl
+++ b/src/EllCrv/FinitePointCount.jl
@@ -109,96 +109,63 @@ end
 ################################################################################
 
 @doc raw"""
-    order_via_bsgs(E::EllipticCurve) -> Vector{ZZRingElem}
+    order_via_bsgs(E::EllipticCurve) -> ZZRingElem
 
-Returns a vector of candidates for the number of points on an elliptic curve $E$ given
-over a finite field $\mathbf{F}_q$, using the Baby-step Giant-step method. If
-$q$ is prime, and if $q > 229$, then the order is determined uniquely by this algorithm.
-It is assumed that the characteristic is not 2.
+Returns the number of points on an elliptic curve $E$ given over a finite field
+$\mathbf{F}_q$, using the Baby-step Giant-step method.
+Implements Cremona-Sutherland modification of Mestre trick.
+It is assumed that q > 49.
 """
 function order_via_bsgs(E::EllipticCurve{T}) where T<:FinFieldElem
   R = base_field(E)
   p = characteristic(R)
-  p == 0 && error("Base field must be finite")
+  @req p > 0 "Base field must be finite"
 
   q = order(R)
+  @req q > 49 "The size of the base field must be at least 50"
 
-  if (p == 2)
-    error("Characteristic must not be 2")
-  end
-  #char also not 3 right?
-  if E.short == false
-    E = short_weierstrass_model(E)[1]
-  end
+  E1, E2 = E, quadratic_twist(E)
+  q1 = q + 1
+  ML = 4*isqrt(q) + ZZ(isodd(degree(R)) ? 4 : 0)
 
-  Nposs = ZZ(1)
-  h = hasse_interval(E)
-  l = h[1]
-  b = h[2]
+  # E1 = E, E2 = quadratic twist of E: |E1| + |E2| = 2(q+1)
+  # |E1| = q + 1 - t, we maintain t = a mod M
+  # N1, N2 are known divisors of |E1| and |E2| respectively
+  a, M = ZZ(0), ZZ(1)
+  N1, N2 = ZZ(1), ZZ(1)
 
-  counter = 0
-  runwhile = true
+  # find order n of random point on E given divisor N of |E|
+  # for E1 this gives: t = q + 1 (mod n); for E2: t = -(q + 1) (mod n)
+  #   we pass this as Q1
+  # since we know that t = a (mod M), we use CRT with non-coprime moduli
+  # for g = u*M + v*n gcd of M and n, the solution is
+  #   (a*v*n + Q1*u*M) / g modulo Mn/g
+  function _add_point(P, Q1, N, a, M)
+    n = _point_order_bsgs(P, N)
+    N = lcm(N, n)
 
-  # if Nposs is greater than interval length, there is only one multiple of
-  # Nposs in the interval, so stop
-  # Also, if lcm does not change in 10(?) consecutive loops, leave while loop
-  while (Nposs <= (b-l)) && (runwhile == true)
-
-    P = rand(E)
-    ord = elem_order_bsgs(P)
-
-    if lcm(ord, Nposs) == Nposs
-      counter = counter + 1
-    else
-      Nposs = lcm(ord, Nposs)
-      counter = 0
+    g, u, v = gcdx(M, n) # g = u*M + v*n
+    if g < n # for g == n we don't gain extra information
+      a = divexact(a*v*n + Q1*u*M, g)
+      M = M * divexact(n,g)
+      a = mod(a, M)
     end
-
-    if counter > 10 # maybe take another criterion
-      runwhile = false
-    end
-
+    return a, M, N
   end
 
-  if runwhile == false # could not determine group order uniquely
-    candidates = ZZRingElem[]
-    Ncand = divrem(l, Nposs)[1]*Nposs
-    if Ncand != 0
-      push!(candidates, Ncand)
-    end
-
-    Ncand = Ncand + Nposs
-
-    while Ncand < b # compute all possible group orders using Hasse's theorem
-      push!(candidates, Ncand)
-      Ncand = Ncand + Nposs
-    end
-
-    output = candidates
-
-  else # group order is determined
-    N = (divrem(l, Nposs)[1] + 1) * Nposs
-    output = [N]
+  # when M >= 4*sqrt(q) we have unique remainder in Hasse interval
+  # if a > 2*sqrt(q), then a - M is the correct value
+  while M < ML
+    a, M, N1 = _add_point(rand(E1),  q1, N1, a, M)
+    M >= ML && break
+    a, M, N2 = _add_point(rand(E2), -q1, N2, a, M)
   end
 
-  if (p == q) && (p > 229) && (length(output) != 1)
-  # group order is uniquely determined, but by quadratic twist
-
-    d = R(0)
-    boolie = true
-    while boolie # get a quadratic non-residue mod p
-      d = rand(R)
-      if is_square(d)[1] == false
-        boolie = false
-      end
-    end
-    _, _, _, a4, a6 = a_invariants(E)
-    Eprime = elliptic_curve([a4*d^2, a6*d^3]) # quadratic twist
-    bb = order_via_bsgs(Eprime)[1]
-    output = [2*p + 2 - bb]
+  if a^2 > 4*q
+    return q1 - (a - M)
+  else
+    return q1 - a
   end
-
-  return output
 end
 
 ################################################################################
@@ -503,11 +470,13 @@ julia> order(E)
   p == 3 && return _order_ordinary_char3(E)
   j_invariant(E) == R(1728) && return _order_j_1728(E)
 
-  A = order_via_bsgs(E)
-  if length(A) == 1
-    return ZZ(A[1])
-  end
-  return ZZ(order_via_schoof(E)) # bsgs may only return candidate list
+  # TODO: we did rewrite BSGS so now it always returns one number (but has extra constraints)
+  # TODO: we will add it back in next commit, introducing proper dispatch mechanism
+  # A = order_via_bsgs(E)
+  # if length(A) == 1
+  #   return ZZ(A[1])
+  # end
+  return order_via_schoof(E)
 end
 
 # don't use @attr, because I need that the attribute has this

--- a/src/EllCrv/Twists.jl
+++ b/src/EllCrv/Twists.jl
@@ -8,49 +8,49 @@
 ###############################################################################
 
 @doc raw"""
-    quadratic_twist(E::EllipticCurve{T}}, d::T) -> EllipticCurve{T}
+    quadratic_twist(E::EllipticCurve{T}, d::T) -> EllipticCurve{T}
 
 Compute the quadratic twist of $E$ by $d$.
 """
-#Needs more testing over characteristic 2. (Magma's twists don't always work over char 2.
-#Adapted from Connell's Handbook of elliptic curves.
+
+# Note that d is untyped for the case of EllipticCurve over Q, where we want to
+#   allow d to be Integer, or ZZRingElem, etc
+# Specializing to EllipticCurve{QQFieldElem} causes method ambiguity, so d is left untyped
 function quadratic_twist(E::EllipticCurve{T}, d) where T<: FieldElem
-
-  a1, a2, a3, a4, a6 = a_invariants(E)
   K = base_field(E)
-  if characteristic(K) != 2
-    return elliptic_curve(K, [a1, a2*d + a1^2*(d-1)//4, a3, a4*d^2 + a1*a3*(d^2-1)//2, a6*d^3 + a3^2*(d^3 -1)//4])
+  a1, a2, a3, a4, a6 = a_invariants(E)
+
+  if characteristic(K) != 2 # multiplicative twist, have degree 2 when d is non-square
+    a2_ = a2*d   + a1^2 *  (d   - 1) // 4
+    a4_ = a4*d^2 + a1*a3 * (d^2 - 1) // 2
+    a6_ = a6*d^3 + a3^2 *  (d^3 - 1) // 4
+    return elliptic_curve(K, [a1, a2_, a3, a4_, a6_])
+  else                      # additive twist, have degree 2 when Tr(d) = 1
+    a2_ = a2 + a1^2*d
+    a6_ = a6 + a3^2*d
+    return elliptic_curve(K, [a1, a2_, a3, a4, a6_])
   end
-
-  return elliptic_curve(K, [a1, a2+a1^2*d, a3, a4, a6 + a3^2])
-
 end
 
-
 @doc raw"""
-    quadratic_twist(E::EllipticCurve{FinFieldElem}}) -> EllipticCurve{FinFieldElem}
+    quadratic_twist(E::EllipticCurve{FinFieldElem}) -> EllipticCurve{FinFieldElem}
 
 Compute the unique quadratic twist of $E$.
 """
-function quadratic_twist(E::EllipticCurve{T}) where T<: FieldElem
-
+function quadratic_twist(E::EllipticCurve{T}) where T<: FinFieldElem
   K = base_field(E)
-  char = characteristic(K)
 
-  if char == 2
-    f, h = hyperelliptic_polynomials(E)
-    if iseven(degree(K))
-      u = normal_basis(GF(Int(char), 1),K)
-    else
-      u = one(K)
-    end
-
-    return elliptic_curve(f + u*h^2, h)
+  if characteristic(K) != 2 # twist-by-d has degree 2 when d is non-square
+    return quadratic_twist(E, non_square(K))
   end
 
-  a = non_square(K)
-  return quadratic_twist(E, a)
-
+  # in characteristic 2 twist-by-d has degree 2 when Tr(d) = 1
+  if isodd(degree(K))     # Tr(1) = degree(K)*1
+    return quadratic_twist(E, one(K))
+  else                    # need to search for an element of trace 1
+    u = normal_basis(GF(2,1), K)
+    return quadratic_twist(E, u)
+  end
 end
 
 #Test if we can't sometimes get two isomorphic curves

--- a/test/EllCrv/Finite.jl
+++ b/test/EllCrv/Finite.jl
@@ -40,14 +40,6 @@
     @test 24 == @inferred Hecke.order_via_legendre(E1)
   end
 
-  @testset "Order computation (BSGS)" begin
-    @test 24 in @inferred Hecke.order_via_bsgs(E1)
-    @test 24 in @inferred Hecke.order_via_bsgs(E2)
-    @test 24 in @inferred Hecke.order_via_bsgs(E3)
-    @test 576 in @inferred Hecke.order_via_bsgs(E4)
-    @test 576 in @inferred Hecke.order_via_bsgs(E4_)
-  end
-
   @testset "Hasse interval" begin
     l = @inferred hasse_interval(E1)
     @test l[1] <= 24 && 24 <= l[2]
@@ -169,25 +161,35 @@
   end
 
   @testset "Order of points" begin
-    function test_curve(E, count)
+    function test_bsgs_with_curve(E, count)
+      fN = factor(order(E))
       for i in 1:count
         P = rand(E)
-        n = order(P)
+        n = Hecke._point_order_bsgs(P, ZZ(1))
 
         @test n*P == infinity(E)
+
         # check minimality: the numbers involved are very small, it is ok to factorize them
         for (p, _) in factor(n)
           @test !is_infinite(divexact(n, p) * P)
         end
-        # check variant with fac
-        @test n == order(P, factor(n))
+
+        # check variant with factorized multiple of order
         @test n == order(P, factor(30*n))
+
+        # check _order_elem_via_fac
+        @test n == Hecke._order_elem_via_fac(P)
+
+        # check variant with group order divisor
+        for (p, _) in fN
+          @test n == Hecke._point_order_bsgs(P, p)
+        end
       end
     end
 
     K = finite_field(103; cached = false)[1]
     E = elliptic_curve(K, [1, 18])
-    test_curve(E, 10)
+    test_bsgs_with_curve(E, 10)
 
     P = E([33, 91])
     @test order(P) == 19
@@ -199,16 +201,20 @@
 
     K, a = finite_field(103, 2; cached = false)
     E = elliptic_curve(K, [a, one(K)])
-    test_curve(E, 10)
+    test_bsgs_with_curve(E, 10)
 
     K = finite_field(2, 9; cached = false)[1]
     E = elliptic_curve(K, [0,0, 1,1,1])
-    test_curve(E, 10)
+    test_bsgs_with_curve(E, 10)
+
+    K = finite_field(2, 9; cached = false)[1]
+    E = elliptic_curve(K, [1,0, 0,0,1])
+    test_bsgs_with_curve(E, 10)
 
     # y^2 = (x-1)*(x-2)*(x-3) = x^3 - 6 * x^2 + 11*x - 6 (mod 10007)
     K = finite_field(10007; cached = false)[1]
     E = elliptic_curve(K, [0, -6, 0, 11, -6])
-    test_curve(E, 10)
+    test_bsgs_with_curve(E, 10)
 
     @test order(E([1, 0])) == 2
     @test order(E([2, 0])) == 2

--- a/test/EllCrv/Finite.jl
+++ b/test/EllCrv/Finite.jl
@@ -169,14 +169,60 @@
   end
 
   @testset "Order of points" begin
-    K = GF(103)
+    function test_curve(E, count)
+      for i in 1:count
+        P = rand(E)
+        n = order(P)
+
+        @test n*P == infinity(E)
+        # check minimality: the numbers involved are very small, it is ok to factorize them
+        for (p, _) in factor(n)
+          @test !is_infinite(divexact(n, p) * P)
+        end
+        # check variant with fac
+        @test n == order(P, factor(n))
+        @test n == order(P, factor(30*n))
+      end
+    end
+
+    K = finite_field(103; cached = false)[1]
     E = elliptic_curve(K, [1, 18])
+    test_curve(E, 10)
+
     P = E([33, 91])
     @test order(P) == 19
     @test Hecke._order_elem_via_fac(P) == 19
+
     P = E([38, 82])
     @test order(P) == 114
     @test Hecke._order_elem_via_fac(P) == 114
+
+    K, a = finite_field(103, 2; cached = false)
+    E = elliptic_curve(K, [a, one(K)])
+    test_curve(E, 10)
+
+    K = finite_field(2, 9; cached = false)[1]
+    E = elliptic_curve(K, [0,0, 1,1,1])
+    test_curve(E, 10)
+
+    # y^2 = (x-1)*(x-2)*(x-3) = x^3 - 6 * x^2 + 11*x - 6 (mod 10007)
+    K = finite_field(10007; cached = false)[1]
+    E = elliptic_curve(K, [0, -6, 0, 11, -6])
+    test_curve(E, 10)
+
+    @test order(E([1, 0])) == 2
+    @test order(E([2, 0])) == 2
+    @test order(E([3, 0])) == 2
+    @test order(E([3, 0]), factor(ZZ(6))) == 2
+    @test order(E([3, 0]), factor(ZZ(36))) == 2
+
+    # y^2 = x^3 + x over F_p with p = 10^9+7
+    # (1, 940286407) is 4-torsion
+    F = finite_field(10^9+7; cached=false)[1]
+    E = elliptic_curve(F, [1,0])
+    @test order(E([1,940286407])) == 4
+    @test order(E([1,940286407]), factor(ZZ(16))) == 4
+    @test order(E([1,940286407]), factor(ZZ(60))) == 4
   end
 
   @testset "Abelian group structure and disc log" begin

--- a/test/EllCrv/FinitePointCount.jl
+++ b/test/EllCrv/FinitePointCount.jl
@@ -486,4 +486,52 @@
       @test @inferred Hecke.order_via_schoof(E) == expected
     end
   end
+
+  @testset "BSGS" begin
+    for d in 6:16
+      K, a = finite_field(2, d; cached=false)
+
+      E = elliptic_curve(K, [1,0,0,0,a])
+      @test @inferred Hecke.order_via_bsgs(E) == Hecke._order_ordinary_char2(E)
+
+      E = elliptic_curve(K, [0,0,1,1,1])
+      @test @inferred Hecke.order_via_bsgs(E) == Hecke._order_supersingular_char2(E)
+    end
+
+    for d in 4:16
+      K, a = finite_field(3, d, :a; cached=false)
+
+      E = elliptic_curve(K, [0,1,0,0,a])
+      @test @inferred Hecke.order_via_bsgs(E) == Hecke._order_ordinary_char3(E)
+
+      E = elliptic_curve(K, [0,0,0,a,1])
+      @test @inferred Hecke.order_via_bsgs(E) == Hecke._order_supersingular_char3(E)
+    end
+
+    for (p,d) in [(5,3), (5,4), (7,3), (7,4), (11,2), (11,3), (13,2)]
+      K, a = finite_field(p, d; cached=false)
+
+      E = elliptic_curve(K, [1,a])
+      @test @inferred Hecke.order_via_bsgs(E) == Hecke.order_via_schoof(E)
+
+      E = elliptic_curve(K, [0,1])
+      @test @inferred Hecke.order_via_bsgs(E) == Hecke.order_via_schoof(E)
+
+      E = elliptic_curve(K, [a,0])
+      @test @inferred Hecke.order_via_bsgs(E) == Hecke.order_via_schoof(E)
+    end
+
+    for p in [53, 113, 229, 367, 479]
+      K = finite_field(p; cached=false)[1]
+
+      E = elliptic_curve(K, [0,1])
+      @test @inferred Hecke.order_via_bsgs(E) == Hecke.order_via_schoof(E)
+
+      E = elliptic_curve(K, [1,0])
+      @test @inferred Hecke.order_via_bsgs(E) == Hecke.order_via_schoof(E)
+
+      E = elliptic_curve(K, [1,1])
+      @test @inferred Hecke.order_via_bsgs(E) == Hecke.order_via_schoof(E)
+    end
+  end
 end

--- a/test/EllCrv/Twists.jl
+++ b/test/EllCrv/Twists.jl
@@ -1,7 +1,25 @@
 @testset "Twists of elliptic curves" begin
-  K = GF(2,2)
-  a = gen(K)
-  E = elliptic_curve_from_j_invariant(K(0))
+  function test_twist_deg1(E::EllipticCurve{T}, d::T) where T <: FieldElem
+    F = @inferred quadratic_twist(E, d)
+    @test is_isomorphic(E, F)
+    @test is_twist(E, F)
+  end
+
+  function test_twist_deg2(E::EllipticCurve{T}, d::T) where T <: FieldElem
+    F = @inferred quadratic_twist(E, d)
+    @test !is_isomorphic(E, F)
+    @test is_twist(E, F)
+  end
+
+  function test_unique_twist(E::EllipticCurve{T}) where T <: FieldElem
+    F = @inferred quadratic_twist(E)
+    @test !is_isomorphic(E, F)
+    @test is_twist(E, F)
+  end
+
+  K, a = finite_field(2, 2; cached = false)
+
+  E = elliptic_curve_from_j_invariant(zero(K))
   L = @inferred twists(E)
   twistlist = [elliptic_curve(K, [0, 0, 1, 0, 0 ]),
                elliptic_curve(K, [0, 0, 1, a, 0 ]),
@@ -14,16 +32,26 @@
   for tw in L
     @test @inferred is_twist(E, tw)
   end
+  @test 1 == count(F -> is_isomorphic(E, F), L)
 
-  E = elliptic_curve_from_j_invariant(K(a+1))
-  F = @inferred quadratic_twist(E)
-  @test is_twist(E, F)
+  test_unique_twist(E)
+  test_twist_deg1(E, one(K))  # Tr(1) = 0, so the twist has degree 1
+  test_twist_deg2(E, a)       # Tr(a) = 1, so the twist has degree 2
 
-  K = GF(3,2)
-  a = gen(K)
-  E = elliptic_curve_from_j_invariant(K(0))
+  E = elliptic_curve_from_j_invariant(a+1)
+  test_unique_twist(E)
+  test_twist_deg1(E, one(K))  # Tr(1) = 0, so the twist has degree 1
+  test_twist_deg2(E, a)       # Tr(a) = 1, so the twist has degree 2
+
+  E = elliptic_curve(K, [1, 0, 1, 0, 1])
+  test_unique_twist(E)
+  test_twist_deg1(E, one(K))  # Tr(1) = 0, so the twist has degree 1
+  test_twist_deg2(E, a)       # Tr(a) = 1, so the twist has degree 2
+
+  K, a = finite_field(3, 2; cached = false)
+
+  E = elliptic_curve_from_j_invariant(zero(K))
   L = @inferred twists(E)
-
   twistlist = [elliptic_curve(K, [ 0, 0, 0, 2, 0 ]),
                elliptic_curve(K, [ 0, 0, 0, a^5, 0 ]),
                elliptic_curve(K, [ 0, 0, 0, a^6, 0 ]),
@@ -31,16 +59,24 @@
                elliptic_curve(K, [ 0, 0, 0, 2, 1 ]),
                elliptic_curve(K, [ 0, 0, 0, a^6, a^3 ])]
   @test L == twistlist
+  for tw in L
+    @test @inferred is_twist(E, tw)
+  end
+  @test 1 == count(F -> is_isomorphic(E, F), L)
 
-  E = elliptic_curve_from_j_invariant(K(a+1))
-  F = @inferred quadratic_twist(E)
-  @test is_twist(E, F)
+  test_unique_twist(E)
+  test_twist_deg1(E, one(K))  # 1 is square, so the twist has degree 1
+  test_twist_deg2(E, a)       # a is not a square, so the twist has degree 2
 
-  K = GF(7, 2)
-  a = gen(K)
+  E = elliptic_curve_from_j_invariant(a+1)
+  test_unique_twist(E)
+  test_twist_deg1(E, one(K))  # 1 is square, so the twist has degree 1
+  test_twist_deg2(E, a)       # a is not a square, so the twist has degree 2
+
+  K, a = finite_field(7, 2; cached = false)
+
   E = elliptic_curve_from_j_invariant(K(0))
   L = @inferred twists(E)
-
   twistlist = [elliptic_curve(K, [ 0, 0, 0, 0, 2 ]),
                elliptic_curve(K, [ 0, 0, 0, 0, a^17 ]),
                elliptic_curve(K, [ 0, 0, 0, 0, a^18 ]),
@@ -48,33 +84,34 @@
                elliptic_curve(K, [ 0, 0, 0, 0, a^20 ]),
                elliptic_curve(K, [ 0, 0, 0, 0, a^21 ])]
   @test L == twistlist
-
+  for tw in L
+    @test @inferred is_twist(E, tw)
+  end
+  @test 1 == count(F -> is_isomorphic(E, F), L)
 
   E = elliptic_curve_from_j_invariant(K(1728))
   L = @inferred twists(E)
-
   twistlist = [elliptic_curve(K, [ 0, 0, 0, 1, 0]),
                elliptic_curve(K, [ 0, 0, 0, a, 0]),
                elliptic_curve(K, [ 0, 0, 0, a^2,0]),
                elliptic_curve(K, [ 0, 0, 0, a^3, 0])]
   @test L == twistlist
+  for tw in L
+    @test @inferred is_twist(E, tw)
+  end
+  @test 1 == count(F -> is_isomorphic(E, F), L)
 
   E = elliptic_curve([1,2,3,4,5])
-  F = @inferred quadratic_twist(E, 5)
-  @test !is_isomorphic(E, F)
-  @test is_twist(E, F)
+  test_twist_deg1(E, QQFieldElem(4))
+  test_twist_deg2(E, QQFieldElem(5))
 
   for K in [GF(13), GF(13, 1), GF(ZZRingElem(13)), GF(ZZRingElem(13), 1)]
     E = elliptic_curve_from_j_invariant(K(0))
-    F = @inferred quadratic_twist(E)
-    @test !is_isomorphic(E, F)
-    @test is_twist(E, F)
+    test_unique_twist(E)
   end
 
   for K in [GF(2, 3), GF(ZZRingElem(2), 3)]
     E = elliptic_curve_from_j_invariant(K(1))
-    F = @inferred quadratic_twist(E)
-    @test !is_isomorphic(E, F)
-    @test is_twist(E, F)
+    test_unique_twist(E)
   end
 end


### PR DESCRIPTION
point order BSGS: rewrote to use Dict (instead of array) for baby steps, prettified implementation and added comments
point count BSGS: rewrote to use Cremona-Sutherland modification of Mestre trick, added comments
twists: fixed quadratic twist in characteristic 2 and prettified implementation
ellcrv order dispatch: explicit thresholds to use exhaustive search (q < 10^2) and bsgs (q < 10^5, when not special cased for j=0,1728 and p=2,3)

Bigger takeaway - curve order BSGS is now always returning one number (assuming q>49 - added @req)
point order is considerably faster, for example
```
F = finite_field(1000000000039)[1]; E = elliptic_curve(F, [0,1]);
@btime order( E([737683462082, 253744829439]) );
```
before `18.535 ms (633123 allocations: 41.28 MiB)`
after `1.005 ms (58661 allocations: 4.13 MiB)`