### PR TITLE
Enable Aqua.jl tests and fix failures

### DIFF
--- a/src/AlgAss/Elem.jl
+++ b/src/AlgAss/Elem.jl
@@ -708,7 +708,7 @@ function (A::GroupAlgebra{T, S, R})(d::Dict{R, <: Any}) where {T, S, R}
   end
 end
 
-function (A::GroupAlgebra{T, S, R})(x0::Pair{R, <: Any}, x::Vararg{U}) where {T, S, R, U <: Pair{R, <: Any}}
+function (A::GroupAlgebra{T, S, R})(x0::Pair{R}, x::Pair{R}...) where {T, S, R}
   return A(Dict(x0, x...))
 end
 

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -47,7 +47,7 @@ export GenOrdFracIdl
 export FinGenAbGroup
 export FinGenAbGroupElem
 export FinGenAbGroupHom
-export FinGenAbGroupToGroupHo
+export FinGenAbGroupToGroupHom
 export FiniteRing
 export FiniteRingElem
 export FiniteRingHom
@@ -204,7 +204,6 @@ export class_group
 export class_number
 export classical_modular_polynomial
 export clebsch_from_igusa_clebsch
-export clebsch_from_igusa
 export clebsch_invariants
 export close_vectors
 export close_vectors_iterator

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -255,7 +255,7 @@ function print_res_recursively(testset, cur_level, max_level)
   end
 end
 
-#include("Aqua.jl")
+include("Aqua.jl")
 
 if short_test
   include("setup.jl")


### PR DESCRIPTION
Fixes #2091

## Changes

- Uncomment `include("Aqua.jl")` in `test/runtests.jl` so the Aqua tests actually run
- Fix typo in `exports.jl`: `FinGenAbGroupToGroupHo` → `FinGenAbGroupToGroupHom`
- Remove non-existent export `clebsch_from_igusa` from `exports.jl`
- Fix unbound type parameter in `GroupAlgebra` constructor in `src/AlgAss/Elem.jl`