### PR TITLE
Function fields: some cleanup for divisors

### DIFF
--- a/src/FunField/Divisor.jl
+++ b/src/FunField/Divisor.jl
@@ -38,32 +38,21 @@ function trivial_divisor(F::Generic.FunctionField)
   return divisor(one(F))
 end
 
-
 @doc raw"""
     divisor(I::GenOrdFracIdl, J::GenOrdFracIdl) -> Divisor
 
 Return the divisor corresponding to the factorization of the ideal I (for the finite places) and ideal J (for the infinite places)
 """
-function divisor(I::GenOrdFracIdl, J::GenOrdFracIdl)
-  return Divisor(I, J)
-end
+divisor(I::GenOrdFracIdl, J::GenOrdFracIdl) = Divisor(I, J)
+divisor(I::GenOrdIdl,     J::GenOrdIdl)     = Divisor(GenOrdFracIdl(I), GenOrdFracIdl(J))
+divisor(I::GenOrdFracIdl, J::GenOrdIdl)     = Divisor(I, GenOrdFracIdl(J))
+divisor(I::GenOrdIdl,     J::GenOrdFracIdl) = Divisor(GenOrdFracIdl(I), J)
 
-function divisor(I::GenOrdIdl, J::GenOrdIdl)
-  return Divisor(GenOrdFracIdl(I), GenOrdFracIdl(J))
-end
+@doc raw"""
+    divisor(I::GenOrdFracIdl) -> Divisor
 
-function divisor(I::GenOrdFracIdl, J::GenOrdIdl)
-  return Divisor(I, GenOrdFracIdl(J))
-end
-
-function divisor(I::GenOrdIdl, J::GenOrdFracIdl)
-  return Divisor(GenOrdFracIdl(I), J)
-end
-
-function divisor(I::GenOrdIdl)
-  divisor(GenOrdFracIdl(I))
-end
-
+Return the divisor corresponding to the factorization of the ideal I
+"""
 function divisor(I::GenOrdFracIdl)
   O = order(I)
   F = function_field(O)
@@ -78,6 +67,7 @@ function divisor(I::GenOrdFracIdl)
   end
 end
 
+divisor(I::GenOrdIdl) = divisor(GenOrdFracIdl(I))
 
 @doc raw"""
     divisor(f::Generic.FunctionFieldElem) -> Divisor
@@ -161,7 +151,7 @@ end
 Return a pair of ideals I, J that represent the divisor D. Here I is the ideal for the finite maximal order
 and J is the ideal of the infinite maximal order.
 """
-function ideals(D)
+function ideals(D::Divisor)
   return D.finite_ideal, D.infinite_ideal
 end
 
@@ -218,7 +208,7 @@ end
 
 ################################################################################
 #
-#  Equality
+#  Equality / Comparison
 #
 ################################################################################
 
@@ -227,6 +217,21 @@ Base.:(==)(D1::Divisor, D2::Divisor) = ideals(D1) == ideals(D2)
 Base.isequal(D1::Divisor, D2::Divisor) = D1 == D2
 
 Base.hash(D::Divisor, h::UInt) = hash(ideals(D), h)
+
+# NOTE: divisor comparison defines a partial order, not total order
+# NOTE: thus it is not safe to use sorting algorithms with divisors
+function Base.isless(D1::Divisor, D2::Divisor)
+  @req D1.function_field == D2.function_field "Divisors do not belong to the same field"
+  D1 == D2 && return false
+
+  assure_has_support(D1)
+  assure_has_support(D2)
+
+  s_fin = union(keys(D1.finite_support),   keys(D2.finite_support))
+  s_inf = union(keys(D1.infinite_support), keys(D2.infinite_support))
+  return all(p -> valuation(D1, p) <= valuation(D2, p), union(s_fin, s_inf))
+end
+
 
 ################################################################################
 #
@@ -240,28 +245,8 @@ function Base.:+(D1::Divisor, D2::Divisor)
   Dnew = Divisor(D1_fin * D2_fin, D1_inf * D2_inf)
 
   if has_support(D1) && has_support(D2)
-    P = union(keys(D1.finite_support), keys(D2.finite_support))
-    fin_support = Dict{GenOrdIdl,Int}()
-    for p in P
-      p_val = valuation(D1, p) + valuation(D2, p)
-      if p_val != 0
-        fin_support[p] = p_val
-      end
-    end
-
-    inf_support = Dict{GenOrdIdl,Int}()
-    P_inf = union(keys(D1.infinite_support), keys(D2.infinite_support))
-    for p in P_inf
-      p_val = valuation(D1, p) + valuation(D2, p)
-      if p_val != 0
-        inf_support[p] = p_val
-      end
-    end
-
-    Dnew.finite_support = fin_support
-    Dnew.infinite_support = inf_support
+    _merge_support!(Dnew, +, D1, D2)
   end
-
   return Dnew
 end
 
@@ -280,37 +265,6 @@ function Base.:*(n::Int, D::Divisor)
   return Dnew
 end
 
-function gcd(D1::Divisor, D2::Divisor)
-  D1_fin, D1_inf = ideals(D1)
-  D2_fin, D2_inf = ideals(D2)
-  Dnew = Divisor(D1_fin + D2_fin, D1_inf + D2_inf)
-
-  if has_support(D1) && has_support(D2)
-    P = union(keys(D1.finite_support), keys(D2.finite_support))
-    fin_support = Dict{GenOrdIdl,Int}()
-    for p in P
-      p_val = min(valuation(D1, p), valuation(D2, p))
-      if p_val != 0
-        fin_support[p] = p_val
-      end
-    end
-
-    inf_support = Dict{GenOrdIdl,Int}()
-    P_inf = union(keys(D1.infinite_support), keys(D2.infinite_support))
-    for p in P_inf
-      p_val = min(valuation(D1, p), valuation(D2, p))
-      if p_val != 0
-        inf_support[p] = p_val
-      end
-    end
-
-    Dnew.finite_support = fin_support
-    Dnew.infinite_support = inf_support
-  end
-
-  return Dnew
-end
-
 Base.:*(D::Divisor, n::Int) = n * D
 
 function -(D::Divisor)
@@ -319,6 +273,28 @@ end
 
 function Base.:(-)(D1::Divisor, D2::Divisor)
   return D1 + (-D2)
+end
+
+function gcd(D1::Divisor, D2::Divisor)
+  D1_fin, D1_inf = ideals(D1)
+  D2_fin, D2_inf = ideals(D2)
+  Dnew = Divisor(D1_fin + D2_fin, D1_inf + D2_inf)
+
+  if has_support(D1) && has_support(D2)
+    _merge_support!(Dnew, min, D1, D2)
+  end
+  return Dnew
+end
+
+function lcm(D1::Divisor, D2::Divisor)
+  D1_fin, D1_inf = ideals(D1)
+  D2_fin, D2_inf = ideals(D2)
+  Dnew = Divisor(intersect(D1_fin, D2_fin), intersect(D1_inf, D2_inf))
+
+  if has_support(D1) && has_support(D2)
+    _merge_support!(Dnew, max, D1, D2)
+  end
+  return Dnew
 end
 
 ################################################################################
@@ -330,15 +306,10 @@ end
 has_support(D::Divisor) = isdefined(D, :finite_support) && isdefined(D, :infinite_support)
 
 function assure_has_support(D::Divisor)
-  if has_support(D)
-    return nothing
-  else
+  if !has_support(D)
     D1, D2 = ideals(D)
-    D1_fac = factor(D1)
-    D2_fac = factor(D2)
-    D.finite_support = D1_fac
-    D.infinite_support = D2_fac
-    return nothing
+    D.finite_support = factor(D1)
+    D.infinite_support = factor(D2)
   end
 end
 
@@ -358,26 +329,16 @@ end
 Return the multiplicity of D at the prime ideal p.
 """
 function valuation(D::Divisor, p::GenOrdIdl)
-@assert is_prime(p)
+  @req is_prime(p) "p must be prime ideal"
 
   #Might not always want to compute support for a simple valuation
   assure_has_support(D)
 
   O = order(p)
-  if !isa(base_ring(O), KInftyRing)
-    fin_supp = D.finite_support
-    if haskey(fin_supp, p)
-      return fin_supp[p]
-    else
-      return 0
-    end
+  if isa(base_ring(O), KInftyRing)
+    return get(D.infinite_support, p, 0)
   else
-    inf_supp = D.infinite_support
-    if haskey(inf_supp, p)
-      return inf_supp[p]
-    else
-      return 0
-    end
+    return get(D.finite_support, p, 0)
   end
 end
 
@@ -391,8 +352,40 @@ function infinite_support(D::Divisor)
   return collect(D.infinite_support)
 end
 
-function Base.isless(D1::Divisor, D2::Divisor)
-  all([valuation(D2, f) >= e  for (f, e) in support(D1)]) && D1 != D2
+# Trivial helper to merge supports with an operation, and ensure we have exact/compact support
+function _merge_support_dict(op, s1::Dict{Hecke.GenOrdIdl, Int64}, s2::Dict{Hecke.GenOrdIdl, Int64})
+  s = Dict{GenOrdIdl,Int}()
+
+  for p in union(keys(s1), keys(s2))
+    p_val = op(get(s1, p, 0), get(s2, p, 0))
+    if p_val != 0
+      s[p] = p_val
+    end
+  end
+
+  return s
+end
+
+function _merge_support!(D::Divisor, op, D1::Divisor, D2::Divisor)
+  D.finite_support   = _merge_support_dict(op, D1.finite_support,   D2.finite_support)
+  D.infinite_support = _merge_support_dict(op, D1.infinite_support, D2.infinite_support)
+end
+
+# trivial helper to filter support
+function _filter_support(D::Divisor, pred)
+  s_fin = filter(t -> pred(t), D.finite_support)
+  s_inf = filter(t -> pred(t), D.infinite_support)
+
+  F = function_field(D)
+  Ofin, Oinf = finite_maximal_order(F), infinite_maximal_order(F)
+
+  d_fin = prod(p^e for (p, e) in s_fin; init = Ofin(1)*Ofin)
+  d_inf = prod(p^e for (p, e) in s_inf; init = Oinf(1)*Oinf)
+
+  r = divisor(d_fin, d_inf)
+  r.finite_support   = s_fin
+  r.infinite_support = s_inf
+  return r
 end
 
 ################################################################################
@@ -435,21 +428,8 @@ end
 Return the divisor whose support consists exactly of all zeroes in the support of D.
 """
 function zero_divisor(D::Divisor)
-  supp_fin = finite_support(D)
-  supp_inf = infinite_support(D)
-
-  F = function_field(D)
-
-  Ofin = finite_maximal_order(F)
-  Oinf = infinite_maximal_order(F)
-
-  supp_fin = filter(t -> t[2]>0, supp_fin)
-  supp_inf = filter(t -> t[2]>0, supp_inf)
-
-  D1 = prod(map(t -> t[1]^t[2], supp_fin);init = Ofin(1)*Ofin)
-  D2 = prod(map(t -> t[1]^t[2], supp_inf);init = Oinf(1)*Oinf)
-
-  return divisor(D1, D2)
+  assure_has_support(D)
+  return _filter_support(D, x -> x.second > 0)
 end
 
 @doc raw"""
@@ -458,21 +438,8 @@ end
 Return the divisor whose support consists exactly of all poles in the support of D.
 """
 function pole_divisor(D::Divisor)
-  supp_fin = finite_support(D)
-  supp_inf = infinite_support(D)
-
-  F = function_field(D)
-
-  Ofin = finite_maximal_order(F)
-  Oinf = infinite_maximal_order(F)
-
-  supp_fin = filter(t -> t[2]<0, supp_fin)
-  supp_inf = filter(t -> t[2]<0, supp_inf)
-
-  D1 = prod(map(t -> t[1]^t[2], supp_fin);init = Ofin(1)*Ofin)
-  D2 = prod(map(t -> t[1]^t[2], supp_inf);init = Oinf(1)*Oinf)
-
-  return divisor(D1, D2)
+  assure_has_support(D)
+  return _filter_support(D, x -> x.second < 0)
 end
 
 ################################################################################
@@ -510,7 +477,7 @@ function is_principal(D::Divisor)
 end
 
 @doc raw"""
-    is_principal(D::Divisor) -> Bool
+    is_zero(D::Divisor) -> Bool
 
 Return true if D is the trivial divisor.
 """
@@ -554,11 +521,16 @@ end
 Return the canonical divisor of F.
 """
 function canonical_divisor(F::AbstractAlgebra.Generic.FunctionField)
+  @req is_separable(defining_polynomial(F)) "Currently assumes separable extension"
+
   dx = differential(separating_element(F))
   return divisor(dx)
 end
 
 function separating_element(F::AbstractAlgebra.Generic.FunctionField)
+  # TODO: we need to search for one, instead of using x
+  @req is_separable(defining_polynomial(F)) "Currently assumes separable extension"
+
   return F(gen(base_ring(F)))
 end
 
@@ -568,6 +540,8 @@ end
 Return the genus of F.
 """
 function genus(F::AbstractAlgebra.Generic.FunctionField)
+  @req is_separable(defining_polynomial(F)) "Currently assumes separable extension"
+
   return length(basis_of_differentials(F))
 end
 
@@ -640,6 +614,8 @@ L(K - D), where K is the canonical divisor of the function field of D.
 """
 function index_of_speciality(D::Divisor)
   F = function_field(D)
+  @req is_separable(defining_polynomial(F)) "Currently assumes separable extension"
+
   K = canonical_divisor(F)
   return length(riemann_roch_space(K - D))
 end

--- a/src/FunField/Divisor.jl
+++ b/src/FunField/Divisor.jl
@@ -5,23 +5,18 @@
 ################################################################################
 
 
-mutable struct Divisor
-  function_field::AbstractAlgebra.Generic.FunctionField
-  finite_ideal::GenOrdFracIdl
-  infinite_ideal::GenOrdFracIdl
-  finite_support::Dict{Hecke.GenOrdIdl, Int64}
-  infinite_support::Dict{Hecke.GenOrdIdl, Int64}
+mutable struct Divisor{S <: Generic.FunctionField, T1 <: PolyRing, T2 <: KInftyRing}
+  function_field::S
+  finite_ideal::GenOrdFracIdl{S, T1}
+  infinite_ideal::GenOrdFracIdl{S, T2}
+  finite_support::Dict{Hecke.GenOrdIdl{S, T1}, Int64}
+  infinite_support::Dict{Hecke.GenOrdIdl{S, T2}, Int64}
 
-  function Divisor(I::GenOrdFracIdl, J::GenOrdFracIdl)
-    r = new()
+  function Divisor(I::GenOrdFracIdl{S, T1}, J::GenOrdFracIdl{S, T2}) where {S, T1, T2}
+    r = new{S, T1, T2}()
 
-    O = order(I)
-    Oinf = order(J)
-    K = function_field(O)
-
-    @req K == function_field(Oinf) "Ideals need to belong to orders of the same function field."
-    @req isa(base_ring(O), PolyRing) "First ideal needs to be an ideal over the finite order"
-    @req isa(base_ring(Oinf), KInftyRing) "Second ideal needs to be an ideal over the infinite order"
+    K = function_field(order(I))
+    @req K == function_field(order(J)) "Ideals need to belong to orders of the same function field."
 
     r.function_field = K
     r.finite_ideal = I
@@ -53,21 +48,20 @@ divisor(I::GenOrdIdl,     J::GenOrdFracIdl) = Divisor(GenOrdFracIdl(I), J)
 
 Return the divisor corresponding to the factorization of the ideal I
 """
-function divisor(I::GenOrdFracIdl)
-  O = order(I)
-  F = function_field(O)
-  Ofin = finite_maximal_order(F)
-  Oinf = infinite_maximal_order(F)
-  if O == Ofin
-    return divisor(I, ideal(Oinf, one(Oinf)))
-  elseif O == Oinf
-    return divisor(ideal(Ofin, one(Ofin)), I)
-  else
-    error("There is a bug in divisor")
-  end
+
+function divisor(I::GenOrdFracIdl{<: Generic.FunctionField, <: KInftyRing})
+  Ofin = finite_maximal_order(function_field(order(I)))
+  return divisor(ideal(Ofin, one(Ofin)), I)
 end
 
-divisor(I::GenOrdIdl) = divisor(GenOrdFracIdl(I))
+function divisor(I::GenOrdFracIdl{<: Generic.FunctionField, <: PolyRing})
+  Oinf = infinite_maximal_order(function_field(order(I)))
+  return divisor(I, ideal(Oinf, one(Oinf)))
+end
+
+function divisor(I::GenOrdIdl)
+  return divisor(GenOrdFracIdl(I))
+end
 
 @doc raw"""
     divisor(f::Generic.FunctionFieldElem) -> Divisor
@@ -78,9 +72,7 @@ function divisor(f::Generic.FunctionFieldElem)
   @req !is_zero(f) "Element must be non-zero"
   F = parent(f)
 
-  Ofin = finite_maximal_order(F)
-  Oinf = infinite_maximal_order(F)
-
+  Ofin, Oinf = finite_maximal_order(F), infinite_maximal_order(F)
   return divisor(Ofin * f, Oinf * f)
 end
 
@@ -92,9 +84,7 @@ Return the divisor consisting of the zeroes of f
 function zero_divisor(f::Generic.FunctionFieldElem)
   F = parent(f)
 
-  Ofin = finite_maximal_order(F)
-  Oinf = infinite_maximal_order(F)
-
+  Ofin, Oinf = finite_maximal_order(F), infinite_maximal_order(F)
   f_num, f_denom = integral_split(f, Ofin)
   g_num, g_denom = integral_split(f, Oinf)
 
@@ -109,9 +99,7 @@ Return the divisor consisting of the poles of f
 function pole_divisor(f::Generic.FunctionFieldElem)
   F = parent(f)
 
-  Ofin = finite_maximal_order(F)
-  Oinf = infinite_maximal_order(F)
-
+  Ofin, Oinf = finite_maximal_order(F), infinite_maximal_order(F)
   f_num, f_denom = integral_split(f, Ofin)
   g_num, g_denom = integral_split(f, Oinf)
 
@@ -124,10 +112,10 @@ end
 #
 ################################################################################
 
-function show(io::IO, id::Divisor)
+function show(io::IO, D::Divisor)
   print(io, "Divisor in ideal representation:")
-  print(io, "\nFinite ideal: ", id.finite_ideal)
-  print(io, "\nInfinite ideal: ", id.infinite_ideal)
+  print(io, "\nFinite ideal: ", D.finite_ideal)
+  print(io, "\nInfinite ideal: ", D.infinite_ideal)
 end
 
 ################################################################################
@@ -212,15 +200,20 @@ end
 #
 ################################################################################
 
+function Base.:(==)(D1::Divisor{S, T1, T2}, D2::Divisor{S, T1, T2}) where {S, T1, T2}
+  return D1.finite_ideal == D2.finite_ideal && D1.infinite_ideal == D2.infinite_ideal
+end
+function Base.isequal(D1::Divisor{S, T1, T2}, D2::Divisor{S, T1, T2}) where {S, T1, T2}
+  return D1 == D2
+end
 
-Base.:(==)(D1::Divisor, D2::Divisor) = ideals(D1) == ideals(D2)
-Base.isequal(D1::Divisor, D2::Divisor) = D1 == D2
-
-Base.hash(D::Divisor, h::UInt) = hash(ideals(D), h)
+function Base.hash(D::Divisor, h::UInt)
+  return hash(ideals(D), h)
+end
 
 # NOTE: divisor comparison defines a partial order, not total order
 # NOTE: thus it is not safe to use sorting algorithms with divisors
-function Base.isless(D1::Divisor, D2::Divisor)
+function Base.isless(D1::Divisor{S, T1, T2}, D2::Divisor{S, T1, T2}) where {S, T1, T2}
   @req D1.function_field == D2.function_field "Divisors do not belong to the same field"
   D1 == D2 && return false
 
@@ -239,7 +232,7 @@ end
 #
 ################################################################################
 
-function Base.:+(D1::Divisor, D2::Divisor)
+function Base.:+(D1::Divisor{S, T1, T2}, D2::Divisor{S, T1, T2}) where {S, T1, T2}
   D1_fin, D1_inf = ideals(D1)
   D2_fin, D2_inf = ideals(D2)
   Dnew = Divisor(D1_fin * D2_fin, D1_inf * D2_inf)
@@ -266,16 +259,13 @@ function Base.:*(n::Int, D::Divisor)
 end
 
 Base.:*(D::Divisor, n::Int) = n * D
+Base.:-(D::Divisor) = (-1)*D
 
-function -(D::Divisor)
-  return (-1)*D
-end
-
-function Base.:(-)(D1::Divisor, D2::Divisor)
+function Base.:(-)(D1::Divisor{S, T1, T2}, D2::Divisor{S, T1, T2}) where {S, T1, T2}
   return D1 + (-D2)
 end
 
-function gcd(D1::Divisor, D2::Divisor)
+function gcd(D1::Divisor{S, T1, T2}, D2::Divisor{S, T1, T2}) where {S, T1, T2}
   D1_fin, D1_inf = ideals(D1)
   D2_fin, D2_inf = ideals(D2)
   Dnew = Divisor(D1_fin + D2_fin, D1_inf + D2_inf)
@@ -286,7 +276,7 @@ function gcd(D1::Divisor, D2::Divisor)
   return Dnew
 end
 
-function lcm(D1::Divisor, D2::Divisor)
+function lcm(D1::Divisor{S, T1, T2}, D2::Divisor{S, T1, T2}) where {S, T1, T2}
   D1_fin, D1_inf = ideals(D1)
   D2_fin, D2_inf = ideals(D2)
   Dnew = Divisor(intersect(D1_fin, D2_fin), intersect(D1_inf, D2_inf))
@@ -303,7 +293,9 @@ end
 #
 ################################################################################
 
-has_support(D::Divisor) = isdefined(D, :finite_support) && isdefined(D, :infinite_support)
+function has_support(D::Divisor)
+  return isdefined(D, :finite_support) && isdefined(D, :infinite_support)
+end
 
 function assure_has_support(D::Divisor)
   if !has_support(D)
@@ -328,18 +320,20 @@ end
 
 Return the multiplicity of D at the prime ideal p.
 """
-function valuation(D::Divisor, p::GenOrdIdl)
+function valuation(D::Divisor{S, T1, T2}, p::GenOrdIdl{S, T1}) where {S, T1, T2}
   @req is_prime(p) "p must be prime ideal"
 
   #Might not always want to compute support for a simple valuation
   assure_has_support(D)
+  return get(D.finite_support, p, 0)
+end
 
-  O = order(p)
-  if isa(base_ring(O), KInftyRing)
-    return get(D.infinite_support, p, 0)
-  else
-    return get(D.finite_support, p, 0)
-  end
+function valuation(D::Divisor{S, T1, T2}, p::GenOrdIdl{S, T2}) where {S, T1, T2}
+  @req is_prime(p) "p must be prime ideal"
+
+  #Might not always want to compute support for a simple valuation
+  assure_has_support(D)
+  return get(D.infinite_support, p, 0)
 end
 
 function finite_support(D::Divisor)
@@ -353,8 +347,8 @@ function infinite_support(D::Divisor)
 end
 
 # Trivial helper to merge supports with an operation, and ensure we have exact/compact support
-function _merge_support_dict(op, s1::Dict{Hecke.GenOrdIdl, Int64}, s2::Dict{Hecke.GenOrdIdl, Int64})
-  s = Dict{GenOrdIdl,Int}()
+function _merge_support_dict(op, s1::Dict{Hecke.GenOrdIdl{S, T}, Int64}, s2::Dict{Hecke.GenOrdIdl{S, T}, Int64}) where {S, T}
+  s = Dict{GenOrdIdl{S, T},Int}()
 
   for p in union(keys(s1), keys(s2))
     p_val = op(get(s1, p, 0), get(s2, p, 0))
@@ -366,7 +360,7 @@ function _merge_support_dict(op, s1::Dict{Hecke.GenOrdIdl, Int64}, s2::Dict{Heck
   return s
 end
 
-function _merge_support!(D::Divisor, op, D1::Divisor, D2::Divisor)
+function _merge_support!(D::Divisor{S, T1, T2}, op, D1::Divisor{S, T1, T2}, D2::Divisor{S, T1, T2}) where {S, T1, T2}
   D.finite_support   = _merge_support_dict(op, D1.finite_support,   D2.finite_support)
   D.infinite_support = _merge_support_dict(op, D1.infinite_support, D2.infinite_support)
 end

--- a/src/GenOrd/FractionalIdeal.jl
+++ b/src/GenOrd/FractionalIdeal.jl
@@ -154,10 +154,27 @@ Base.:*(A::T, B::T) where T <: GenOrdFracIdl = prod(A, B)
 
 
 function Base.:(+)(a::T, b::T) where T <: GenOrdFracIdl
-  d = lcm(denominator(a), denominator(b))
-  ma = divexact(d, denominator(a))
-  mb = divexact(d, denominator(b))
-  return GenOrdFracIdl(order(a)(ma)*numerator(a) + order(b)(mb) * numerator(b),d)
+  d = lcm(denominator(a; copy=false), denominator(b; copy=false))
+
+  ma = divexact(d, denominator(a; copy=false))
+  I  = order(a)(ma) * numerator(a; copy=false)
+
+  mb = divexact(d, denominator(b; copy=false))
+  J  = order(b)(mb) * numerator(b; copy=false)
+
+  return GenOrdFracIdl(I + J, d)
+end
+
+function Base.intersect(a::T, b::T) where T <: GenOrdFracIdl
+  d = lcm(denominator(a; copy=false), denominator(b; copy=false))
+
+  ma = divexact(d, denominator(a; copy=false))
+  I  = order(a)(ma) * numerator(a; copy=false)
+
+  mb = divexact(d, denominator(b; copy=false))
+  J  = order(b)(mb) * numerator(b; copy=false)
+
+  return GenOrdFracIdl(intersect(I, J), d)
 end
 
 ################################################################################

--- a/src/GenOrd/FractionalIdeal.jl
+++ b/src/GenOrd/FractionalIdeal.jl
@@ -356,7 +356,7 @@ function Hecke.factor(A::GenOrdFracIdl)
   primes = Dict{GenOrdIdl,Int}()
   for (f,e) in factors
     for (p,r) in prime_decomposition(O,f)
-      p_val = valuation(p,A_num) - valuation(p, A_den)
+      p_val = valuation(A_num, p) - valuation(A_den, p)
       if p_val != 0
         primes[p] = p_val
       end
@@ -366,3 +366,9 @@ function Hecke.factor(A::GenOrdFracIdl)
   return primes
 end
 
+function Hecke.valuation(A::GenOrdFracIdl{S, T}, p::GenOrdIdl{S, T}) where {S, T}
+  O = A.order
+  A_num = numerator(A)
+  A_den = ideal(O, denominator(A))
+  return valuation(A_num, p) - valuation(A_den, p)
+end

--- a/src/GenOrd/FractionalIdeal.jl
+++ b/src/GenOrd/FractionalIdeal.jl
@@ -108,7 +108,7 @@ end
 #
 ################################################################################
 
-function assure_has_numerator_and_denominator(a::GenOrdFracIdl)
+function assure_has_numerator_and_denominator(a::GenOrdFracIdl{S, T}) where {S, T}
   if isdefined(a, :num) && isdefined(a, :den)
     return nothing
   end
@@ -118,7 +118,7 @@ function assure_has_numerator_and_denominator(a::GenOrdFracIdl)
 
   B, d = integral_split(basis_matrix(a, copy = false), coefficient_ring(order(a)))
   a.num = GenOrdIdl(order(a), B)
-  a.den = d
+  a.den = d::elem_type(T)
   return nothing
 end
 
@@ -127,13 +127,9 @@ function Base.numerator(x::GenOrdFracIdl; copy::Bool = true)
   return x.num
 end
 
-function Base.denominator(x::GenOrdFracIdl; copy::Bool = true)
+function Base.denominator(x::GenOrdFracIdl{S, T}; copy::Bool = true) where {S, T}
   assure_has_numerator_and_denominator(x)
-  if copy
-    return deepcopy(x.den)
-  else
-    return x.den
-  end
+  return (copy ? deepcopy(x.den) : x.den)::elem_type(T)
 end
 
 
@@ -145,34 +141,31 @@ end
 ################################################################################
 
 
-function Base.prod(a::T, b::T) where T <: GenOrdFracIdl
+function Base.prod(a::GenOrdFracIdl{S, T}, b::GenOrdFracIdl{S, T}) where {S, T}
   A = numerator(a)*numerator(b)
   return GenOrdFracIdl(A, denominator(a)*denominator(b))
 end
 
-Base.:*(A::T, B::T) where T <: GenOrdFracIdl = prod(A, B)
+function Base.:*(a::GenOrdFracIdl{S, T}, b::GenOrdFracIdl{S, T}) where {S, T}
+  return prod(a, b)
+end
 
+function Base.:(+)(a::GenOrdFracIdl{S, T}, b::GenOrdFracIdl{S, T}) where {S, T}
+  den_a, den_b = denominator(a; copy=false), denominator(b; copy=false)
+  d = lcm(den_a, den_b)
 
-function Base.:(+)(a::T, b::T) where T <: GenOrdFracIdl
-  d = lcm(denominator(a; copy=false), denominator(b; copy=false))
-
-  ma = divexact(d, denominator(a; copy=false))
-  I  = order(a)(ma) * numerator(a; copy=false)
-
-  mb = divexact(d, denominator(b; copy=false))
-  J  = order(b)(mb) * numerator(b; copy=false)
+  I  = order(a)(divexact(d, den_a)) * numerator(a; copy=false)
+  J  = order(b)(divexact(d, den_b)) * numerator(b; copy=false)
 
   return GenOrdFracIdl(I + J, d)
 end
 
-function Base.intersect(a::T, b::T) where T <: GenOrdFracIdl
-  d = lcm(denominator(a; copy=false), denominator(b; copy=false))
+function Base.intersect(a::GenOrdFracIdl{S, T}, b::GenOrdFracIdl{S, T}) where {S, T}
+  den_a, den_b = denominator(a; copy=false), denominator(b; copy=false)
+  d = lcm(den_a, den_b)
 
-  ma = divexact(d, denominator(a; copy=false))
-  I  = order(a)(ma) * numerator(a; copy=false)
-
-  mb = divexact(d, denominator(b; copy=false))
-  J  = order(b)(mb) * numerator(b; copy=false)
+  I  = order(a)(divexact(d, den_a)) * numerator(a; copy=false)
+  J  = order(b)(divexact(d, den_b)) * numerator(b; copy=false)
 
   return GenOrdFracIdl(intersect(I, J), d)
 end

--- a/src/GenOrd/Ideal.jl
+++ b/src/GenOrd/Ideal.jl
@@ -149,14 +149,9 @@ end
 
 Return the basis matrix of $A$.
 """
-function Hecke.basis_matrix(A::GenOrdIdl; copy::Bool = true)
+function Hecke.basis_matrix(A::GenOrdIdl{S, T}; copy::Bool = true) where {S, T}
   assure_has_basis_matrix(A)
-  if copy
-    B = deepcopy(A.basis_matrix)
-    return B
-  else
-    return A.basis_matrix
-  end
+  return (copy ? deepcopy(A.basis_matrix) : A.basis_matrix)::dense_matrix_type(elem_type(T))
 end
 
 function assure_has_basis_matrix(A::GenOrdIdl)
@@ -250,7 +245,7 @@ end
 ################################################################################
 
 
-function Base.:(+)(a::GenOrdIdl, b::GenOrdIdl)
+function Base.:(+)(a::GenOrdIdl{S, T}, b::GenOrdIdl{S, T}) where {S, T}
   @req order(a) === order(b) "Ideals must have same order"
 
   if iszero(a)
@@ -265,10 +260,14 @@ function Base.:(+)(a::GenOrdIdl, b::GenOrdIdl)
   return GenOrdIdl(a.order, V[d+1:2*d,1:d])
 end
 
-Base.:(==)(a::GenOrdIdl, b::GenOrdIdl) = hnf(basis_matrix(a),:lowerleft) == hnf(basis_matrix(b),:lowerleft)
-Base.isequal(a::GenOrdIdl, b::GenOrdIdl) = a == b
+function Base.:(==)(a::GenOrdIdl{S, T}, b::GenOrdIdl{S, T}) where {S, T}
+  return hnf(basis_matrix(a),:lowerleft) == hnf(basis_matrix(b),:lowerleft)
+end
+function Base.isequal(a::GenOrdIdl{S, T}, b::GenOrdIdl{S, T}) where {S, T}
+  return a == b
+end
 
-function Base.:(*)(a::GenOrdIdl, b::GenOrdIdl)
+function Base.:(*)(a::GenOrdIdl{S, T}, b::GenOrdIdl{S, T}) where {S, T}
   O = order(a)
   Ma = basis_matrix(a)
   Mb = basis_matrix(b)
@@ -282,7 +281,7 @@ end
 
 Returns $x \cap y$.
 """
-function Base.intersect(a::GenOrdIdl, b::GenOrdIdl)
+function Base.intersect(a::GenOrdIdl{S, T}, b::GenOrdIdl{S, T}) where {S, T}
 #TODO: Check for new hnf
   M1 = hcat(basis_matrix(a), basis_matrix(a))
   d = nrows(M1)
@@ -321,9 +320,11 @@ function Base.:*(x::GenOrdElem, O::GenOrd)
   return ideal(O, x)
 end
 
-function Base.:*(x::GenOrdElem, y::GenOrdIdl)
+function Base.:*(x::GenOrdElem, y::GenOrdIdl{S, T}) where {S, T}
   parent(x) !== order(y) && error("GenOrds of element and ideal must be equal")
-  return GenOrdIdl(parent(x), x) * y
+  # note that we use order(y) and not parent(x),
+  #   because it provides concrete GenOrd{S,T} for type inference
+  return GenOrdIdl(order(y), x) * y
 end
 
 Base.:*(x::GenOrdIdl, y::GenOrdElem) = y * x

--- a/src/GenOrd/Ideal.jl
+++ b/src/GenOrd/Ideal.jl
@@ -626,7 +626,7 @@ function poly_to_residue(K::AbstractAlgebra.Field, poly:: AbstractAlgebra.Generi
 end
 
 
-function Hecke.valuation(p::GenOrdIdl,A::GenOrdIdl)
+function Hecke.valuation(A::GenOrdIdl{S, T}, p::GenOrdIdl{S, T}) where {S, T}
   O = order(A)
   e = 0
   if has_2_elem(p)
@@ -654,7 +654,7 @@ function Hecke.factor(A::GenOrdIdl)
   primes = Dict{GenOrdIdl,Int}()
   for (f,e) in factors
     for (p,r) in prime_decomposition(O,f)
-      p_val = valuation(p,A)
+      p_val = valuation(A, p)
       if p_val != 0
         primes[p] = p_val
       end
@@ -720,7 +720,7 @@ function _decomposition(O::GenOrd, I::GenOrdIdl, Ip::GenOrdIdl, T::GenOrdIdl, p:
   for j in 1:length(ideals)
     P = ideals[j][1]
     f = P.splitting_type[2]
-    e = valuation(P,GenOrdIdl(O,p))
+    e = valuation(GenOrdIdl(O,p), P)
     P.splitting_type = e, f
     ideals[j] = (P,e)
   end

--- a/src/GenOrd/Types.jl
+++ b/src/GenOrd/Types.jl
@@ -131,7 +131,15 @@ end
     @assert base_ring(M) === coefficient_ring(O)
     # create ideal of O with basis_matrix M
     r = GenOrdIdl(O)
-    r.basis_matrix = M
+
+    # we want to have basis_matrix as a dense_matrix_type(elem_type(T))
+    # materialize the matrix if view was provided
+    if M isa AbstractAlgebra.Generic.MatSpaceView
+      r.basis_matrix = sub(M, 1:nrows(M), 1:ncols(M))
+    else
+      r.basis_matrix = M
+    end
+
     return r
   end
 

--- a/test/FunField/Divisor.jl
+++ b/test/FunField/Divisor.jl
@@ -3,47 +3,74 @@ import Hecke: divisor
 @testset "Divisors" begin
 
   @testset "Basic Operations" begin
-    kx, x = rational_function_field(QQ, :x; cached = false)
-    ky, y = polynomial_ring(kx, :y; cached = false)
-    F, a = function_field(y^2 - x; cached = false)
-    Ofin = finite_maximal_order(F)
-    Oinf = infinite_maximal_order(F)
+    for base_field in [QQ, finite_field(2, 4)[1], finite_field(101)[1]]
+      kx, x = rational_function_field(base_field, :x; cached = false)
+      ky, y = polynomial_ring(kx, :y; cached = false)
 
-    p1 = ideal(Ofin, x-2)
-    p2 = ideal(Ofin, x-3)
-    p3 = ideal(Ofin, x-4)
-    p4, _ = first(factor(ideal(Oinf, base_ring(Oinf)(1//x))))
+      F, a = function_field(y^3 - x^3 - 1; cached = false)
+      Ofin = finite_maximal_order(F)
+      Oinf = infinite_maximal_order(F)
 
-    d1, d2, d3, d4 = divisor.((p1, p2, p3, p4))
+      p1, _ = first(factor(ideal(Ofin, x-1)))
+      p2    = ideal(Ofin, x^2+x+1)
+      p3    = ideal(Ofin, x-3, Ofin(a+3))
+      p4, _ = first(factor(ideal(Oinf, base_ring(Oinf)(1//x))))
 
-    D1 = trivial_divisor(F)
-    D2 = d1 - d2
-    @test !(D1 < D2)
-    @test !(D2 < D1)
+      d1, d2, d3, d4 = divisor.((p1, p2, p3, p4))
+      Hecke.assure_has_support.((d1, d2, d3, d4))
 
-    D1 = d1 + 5*d2
-    D2 = d1 + 2*d2 - 3*d3
-    @test @inferred(gcd(D1, D2)) == d1 + 2*d2 - 3*d3
-    @test @inferred(gcd(D1, D2)) == gcd(D2, D1)
-    @test @inferred(lcm(D1, D2)) == d1 + 5*d2
-    @test @inferred(lcm(D1, D2)) == lcm(D2, D1)
-    @test @inferred(lcm(D1, D2) + gcd(D1, D2)) == D1 + D2
+      D1 = trivial_divisor(F)
+      D2 = d1 - d2 # note that this is guaranteed to be non-trivial
+      @test !(D1 < D2)
+      @test !(D2 < D1)
 
-    D1 = d1 + 3*d4
-    D2 = 2*d1 - 3*d3
-    @test @inferred(gcd(D1, D2)) == d1 - 3*d3
-    @test @inferred(gcd(D1, D2)) == gcd(D2, D1)
-    @test @inferred(lcm(D1, D2)) == 2*d1 + 3*d4
-    @test @inferred(lcm(D1, D2)) == lcm(D2, D1)
-    @test @inferred(lcm(D1, D2) + gcd(D1, D2)) == D1 + D2
+      D1 = d1 + 5*d2
+      D2 = d1 + 2*d2 - 3*d3
+      Dgcd = @inferred(gcd(D1, D2))
+      Dlcm = @inferred(lcm(D1, D2))
 
-    D1 = d1 - 3*d4
-    D2 = 2*d1
-    @test @inferred(gcd(D1, D2)) == D1
-    @test @inferred(gcd(D2, D1)) == D1
-    @test @inferred(lcm(D1, D2)) == 2*d1
-    @test @inferred(lcm(D1, D2)) == lcm(D2, D1)
-    @test @inferred(lcm(D1, D2) + gcd(D1, D2)) == D1 + D2
+      @test Dgcd == d1 + 2*d2 - 3*d3
+      @test Dgcd == gcd(D2, D1)
+      @test Dlcm == d1 + 5*d2
+      @test Dlcm == lcm(D2, D1)
+      @test Dgcd + Dlcm == D1 + D2
+
+      @test valuation(Dgcd, p1) == valuation(Dgcd.finite_ideal, p1)
+      @test valuation(Dgcd, p4) == valuation(Dgcd.infinite_ideal, p4)
+      @test valuation(Dlcm, p1) == valuation(Dlcm.finite_ideal, p1)
+      @test valuation(Dlcm, p4) == valuation(Dlcm.infinite_ideal, p4)
+
+      D1 = d1 + 3*d4
+      D2 = 2*d1 - 3*d3
+      Dgcd = @inferred(gcd(D1, D2))
+      Dlcm = @inferred(lcm(D1, D2))
+
+      @test Dgcd == d1 - 3*d3
+      @test Dgcd == gcd(D2, D1)
+      @test Dlcm == 2*d1 + 3*d4
+      @test Dlcm == lcm(D2, D1)
+      @test Dgcd + Dlcm == D1 + D2
+
+      @test valuation(Dgcd, p1) == valuation(Dgcd.finite_ideal, p1)
+      @test valuation(Dgcd, p4) == valuation(Dgcd.infinite_ideal, p4)
+      @test valuation(Dlcm, p1) == valuation(Dlcm.finite_ideal, p1)
+      @test valuation(Dlcm, p4) == valuation(Dlcm.infinite_ideal, p4)
+
+      D1 = d1 - 3*d4
+      D2 = 2*d1
+      Dgcd = @inferred(gcd(D1, D2))
+      Dlcm = @inferred(lcm(D1, D2))
+      @test Dgcd == D1
+      @test Dgcd == gcd(D2, D1)
+      @test Dlcm == 2*d1
+      @test Dlcm == lcm(D2, D1)
+      @test Dgcd + Dlcm == D1 + D2
+
+      @test valuation(Dgcd, p1) == valuation(Dgcd.finite_ideal, p1)
+      @test valuation(Dgcd, p4) == valuation(Dgcd.infinite_ideal, p4)
+      @test valuation(Dlcm, p1) == valuation(Dlcm.finite_ideal, p1)
+      @test valuation(Dlcm, p4) == valuation(Dlcm.infinite_ideal, p4)
+    end
   end
 
   @testset "Not Separable Extension" begin
@@ -68,7 +95,7 @@ import Hecke: divisor
   end
 
   @testset "Riemann-Roch" begin
-    for base_field in [QQ, finite_field(2,4)[1], finite_field(5, 2)[1], finite_field(101)[1]]
+    for base_field in [QQ, finite_field(2, 4)[1], finite_field(5, 2)[1], finite_field(101)[1]]
       kx, x = rational_function_field(base_field, :x; cached = false)
       ky, y = polynomial_ring(kx, :y; cached = false)
       for poly in [y^3 - x - 1, y^3 - x^3 - 1, y^3 - x^17 - 1]

--- a/test/FunField/Divisor.jl
+++ b/test/FunField/Divisor.jl
@@ -2,6 +2,9 @@ import Hecke: divisor
 
 @testset "Divisors" begin
 
+  # NOTE: currently we cannot quite use @inferred of gcd/lcm
+  #   due to GenOrd losing type stability on ideal operations
+  #   this will be fixed later separately
   @testset "Basic Operations" begin
     kx, x = rational_function_field(QQ, :x; cached = false)
     ky, y = polynomial_ring(kx, :y; cached = false)

--- a/test/FunField/Divisor.jl
+++ b/test/FunField/Divisor.jl
@@ -1,16 +1,73 @@
-k = QQ
-kx, x = rational_function_field(k, "x")
-kt = parent(numerator(x))
-ky, y = polynomial_ring(kx, "y")
-
 import Hecke: divisor
-
 
 @testset "Divisors" begin
 
-    @testset "Algebraic function field over rationals (1)" begin
+  @testset "Basic Operations" begin
+    kx, x = rational_function_field(QQ, :x; cached = false)
+    ky, y = polynomial_ring(kx, :y; cached = false)
+    F, a = function_field(y^2 - x; cached = false)
+    Ofin = finite_maximal_order(F)
+    Oinf = infinite_maximal_order(F)
 
-      F, a = function_field(y^2 - x^3 - 1)
+    p1 = ideal(Ofin, x-2)
+    p2 = ideal(Ofin, x-3)
+    p3 = ideal(Ofin, x-4)
+    p4, _ = first(factor(ideal(Oinf, base_ring(Oinf)(1//x))))
+
+    d1, d2, d3, d4 = divisor.((p1, p2, p3, p4))
+
+    D1 = trivial_divisor(F)
+    D2 = d1 - d2
+    @test !(D1 < D2)
+    @test !(D2 < D1)
+
+    D1 = d1 + 5*d2
+    D2 = d1 + 2*d2 - 3*d3
+    @test gcd(D1, D2) == d1 + 2*d2 - 3*d3
+    @test gcd(D1, D2) == gcd(D2, D1)
+    @test lcm(D1, D2) == d1 + 5*d2
+    @test lcm(D1, D2) == lcm(D2, D1)
+
+    D1 = d1 + 3*d4
+    D2 = 2*d1 - 3*d3
+    @test gcd(D1, D2) == d1 - 3*d3
+    @test gcd(D1, D2) == gcd(D2, D1)
+    @test lcm(D1, D2) == 2*d1 + 3*d4
+    @test lcm(D1, D2) == lcm(D2, D1)
+
+    D1 = d1 - 3*d4
+    D2 = 2*d1
+    @test gcd(D1, D2) == D1
+    @test gcd(D2, D1) == D1
+    @test lcm(D1, D2) == 2*d1
+    @test lcm(D1, D2) == lcm(D2, D1)
+  end
+
+  @testset "Not Separable Extension" begin
+    k = finite_field(3; cached = false)[1]
+    kx, x = rational_function_field(k, :x; cached = false)
+    ky, y = polynomial_ring(kx, :y; cached = false)
+
+    # current implementation of separating_element/canonical_divisor
+    #   assumes separable extension
+
+    # purely inseparable
+    F, a = function_field(y^3 - x; cached = false)
+    @test_throws ArgumentError Hecke.separating_element(F)
+    @test_throws ArgumentError Hecke.canonical_divisor(F)
+    @test_throws ArgumentError Hecke.genus(F)
+
+    # (not purely) inseparable
+    F, a = function_field(y^6 - x*y^3 + x; cached = false)
+    @test_throws ArgumentError Hecke.separating_element(F)
+    @test_throws ArgumentError Hecke.canonical_divisor(F)
+    @test_throws ArgumentError Hecke.genus(F)
+  end
+
+    @testset "Algebraic function field over rationals (1)" begin
+      kx, x = rational_function_field(QQ, :x; cached = false)
+      ky, y = polynomial_ring(kx, :y; cached = false)
+      F, a = function_field(y^2 - x^3 - 1; cached = false)
       Ofin = finite_maximal_order(F)
       Oinf = infinite_maximal_order(F)
 
@@ -83,8 +140,9 @@ import Hecke: divisor
     end
 
     @testset "Algebraic function field over rationals (2)" begin
-
-      F, a = function_field(y^4 - 3*y + x^6 +x^2 - 1)
+      kx, x = rational_function_field(QQ, :x; cached = false)
+      ky, y = polynomial_ring(kx, :y; cached = false)
+      F, a = function_field(y^4 - 3*y + x^6 +x^2 - 1; cached = false)
       Ofin = finite_maximal_order(F)
       Oinf = infinite_maximal_order(F)
 

--- a/test/FunField/Divisor.jl
+++ b/test/FunField/Divisor.jl
@@ -67,6 +67,42 @@ import Hecke: divisor
     @test_throws ArgumentError Hecke.genus(F)
   end
 
+  @testset "Riemann-Roch" begin
+    for base_field in [QQ, finite_field(2,4)[1], finite_field(5, 2)[1], finite_field(101)[1]]
+      kx, x = rational_function_field(base_field, :x; cached = false)
+      ky, y = polynomial_ring(kx, :y; cached = false)
+      for poly in [y^3 - x - 1, y^3 - x^3 - 1, y^3 - x^17 - 1]
+        F, a = function_field(poly; cached = false)
+        Ofin, Oinf = finite_maximal_order(F), infinite_maximal_order(F)
+
+        g = genus(F)
+        CD = canonical_divisor(F)
+
+        p1, _ = @inferred first(factor(ideal(Ofin, x - 13)))
+        p2, _ = first(factor(ideal(Oinf, base_ring(Oinf)(1//x))))
+        D1, D2 = divisor(p1), divisor(p2)
+
+        # Riemann-Roch: l(D) - l(K-D) = deg(D) - g + 1
+        for n in -3:3
+          D = n*D1 + D2
+          @test dimension(D) - index_of_speciality(D) == degree(D) - g + 1
+          D = D1 + n*D2
+          @test dimension(D) - index_of_speciality(D) == degree(D) - g + 1
+        end
+
+        # 2 * (l(K) - l(0)) = deg(K) - deg(0)
+        @test degree(CD) == 2*g - 2
+        @test degree(trivial_divisor(F)) == 0
+        @test dimension(CD) - dimension(trivial_divisor(F)) == g - 1
+
+        # l(D) = 0 for deg(D) < 0
+        @test dimension(-3*D1) == 0
+        @test dimension(-D2) == 0
+        @test dimension(-D1 - 3*D2) == 0
+      end
+    end
+  end
+
     @testset "Algebraic function field over rationals (1)" begin
       kx, x = rational_function_field(QQ, :x; cached = false)
       ky, y = polynomial_ring(kx, :y; cached = false)

--- a/test/FunField/Divisor.jl
+++ b/test/FunField/Divisor.jl
@@ -2,9 +2,6 @@ import Hecke: divisor
 
 @testset "Divisors" begin
 
-  # NOTE: currently we cannot quite use @inferred of gcd/lcm
-  #   due to GenOrd losing type stability on ideal operations
-  #   this will be fixed later separately
   @testset "Basic Operations" begin
     kx, x = rational_function_field(QQ, :x; cached = false)
     ky, y = polynomial_ring(kx, :y; cached = false)
@@ -26,24 +23,27 @@ import Hecke: divisor
 
     D1 = d1 + 5*d2
     D2 = d1 + 2*d2 - 3*d3
-    @test gcd(D1, D2) == d1 + 2*d2 - 3*d3
-    @test gcd(D1, D2) == gcd(D2, D1)
-    @test lcm(D1, D2) == d1 + 5*d2
-    @test lcm(D1, D2) == lcm(D2, D1)
+    @test @inferred(gcd(D1, D2)) == d1 + 2*d2 - 3*d3
+    @test @inferred(gcd(D1, D2)) == gcd(D2, D1)
+    @test @inferred(lcm(D1, D2)) == d1 + 5*d2
+    @test @inferred(lcm(D1, D2)) == lcm(D2, D1)
+    @test @inferred(lcm(D1, D2) + gcd(D1, D2)) == D1 + D2
 
     D1 = d1 + 3*d4
     D2 = 2*d1 - 3*d3
-    @test gcd(D1, D2) == d1 - 3*d3
-    @test gcd(D1, D2) == gcd(D2, D1)
-    @test lcm(D1, D2) == 2*d1 + 3*d4
-    @test lcm(D1, D2) == lcm(D2, D1)
+    @test @inferred(gcd(D1, D2)) == d1 - 3*d3
+    @test @inferred(gcd(D1, D2)) == gcd(D2, D1)
+    @test @inferred(lcm(D1, D2)) == 2*d1 + 3*d4
+    @test @inferred(lcm(D1, D2)) == lcm(D2, D1)
+    @test @inferred(lcm(D1, D2) + gcd(D1, D2)) == D1 + D2
 
     D1 = d1 - 3*d4
     D2 = 2*d1
-    @test gcd(D1, D2) == D1
-    @test gcd(D2, D1) == D1
-    @test lcm(D1, D2) == 2*d1
-    @test lcm(D1, D2) == lcm(D2, D1)
+    @test @inferred(gcd(D1, D2)) == D1
+    @test @inferred(gcd(D2, D1)) == D1
+    @test @inferred(lcm(D1, D2)) == 2*d1
+    @test @inferred(lcm(D1, D2)) == lcm(D2, D1)
+    @test @inferred(lcm(D1, D2) + gcd(D1, D2)) == D1 + D2
   end
 
   @testset "Not Separable Extension" begin


### PR DESCRIPTION
- Type Stability: parametrized `Divisor` with explicit constraints: `Divisor{S <: Generic.FunctionField, T1 <: PolyRing, T2 <: KInftyRing}`; added extra type assertions to `GenOrdIdl.basis_matrix`, and `GenOrdFracIdl.denominator` along with explicit matrix construction (from view) in `GenOrdIdl` constructor
- Added valuation for `GenOrdFracIdl`, fixed valuation of `GenOrdIdl` argument order
- Fixed Divisor.isless to check support primes of both divisors
- Extracted trivial helpers to remove excessive duplication of code handling finite/infinite support
- Added explicit is_separable guards to functions that assume it implicitly due to current implementation (separating_element, canonical_divisor, genus, index_of_speciality)
- Added lcm for divisors, added tests for gcd/lcm
- Added explicit Riemann-Roch theorem testing for function fields over QQ(x) and F_q(x) and across different genera