### PR TITLE
Fix two issues with unit_group_fac_elem for AlgAssAbsOrd (#2242)

### DIFF
--- a/src/AlgAssAbsOrd/UnitGroup.jl
+++ b/src/AlgAssAbsOrd/UnitGroup.jl
@@ -19,14 +19,14 @@ function unit_group(O::AlgAssAbsOrd; GRH::Bool = true)
   return domain(mU), mU
 end
 
-function unit_group_fac_elem(O::AlgAssAbsOrd)
+function unit_group_fac_elem(O::AlgAssAbsOrd; GRH::Bool = true)
   @assert is_commutative(O)
   mU = get_attribute!(O, :unit_group_fac_elem) do
     if is_maximal(O)
-      U, mU = _unit_group_maximal_fac_elem(O)
+      U, mU = _unit_group_maximal_fac_elem(O; GRH = GRH)
     else
       OK = maximal_order(O)
-      UU, mUU = unit_group_fac_elem(OK)
+      UU, mUU = unit_group_fac_elem(OK; GRH = GRH)
       U, mU = _unit_group_non_maximal(O, OK, mUU)
     end
     return mU
@@ -54,10 +54,10 @@ end
 #  return FacElem(domain(f), D)
 #end
 
-function _unit_group_maximal_fac_elem(O::AlgAssAbsOrd)
+function _unit_group_maximal_fac_elem(O::AlgAssAbsOrd; GRH::Bool = true)
   A = algebra(O)
   fields_and_maps = as_number_fields(A)
-  unit_groups = Tuple{FinGenAbGroup, MapUnitGrp{FacElemMon{AbsSimpleNumField}}}[unit_group_fac_elem(maximal_order(field)) for (field, map) in fields_and_maps ]
+  unit_groups = Tuple{FinGenAbGroup, MapUnitGrp{FacElemMon{AbsSimpleNumField}}}[unit_group_fac_elem(maximal_order(field); GRH = GRH) for (field, map) in fields_and_maps ]
   G = unit_groups[1][1]
   for i = 2:length(unit_groups)
     G = direct_product(G, unit_groups[i][1], task = :none)::FinGenAbGroup

--- a/src/NumFieldOrd/NfOrd/Ideal/Ideal.jl
+++ b/src/NumFieldOrd/NfOrd/Ideal/Ideal.jl
@@ -168,6 +168,10 @@ function ideal(O::AbsNumFieldOrder, v::Vector{<:AbsNumFieldOrderElem})
   for i = 1:length(v)
     @assert O === parent(v[i])
   end
+  v = filter(!is_zero, v)
+  if isempty(v)
+    return ideal(O, 0)
+  end
   M = zero_matrix(ZZ, 2*degree(O), degree(O))
   M1 = representation_matrix(v[1])
   _hnf!(M1, :lowerleft)

--- a/test/AlgAssAbsOrd/PicardGroup.jl
+++ b/test/AlgAssAbsOrd/PicardGroup.jl
@@ -124,4 +124,18 @@ end
   @test abs(norm(evaluate(u))) == 1
   @test evaluate(u) in O
   @test is_trivial(quo(U, [mU\(O(evaluate(mUU(u)))) for u in gens(UU)])[1])
+
+  # GRH keyword argument (issue #2242)
+  UU2, mUU2 = unit_group_fac_elem(O; GRH = false)
+  @test is_trivial(quo(U, [mU\(O(evaluate(mUU2(u)))) for u in gens(UU2)])[1])
+
+  # unit_group_fac_elem should work regardless of basis order (issue #2242)
+  bs = [
+    matrix(QQ, [0 599 0; 0 6 0; 0 -168 0]),
+    identity_matrix(QQ, 3),
+  ]
+  A2 = matrix_algebra(QQ, bs)
+  O2 = order(A2, bs)
+  UU3, mUU3 = unit_group_fac_elem(O2)
+  @test !is_trivial(UU3)
 end

--- a/test/NfOrd/Ideal.jl
+++ b/test/NfOrd/Ideal.jl
@@ -39,6 +39,9 @@
 
     @test is_zero(ideal(O1, 0))
     @test is_zero(ideal(O1, ZZ(0)))
+
+    # ideal from vector of zeros should return the zero ideal
+    @test is_zero(ideal(O1, [O1(0), O1(0)]))
   end
 
   I = ideal(O1, -17)


### PR DESCRIPTION
Fixes #2242.

Two fixes:

1. **`ideal(O::AbsNumFieldOrder, v::Vector)` with all-zero input**

2. **Missing `GRH` keyword argument in `unit_group_fac_elem(O::AlgAssAbsOrd)`**