### PR TITLE
GenOrd: cleanup, fixes, type stability

### DIFF
--- a/src/FunField/DegreeLocalization.jl
+++ b/src/FunField/DegreeLocalization.jl
@@ -57,7 +57,7 @@ characteristic(R::KInftyRing) = characteristic(R.K)
 Return the degree of the given element, i.e.
 `degree(numerator) - degree(denominator)`.
 """
-degree(a::KInftyElem) = degree(numerator(a, false)) - degree(denominator(a, false))
+degree(a::KInftyElem)::Int = degree(numerator(a, false)) - degree(denominator(a, false))
 
 @doc raw"""
     valuation(a::KInftyElem)

--- a/src/FunField/DegreeLocalization.jl
+++ b/src/FunField/DegreeLocalization.jl
@@ -13,18 +13,16 @@
 #
 ###############################################################################
 
-elem_type(::Type{KInftyRing{T}}) where T <: FieldElement = KInftyElem{T}
+elem_type(::Type{KInftyRing{T,U}}) where {T, U} = KInftyElem{T, U}
 
-parent_type(::Type{KInftyElem{T}}) where T <: FieldElement = KInftyRing{T}
+parent_type(::Type{KInftyElem{T, U}}) where {T, U} = KInftyRing{T, U}
 
-is_domain_type(::Type{KInftyElem{T}}) where {T} = true
+is_domain_type(::Type{KInftyElem{T, U}}) where {T, U} = true
 
 # return the rational function field which KInfty wraps, mostly internal use
-function function_field(R::KInftyRing{T}) where T <: FieldElement
-  return R.K::Generic.RationalFunctionField{T}
-end
+function_field(R::KInftyRing) = R.K
 
-parent(a::KInftyElem{T}) where T <: FieldElement = a.parent
+parent(a::KInftyElem) = a.parent
 
 function Base.hash(a::KInftyElem, h::UInt)
   b = 0x32ba43ad011affd1%UInt
@@ -37,13 +35,13 @@ end
 #
 ###############################################################################
 
-data(a::KInftyElem{T}) where T <: FieldElement = a.d::Generic.RationalFunctionFieldElem{T}
+data(a::KInftyElem) = a.d
 
-function numerator(a::KInftyElem{T}, canonicalise::Bool=true) where T <: FieldElement
+function numerator(a::KInftyElem, canonicalise::Bool=true)
   return numerator(data(a), canonicalise)
 end
 
-function denominator(a::KInftyElem{T}, canonicalise::Bool=true) where T <: FieldElement
+function denominator(a::KInftyElem, canonicalise::Bool=true)
   return denominator(data(a), canonicalise)
 end
 
@@ -57,7 +55,7 @@ characteristic(R::KInftyRing) = characteristic(R.K)
 Return the degree of the given element, i.e.
 `degree(numerator) - degree(denominator)`.
 """
-degree(a::KInftyElem)::Int = degree(numerator(a, false)) - degree(denominator(a, false))
+degree(a::KInftyElem) = degree(numerator(a, false)) - degree(denominator(a, false))
 
 @doc raw"""
     valuation(a::KInftyElem)
@@ -66,33 +64,30 @@ Return the degree valuation of the given element, i.e. `-degree(a)`.
 """
 valuation(a::KInftyElem) = -degree(a)
 
-zero(K::KInftyRing{T}) where T <: FieldElement = K(0)
+zero(K::KInftyRing) = K(0)
+one(K::KInftyRing)  = K(1)
 
-one(K::KInftyRing{T}) where T <: FieldElement = K(1)
+is_zero(a::KInftyElem) = is_zero(data(a))
+is_one(a::KInftyElem)  = is_one(data(a))
 
-iszero(a::KInftyElem{T}) where T <: FieldElement = iszero(data(a))
-
-isone(a::KInftyElem{T}) where T <: FieldElement = isone(data(a))
-
-function is_unit(a::KInftyElem{T}) where T <: FieldElement
-  return degree(numerator(data(a), false)) ==
-                                            degree(denominator(data(a), false))
+function is_unit(a::KInftyElem)
+  return degree(numerator(data(a), false)) == degree(denominator(data(a), false))
 end
 
 @doc raw"""
-    in(a::Generic.RationalFunctionFieldElem{T}, R::KInftyRing{T}) where T <: FieldElement
+    in(a::Generic.RationalFunctionFieldElem{T,U}, R::KInftyRing{T,U})
 
 Return `true` if the given element of the rational function field is an
 element of $k_\infty(x)$, i.e. if `degree(numerator) <= degree(denominator)`.
 """
-function in(a::Generic.RationalFunctionFieldElem{T}, R::KInftyRing{T}) where T <: FieldElement
+function in(a::Generic.RationalFunctionFieldElem{T,U}, R::KInftyRing{T,U}) where {T, U}
   if parent(a) != function_field(R)
     return false
   end
   return degree(numerator(a, false)) <= degree(denominator(a, false))
 end
 
-function Base.deepcopy_internal(a::KInftyElem{T}, dict::IdDict) where T <: FieldElement
+function Base.deepcopy_internal(a::KInftyElem, dict::IdDict)
   c = Base.deepcopy_internal(data(a), dict)
   parent(a)(Base.deepcopy_internal(data(a), dict))
 end
@@ -121,7 +116,7 @@ end
 #
 ###############################################################################
 
-function -(a::KInftyElem{T}) where T <: FieldElement
+function -(a::KInftyElem)
   parent(a)(-data(a), false)
 end
 
@@ -131,17 +126,17 @@ end
 #
 ###############################################################################
 
-function +(a::KInftyElem{T}, b::KInftyElem{T})  where T <: FieldElement
+function +(a::KInftyElem{T,U}, b::KInftyElem{T,U})  where {T,U}
   check_parent(a, b)
   return parent(a)(data(a) + data(b), false)
 end
 
-function -(a::KInftyElem{T}, b::KInftyElem{T})  where T <: FieldElement
+function -(a::KInftyElem{T,U}, b::KInftyElem{T,U})  where {T,U}
   check_parent(a, b)
   return parent(a)(data(a) - data(b), false)
 end
 
-function *(a::KInftyElem{T}, b::KInftyElem{T})  where T <: FieldElement
+function *(a::KInftyElem{T,U}, b::KInftyElem{T,U})  where {T,U}
   check_parent(a, b)
   return parent(a)(data(a)*data(b), false)
 end
@@ -152,7 +147,7 @@ end
 #
 ###############################################################################
 
-function mul!(a::KInftyElem{T}, b::KInftyElem{T}, c::KInftyElem{T}) where {T}
+function mul!(a::KInftyElem{T,U}, b::KInftyElem{T,U}, c::KInftyElem{T,U}) where {T,U}
   return b*c
 end
 
@@ -162,7 +157,7 @@ end
 #
 ###############################################################################
 
-function ==(a::KInftyElem{T}, b::KInftyElem{T}) where T <: FieldElement
+function ==(a::KInftyElem{T,U}, b::KInftyElem{T,U}) where {T,U}
   check_parent(a, b)
   return data(a) == data(b)
 end
@@ -174,12 +169,12 @@ end
 ###############################################################################
 
 @doc raw"""
-     inv(a::KInftyElem{T}, checked::Bool = true)  where T <: FieldElement
+     inv(a::KInftyElem, checked::Bool = true)
 Returns the inverse element of $a$ if $a$ is a unit.
 If 'checked = false' the invertibility of $a$ is not checked and the
 corresponding inverse element of the rational function field is returned.
 """
-function inv(a::KInftyElem{T}, checked::Bool = true)  where T <: FieldElement
+function inv(a::KInftyElem, checked::Bool = true)
   b = inv(data(a))
   return parent(a)(b, checked)
 end
@@ -191,7 +186,7 @@ end
 ###############################################################################
 
 @doc raw"""
-     divides(a::KInftyElem{T}, b::KInftyElem{T}, checked::Bool = true) where T <: FieldElement
+     divides(a::KInftyElem, b::KInftyElem, checked::Bool = true)
 
 Returns tuple `(flag, c)` where `flag = true` if $b$ divides $a$ and $a = bc$,
 otherwise `flag = false` and $c = 0$.
@@ -199,7 +194,7 @@ If `checked = false` the corresponding element of the rational function field
 is returned and it is not checked whether it is an element of the given
 localization.
 """
-function divides(a::KInftyElem{T}, b::KInftyElem{T}, checked::Bool = true) where T <: FieldElement
+function divides(a::KInftyElem{T,U}, b::KInftyElem{T,U}, checked::Bool = true) where {T,U}
   check_parent(a, b)
 
   iszero(a) && return true, a
@@ -209,13 +204,13 @@ function divides(a::KInftyElem{T}, b::KInftyElem{T}, checked::Bool = true) where
 end
 
 @doc raw"""
-     divexact(a::KInftyElem{T}, b::KInftyElem{T}, checked::Bool = true)  where {T <: AbsSimpleNumFieldElem}
+     divexact(a::KInftyElem, b::KInftyElem, checked::Bool = true)
 Returns element 'c' of given localization such that $a = bc$ if such element
 exists. If `checked = false` the corresponding element of the rational function
 field is returned and it is not checked whether it is an element of the given
 localization.
 """
-function divexact(a::KInftyElem{T}, b::KInftyElem{T}; check::Bool = true)  where T <: FieldElement
+function divexact(a::KInftyElem{T,U}, b::KInftyElem{T,U}; check::Bool = true) where {T,U}
   iszero(b) && throw(DivideError())
 
   flag, quo = divides(a, b, check)
@@ -232,7 +227,7 @@ end
 
 # compute the canonical representative of a modulo <b> = <1/x^n> with n = v(b)
 #   this is the truncation of a power series in uniformizer 1/x to the first n terms
-function mod(a::KInftyElem{T}, b::KInftyElem{T}) where T <: FieldElement
+function mod(a::KInftyElem{T,U}, b::KInftyElem{T,U}) where {T,U}
   check_parent(a, b)
   iszero(b) && throw(DivideError())
   iszero(a) && return a
@@ -265,12 +260,12 @@ function mod(a::KInftyElem{T}, b::KInftyElem{T}) where T <: FieldElement
   return parent(a)( Qx(reverse(r)) // Qx(x)^degree(r) )
 end
 
-function div(a::KInftyElem{T}, b::KInftyElem{T}) where T <: FieldElement
+function div(a::KInftyElem{T,U}, b::KInftyElem{T,U}) where {T,U}
   check_parent(a, b)
   return divrem(a, b)[1]
 end
 
-function divrem(a::KInftyElem{T}, b::KInftyElem{T}) where T <: FieldElement
+function divrem(a::KInftyElem{T,U}, b::KInftyElem{T,U}) where {T,U}
   check_parent(a, b)
   iszero(b) && throw(DivideError())
   iszero(a) && return a, a
@@ -283,7 +278,7 @@ function divrem(a::KInftyElem{T}, b::KInftyElem{T}) where T <: FieldElement
   end
 end
 
-Base.rem(a::KInftyElem{T}, b::KInftyElem{T}) where T <: FieldElement = mod(a, b)
+Base.rem(a::KInftyElem{T,U}, b::KInftyElem{T,U}) where {T,U} = mod(a, b)
 
 ###############################################################################
 #
@@ -291,7 +286,7 @@ Base.rem(a::KInftyElem{T}, b::KInftyElem{T}) where T <: FieldElement = mod(a, b)
 #
 ###############################################################################
 
-function gcd(a::KInftyElem{T}, b::KInftyElem{T}) where T <: FieldElement
+function gcd(a::KInftyElem{T,U}, b::KInftyElem{T,U}) where {T,U}
   check_parent(a, b)
   t = gen(parent(a))
 
@@ -304,7 +299,7 @@ function gcd(a::KInftyElem{T}, b::KInftyElem{T}) where T <: FieldElement
   end
 end
 
-function lcm(a::KInftyElem{T}, b::KInftyElem{T}) where T <: FieldElement
+function lcm(a::KInftyElem{T,U}, b::KInftyElem{T,U}) where {T,U}
   check_parent(a, b)
 
   if iszero(a) || iszero(b)
@@ -321,7 +316,7 @@ end
 #
 ###############################################################################
 
-function gcdx(a::KInftyElem{T}, b::KInftyElem{T}) where T <: FieldElement
+function gcdx(a::KInftyElem{T,U}, b::KInftyElem{T,U}) where {T,U}
   check_parent(a, b)
   K = parent(a)
   t = gen(K)
@@ -341,7 +336,7 @@ function gcdx(a::KInftyElem{T}, b::KInftyElem{T}) where T <: FieldElement
   return t^valuation(b), zero(K), inv(canonical_unit(b))
 end
 
-function gcdinv(a::KInftyElem{T}, b::KInftyElem{T}) where {T}
+function gcdinv(a::KInftyElem{T,U}, b::KInftyElem{T,U}) where {T,U}
   g, q, w = gcdx(a, b)
   @assert is_unit(g)
   return one(parent(a)), q*inv(g)
@@ -353,7 +348,7 @@ end
 #
 ###############################################################################
 
-function ^(a::KInftyElem{T}, b::Int) where T <: FieldElement
+function ^(a::KInftyElem, b::Int)
   return parent(a)(data(a)^b, false)
 end
 
@@ -400,14 +395,14 @@ rand(S::KInftyRing, v...) = rand(GLOBAL_RNG, S, v...)
 #
 ###############################################################################
 
-AbstractAlgebra.promote_rule(::Type{KInftyElem{T}}, ::Type{KInftyElem{T}}) where T <: FieldElement = KInftyElem{T}
+AbstractAlgebra.promote_rule(::Type{KInftyElem{T,U}}, ::Type{KInftyElem{T,U}}) where {T,U} = KInftyElem{T,U}
 
-function AbstractAlgebra.promote_rule(::Type{KInftyElem{T}}, ::Type{U}) where {T <: FieldElement, U <: Generic.RationalFunctionFieldElem{T}}
-  return U
+function AbstractAlgebra.promote_rule(::Type{KInftyElem{T,U}}, ::Type{S}) where {T,U, S <: Generic.RationalFunctionFieldElem{T,U}}
+  return S
 end
 
-function AbstractAlgebra.promote_rule(::Type{KInftyElem{T}}, ::Type{U}) where {T <: FieldElement, U <: RingElem}
-  promote_rule(T, U) == T ? KInftyElem{T} : Union{}
+function AbstractAlgebra.promote_rule(::Type{KInftyElem{T,U}}, ::Type{S}) where {T,U, S <: RingElem}
+  promote_rule(T, U) == T ? KInftyElem{T,U} : Union{}
 end
 
 ###############################################################################
@@ -418,15 +413,15 @@ end
 
 (R::KInftyRing)() = R(function_field(R)())
 
-function (R::KInftyRing{T})(a::Generic.RationalFunctionFieldElem{T}, checked::Bool=true) where T <: FieldElement
+function (R::KInftyRing{T,U})(a::Generic.RationalFunctionFieldElem{T,U}, checked::Bool=true) where {T, U}
   checked && degree(numerator(a, false)) > degree(denominator(a, false)) &&
                                            error("Not an element of k_infty(x)")
-  return KInftyElem{T}(a, R)
+  return KInftyElem{T,U}(a, R)
 end
 
-(R::KInftyRing)(a::RingElement) = R(function_field(R)(a), false)
+(R::KInftyRing{T,U})(a::RingElement) where {T, U} = R(function_field(R)(a), false)
 
-function (R::KInftyRing{T})(a::KInftyElem{T}) where T <: FieldElement
+function (R::KInftyRing{T,U})(a::KInftyElem{T,U}) where {T, U}
   parent(a) != R && error("Cannot coerce element")
   return a
 end
@@ -464,7 +459,7 @@ end
 #
 ###############################################################################
 
-function residue_field(K::KInftyRing{T}, a::KInftyElem{T}) where {T <: FieldElement}
+function residue_field(K::KInftyRing{T,U}, a::KInftyElem{T,U}) where {T,U}
   F = base_ring(K.K)
   @assert degree(a) == -1
   #TODO: can be optimized, see blurb of euc. div. above
@@ -480,8 +475,6 @@ field $k(x)$, i.e. the localization of the function field at the point at
 infinity, i.e. the valuation ring for valuation $-$degree$(x)$. This is the ring
 $k_\infty(x) = \{ f/g | \deg(f) \leq \deg(g)\}$.
 """
-function localization(K::Generic.RationalFunctionField{T}, ::typeof(degree); cached::Bool=true) where T <: FieldElement
-  return KInftyRing{T}(K, cached)
+function localization(K::Generic.RationalFunctionField{T, U}, ::typeof(degree); cached::Bool = true) where {T, U}
+  return KInftyRing{T, U}(K; cached = cached)
 end
-
-

--- a/src/FunField/Divisor.jl
+++ b/src/FunField/Divisor.jl
@@ -448,8 +448,27 @@ end
 Return the degree of D.
 """
 function degree(D::Divisor)
-  L = support(D)
-  return sum(degree(f)*e for (f, e) in L; init = zero(Int))::Int
+  # A divisor D = sum_P n_P * P has degree sum_P n_P * deg(P), where P ranges
+  #   over *places* of F/K (K the field of constants).
+  #
+  # For a place P lying over a (finite) prime p in the base ring,
+  #   deg(P) = [F_P : K] = f(P) * deg(p),
+  # where f(P) is the inertia degree and deg(p) is the degree of p as a
+  # polynomial in the base ring.
+  #
+  # For infinite places, p lies in KInftyRing.
+  # The formula above stays correct if we read deg(p) as the degree of p
+  # as a polynomial in the local parameter t = 1/x.
+  # However, `degree(::KInftyElem)` returns the degree in x, which is -(degree in t).
+  # We therefore compensate by subtracting the infinite contribution rather than adding it.
+  function deg_place(p::GenOrdIdl, e::Integer)
+    return degree(p)*degree(minimum(p))*e
+  end
+
+  fin_deg = sum(deg_place(f, e) for (f, e) in finite_support(D); init = zero(Int))
+  inf_deg = sum(deg_place(f, e) for (f, e) in infinite_support(D); init = zero(Int))
+
+  return fin_deg - inf_deg
 end
 
 @doc raw"""

--- a/src/FunField/Divisor.jl
+++ b/src/FunField/Divisor.jl
@@ -183,9 +183,15 @@ end
 Return the infinite maximal order of K
 """
 function infinite_maximal_order(K::AbstractAlgebra.Generic.FunctionField{T}) where {T <: FieldElement}
+  return _infinite_maximal_order_function_field_typed(K, base_ring(K))
+end
+
+# Function-barrier helper. K's type (FunctionField) only carries T,
+#   so we recover U from base_ring(K) to get a fully concrete KInftyRing{T, U}
+function _infinite_maximal_order_function_field_typed(K::F, ::Generic.RationalFunctionField{T, U}) where {T, U, F <: AbstractAlgebra.Generic.FunctionField{T}}
   get_attribute!(K, :infinite_maximal_order) do
     return _infinite_maximal_order(K)
-  end::GenOrd{AbstractAlgebra.Generic.FunctionField{T}, KInftyRing{T}}
+  end::GenOrd{F, KInftyRing{T, U}}
 end
 
 function _infinite_maximal_order(K::AbstractAlgebra.Generic.FunctionField)

--- a/src/GenOrd/Auxiliary.jl
+++ b/src/GenOrd/Auxiliary.jl
@@ -181,13 +181,16 @@ Hecke.is_domain_type(::Type{LocalizedEuclideanRingElem{ZZRingElem}}) = true
 # support for RationalFunctionFieldElem{T}
 #
 #######################################################################
-# RationalFunctionFieldElem{T}, KInftyRing{T}
 
-Base.denominator(x::AbstractAlgebra.Generic.RationalFunctionFieldElem{T}, R::KInftyRing{T}) where {T} = Hecke.integral_split(x, R)[2]
+function Base.denominator(x::AbstractAlgebra.Generic.RationalFunctionFieldElem{T,U}, R::KInftyRing{T,U}) where {T<:FieldElement, U<:PolyRingElem{T}}
+  return Hecke.integral_split(x, R)[2]
+end
 
-Base.numerator(x::AbstractAlgebra.Generic.RationalFunctionFieldElem{T}, R::KInftyRing{T}) where {T} = Hecke.integral_split(x, R)[1]
+function Base.numerator(x::AbstractAlgebra.Generic.RationalFunctionFieldElem{T,U}, R::KInftyRing{T,U}) where {T<:FieldElement, U<:PolyRingElem{T}}
+  return Hecke.integral_split(x, R)[1]
+end
 
-function Hecke.integral_split(x::AbstractAlgebra.Generic.RationalFunctionFieldElem{T}, R::KInftyRing{T}) where {T}
+function Hecke.integral_split(x::AbstractAlgebra.Generic.RationalFunctionFieldElem{T,U}, R::KInftyRing{T,U}) where {T<:FieldElement, U<:PolyRingElem{T}}
   if iszero(x)
     return zero(R), one(R)
   end
@@ -200,7 +203,7 @@ function Hecke.integral_split(x::AbstractAlgebra.Generic.RationalFunctionFieldEl
   return R(x*t^(b-a)), R(t^(b-a))
 end
 
-(R::Generic.RationalFunctionField{T})(x::KInftyElem{T}) where {T <: FieldElem} = x.d
+(R::Generic.RationalFunctionField{T,U})(x::KInftyElem{T,U}) where {T<:FieldElement, U<:PolyRingElem{T}} = x.d
 
 # RationalFunctionFieldElem{T}, PolyRing{T}
 function Hecke.numerator(a::Generic.RationalFunctionFieldElem{T}, S::PolyRing{T}) where {T}

--- a/src/GenOrd/Auxiliary.jl
+++ b/src/GenOrd/Auxiliary.jl
@@ -231,6 +231,20 @@ function Hecke.factor(R::S, a::Generic.RationalFunctionFieldElem{T}) where {T, S
   return Fac(u, Nemo._pretty_sort!(arr))
 end
 
+#######################################################################
+#
+# support for AbsSimpleNumFieldElem{T}
+#
+#######################################################################
+
+function Hecke.numerator(a::AbsSimpleNumFieldElem, O::GenOrd)
+  return integral_split(a, O)[1]
+end
+
+function Hecke.denominator(a::AbsSimpleNumFieldElem, O::GenOrd)
+  return integral_split(a, O)[2]
+end
+
 ########################################################################
 #
 # Matrices

--- a/src/GenOrd/FractionalIdeal.jl
+++ b/src/GenOrd/FractionalIdeal.jl
@@ -238,7 +238,7 @@ Hecke.is_integral(I::GenOrdIdl) = true
 
 function Hecke.is_integral(I::GenOrdFracIdl)
   simplify(I)
-  return denominator(I) == 1
+  return is_one(denominator(I))
 end
 
 ################################################################################

--- a/src/GenOrd/GenOrd.jl
+++ b/src/GenOrd/GenOrd.jl
@@ -430,7 +430,7 @@ function Hecke.integral_split(a::AbsSimpleNumFieldElem, O::GenOrd)
   return O(d.data*a, check =false), d #evil, but no legal way found
 end
 
-function Hecke.integral_split(a::AbsSimpleNumFieldElem, O::GenOrd{<: Any, ZZRing})
+function Hecke.integral_split(a::AbsSimpleNumFieldElem, O::GenOrd{<:Field, ZZRing})
   d = integral_split(coordinates(a, O), base_ring(O))[2]
   return O(d*a, check = false), d #evil, but no legal way found
 end

--- a/src/GenOrd/GenOrd.jl
+++ b/src/GenOrd/GenOrd.jl
@@ -662,7 +662,7 @@ function integral_closure(S::KInftyRing{T}, F::Generic.FunctionField{T}) where {
   return _integral_closure(S, F)
 end
 
-function _integral_closure(S::AbstractAlgebra.Ring, F::AbstractAlgebra.Ring)
+function _integral_closure(S::AbstractAlgebra.Ring, F::AbstractAlgebra.Field)
   O = GenOrd(S, F)
   return Hecke.maximal_order(O)
 end

--- a/src/GenOrd/GenOrd.jl
+++ b/src/GenOrd/GenOrd.jl
@@ -160,8 +160,10 @@ function (R::GenOrd{S, T})(a::RingElement; check::Bool = true) where {S, T}
   if parent(a) === field(R)
     return GenOrdElem(R, a, check)
   elseif AbstractAlgebra.promote_rule(elem_type(T), typeof(a)) === elem_type(T)
-    # so a can be coerced into base_ring(R), remove the check
-    return GenOrdElem(R, field(R)(a), false)
+    # a can be coerced into base_ring(R)
+    # make sure to go through the base field (where base ring lives)
+    F = field(R)
+    return GenOrdElem(R, F(base_field(F)(a)), false)
   else
     return GenOrdElem(R, field(R)(a), true)
   end

--- a/src/GenOrd/GenOrd.jl
+++ b/src/GenOrd/GenOrd.jl
@@ -661,7 +661,7 @@ function integral_closure(S::PolyRing{T}, F::Generic.FunctionField{T}) where {T}
   return _integral_closure(S, F)
 end
 
-function integral_closure(S::KInftyRing{T}, F::Generic.FunctionField{T}) where {T}
+function integral_closure(S::KInftyRing{T,U}, F::Generic.FunctionField{T}) where {T,U}
   return _integral_closure(S, F)
 end
 

--- a/src/GenOrd/GenOrd.jl
+++ b/src/GenOrd/GenOrd.jl
@@ -51,6 +51,9 @@ end
 # prepare for algebras, which are not domains
 is_domain_type(::Type{GenOrdElem{S, T}}) where {S, T} = is_domain_type(S)
 
+ideal_type(::Type{GenOrd{S, T}}) where {S, T} = GenOrdIdl{S, T}
+fractional_ideal_type(::Type{GenOrd{S, T}}) where {S, T} = GenOrdFracIdl{S, T}
+
 ################################################################################
 #
 #  Show

--- a/src/GenOrd/GenOrd.jl
+++ b/src/GenOrd/GenOrd.jl
@@ -141,7 +141,7 @@ function Base.show(io::IO, a::GenOrdElem)
 end
 
 function expressify(a::GenOrdElem; context = nothing)
-  return expressify(base_ring(R), context = context)
+  return expressify(data(a), context = context)
 end
 
 ################################################################################
@@ -435,7 +435,7 @@ function Hecke.integral_split(a::AbsSimpleNumFieldElem, O::GenOrd{<: Any, ZZRing
   return O(d*a, check = false), d #evil, but no legal way found
 end
 
-#############################3333333333333333333333############################3
+################################################################################
 #
 #  Modular arithmetic
 #
@@ -585,7 +585,7 @@ end
 ################################################################################
 
 function Hecke.pmaximal_overorder(O::GenOrd, p::RingElem, is_prime::Bool = false)
-  @vprintln :AbsNumFieldOrder 1 "computing a $p-maximal orderorder"
+  @vprintln :AbsNumFieldOrder 1 "computing a $p-maximal overorder"
 
   t = residue_field(parent(p), p)
 
@@ -885,7 +885,7 @@ function radical_basis_power_non_perfect(O::GenOrd, p::RingElem)
   M2 = transpose(B)
   M2 = map_entries(x->preimage(mF, x), M2)
   M3 = Hecke.hnf_modular(M2, p, true)
-  return return M3 #[O(vec(collect((M3[i, :])))) for i=1:degree(O)]
+  return M3 #[O(vec(collect((M3[i, :])))) for i=1:degree(O)]
 end
 
 ################################################################################

--- a/src/GenOrd/Ideal.jl
+++ b/src/GenOrd/Ideal.jl
@@ -83,9 +83,9 @@ function show(io::IO, id::GenOrdIdl)
   if isdefined(id, :princ_gen)
     print(io, "\nPrincipal generator ", id.princ_gen)
   end
-   if isdefined(id, :basis_matrix)
-     print(io, "\nBasis_matrix \n", id.basis_matrix)
-   end
+  if isdefined(id, :basis_matrix)
+    print(io, "\nBasis_matrix \n", id.basis_matrix)
+  end
 end
 
 

--- a/src/GenOrd/Ideal.jl
+++ b/src/GenOrd/Ideal.jl
@@ -836,17 +836,24 @@ end
 #
 ################################################################################
 
+@doc raw"""
+    degree(P::GenOrdIdl) -> Int
+    inertia_degree(P::GenOrdIdl) -> Int
+
+The inertia degree of the prime-ideal $P$.
+"""
 function degree(P::GenOrdIdl)
   @assert is_prime(P)
-  @assert P.splitting_type != [-1,-1]
-  deg_min = degree(minimum(P))
-  O = order(P)
-  if O == infinite_maximal_order(function_field(O))
-    deg_min = -deg_min
-  end
-  return P.splitting_type[2]*deg_min
+  return P.splitting_type[2]
 end
 
+inertia_degree(P::GenOrdIdl) = degree(P)
+
+@doc raw"""
+    ramification_index(P::GenOrdIdl) -> Int
+
+The ramification index of the prime-ideal $P$.
+"""
 function ramification_index(P::GenOrdIdl)
   @assert is_prime(P)
   return P.splitting_type[1]

--- a/src/GenOrd/Ideal.jl
+++ b/src/GenOrd/Ideal.jl
@@ -8,7 +8,9 @@ ideal(O::GenOrd, a::RingElement, b::RingElement) = GenOrdIdl(O, a, b)
 
 ideal(O::GenOrd, a::RingElement) = GenOrdIdl(O, a)
 
-ideal(O::GenOrd, a::MatElem) = GenOrdIdl(O, a)
+function ideal(O::GenOrd, M::MatElem)
+  return GenOrdIdl(O, hnf(M, :lowerleft))
+end
 
 function AbstractAlgebra.zero(a::GenOrdIdl)
   O = a.order
@@ -167,15 +169,15 @@ function assure_has_basis_matrix(A::GenOrdIdl)
   end
 
   if has_princ_gen(A)
-    A.basis_matrix = representation_matrix(A.princ_gen)
+    A.basis_matrix = hnf(representation_matrix(A.princ_gen), :lowerleft)
     return nothing
   end
 
   @hassert :AbsNumFieldOrder 1 has_2_elem(A)
 
-  V = hnf(reduce(vcat, [representation_matrix(x) for x in [O(A.gen_one),A.gen_two]]),:lowerleft)
+  V = hnf(reduce(vcat, [representation_matrix(x) for x in [O(A.gen_one),A.gen_two]]), :lowerleft)
   d = ncols(V)
-  A.basis_matrix = V[d+1:2*d,1:d]
+  A.basis_matrix = V[d+1:2*d, 1:d]
   return nothing
 end
 
@@ -428,20 +430,25 @@ function assure_has_minimum(A::GenOrdIdl)
   end
 
   O = order(A)
-  M = basis_matrix(A, copy = false)
-  d = prod([M[i, i] for i = 1:nrows(M)])
-  v = transpose(matrix(map(base_ring(O), coordinates(O(d)))))
-  fl, s = can_solve_with_solution(M, v, side = :left)
-  @assert fl
-  den = denominator(s[1]//d)
-  for i = 2:ncols(s)
-    den = lcm(den, denominator(s[i]//d))
-  end
 
-  if isa(den, KInftyElem)
-    A.minimum = O.R(Hecke.AbstractAlgebra.MPolyFactor.make_monic(numerator(den))//denominator(den))
-  elseif isa(den, PolyRingElem)
-    A.minimum = Hecke.AbstractAlgebra.MPolyFactor.make_monic(den)
+  if isone(basis(O, copy = false)[1])
+    A.minimum = deepcopy(basis_matrix(A, copy = false)[1, 1])
+  else
+    M = basis_matrix(A, copy = false)
+    d = prod([M[i, i] for i = 1:nrows(M)])
+    v = transpose(matrix(map(base_ring(O), coordinates(O(d)))))
+    fl, s = can_solve_with_solution(M, v, side = :left)
+    @assert fl
+    den = denominator(s[1]//d)
+    for i = 2:ncols(s)
+      den = lcm(den, denominator(s[i]//d))
+    end
+
+    if isa(den, KInftyElem)
+      A.minimum = O.R(Hecke.AbstractAlgebra.MPolyFactor.make_monic(numerator(den))//denominator(den))
+    elseif isa(den, PolyRingElem)
+      A.minimum = Hecke.AbstractAlgebra.MPolyFactor.make_monic(den)
+    end
   end
 
   return nothing

--- a/src/GenOrd/Ideal.jl
+++ b/src/GenOrd/Ideal.jl
@@ -588,6 +588,10 @@ end
 function prime_dec_nonindex(O::GenOrd{S, T}, p::RingElem, degree_limit::Int = 0, lower_limit::Int = 0) where {S, T}
   @req parent(p) === base_ring(O) "p must come from the base ring of O"
 
+  F = field(O)
+  B = base_field(F)
+  a = gen(F)
+
   K, mK = residue_field(base_ring(O), p)
 
   fmodp = map_coefficients(defining_polynomial(O.F); cached = false) do c
@@ -597,10 +601,9 @@ function prime_dec_nonindex(O::GenOrd{S, T}, p::RingElem, degree_limit::Int = 0,
   fact = factor(fmodp)
 
   result = Vector{Tuple{GenOrdIdl{S, T}, Int}}(undef, length(fact))
-  a = gen(field(O))
   for (i, (fac, e)) in enumerate(fact)
     f = degree(fac)
-    facnew = map_coefficients(y -> preimage(mK, y), fac, cached = false)
+    facnew = map_coefficients(y -> B(preimage(mK, y)), fac, cached = false)
     b = O(facnew(a))
     # We want a P-normal two-element presentation, i.e. v_P(b) = 1.
     # Since we are in the case of p not dividing the index, we have a good candidate b = g(a).

--- a/src/GenOrd/Ideal.jl
+++ b/src/GenOrd/Ideal.jl
@@ -585,13 +585,19 @@ function Hecke.index(O::GenOrd)
   return is_equation_order(O) ? O.R(1) : O.R(det(basis_matrix_inverse(O)))
 end
 
-# TODO: currently works only for function fields
-function prime_dec_nonindex(O::GenOrd{S, T}, p::PolyRingElem, degree_limit::Int = 0, lower_limit::Int = 0) where {S, T}
-  K, mK = residue_field(parent(p),p)
-  fact = factor(poly_to_residue(K, O.F.pol))
+function prime_dec_nonindex(O::GenOrd{S, T}, p::RingElem, degree_limit::Int = 0, lower_limit::Int = 0) where {S, T}
+  @req parent(p) === base_ring(O) "p must come from the base ring of O"
+
+  K, mK = residue_field(base_ring(O), p)
+
+  fmodp = map_coefficients(defining_polynomial(O.F); cached = false) do c
+    num, den = integral_split(c, base_ring(O))
+    mK(num) // mK(den)
+  end
+  fact = factor(fmodp)
+
   result = Vector{Tuple{GenOrdIdl{S, T}, Int}}(undef, length(fact))
-  F = function_field(O)
-  a = gen(F)
+  a = gen(field(O))
   for (i, (fac, e)) in enumerate(fact)
     f = degree(fac)
     facnew = map_coefficients(y -> preimage(mK, y), fac, cached = false)
@@ -624,17 +630,6 @@ function prime_dec_nonindex(O::GenOrd{S, T}, p::PolyRingElem, degree_limit::Int 
   end
   return result
 end
-
-
-function poly_to_residue(K::AbstractAlgebra.Field, poly::AbstractAlgebra.Generic.Poly{<:AbstractAlgebra.Generic.RationalFunctionFieldElem{T}}) where T
-  P, _ = polynomial_ring(K, :y)
-  if iszero(poly)
-    return zero(P)
-  else
-    return P([K(numerator(c)) // K(denominator(c)) for c in coefficients(poly)])
-  end
-end
-
 
 function Hecke.valuation(A::GenOrdIdl{S, T}, p::GenOrdIdl{S, T}) where {S, T}
   O = order(A)

--- a/src/GenOrd/Ideal.jl
+++ b/src/GenOrd/Ideal.jl
@@ -585,6 +585,7 @@ function Hecke.index(O::GenOrd)
   return is_equation_order(O) ? O.R(1) : O.R(det(basis_matrix_inverse(O)))
 end
 
+# TODO: currently works only for function fields
 function prime_dec_nonindex(O::GenOrd, p::PolyRingElem, degree_limit::Int = 0, lower_limit::Int = 0)
   K, mK = residue_field(parent(p),p)
   fact = factor(poly_to_residue(K, O.F.pol))
@@ -592,10 +593,30 @@ function prime_dec_nonindex(O::GenOrd, p::PolyRingElem, degree_limit::Int = 0, l
   F = function_field(O)
   a = gen(F)
   for (fac, e) in fact
-    facnew = map_coefficients(y -> preimage(mK, y), fac, cached = false)
-    I = GenOrdIdl(O, p, O(facnew(a)))
-    I.is_prime = 1
     f = degree(fac)
+    facnew = map_coefficients(y -> preimage(mK, y), fac, cached = false)
+    b = O(facnew(a))
+    # We want a P-normal two-element presentation, i.e. v_P(b) = 1.
+    # Since we are in the case of p not dividing the index, we have a good candidate b = g(a).
+    #
+    # v_P(<p,b>) = min[v_P(p), v_P(b)] = 1.
+    # Ramified case   (e > 1): v_P(p) = e > 1, so v_P(b) = 1 is forced.
+    # Unramified case (e = 1): v_P(b) can exceed 1, in which case
+    #   v_P(b + p) = min(v_P(b), 1) = 1
+    # For other primes Q over p, v_Q(b) > 0 would give v_Q(<p, b>) > 0,
+    #   giving <p,b> subset of Q, contradicting <p, b> = P.
+    #
+    # In the unramified case we need to check if v_P(b) == 1.
+    # One possibility is to check if p*N(P) = p^{f+1} divides N(b)
+    #   and if it doesn't, we must have v_P(b) == 1.
+    # Unlike the number field case, b can be zero (single inert prime over p),
+    #   which is also covered by adding p.
+    if e == 1 && (is_zero(b) || divides(norm(b), p^(f + 1))[1])
+      b = b + O(p)
+    end
+
+    I = GenOrdIdl(O, p, b)
+    I.is_prime = 1
     I.splitting_type = e, f
     I.norm = p^f
     I.minimum = p

--- a/src/GenOrd/Ideal.jl
+++ b/src/GenOrd/Ideal.jl
@@ -586,13 +586,13 @@ function Hecke.index(O::GenOrd)
 end
 
 # TODO: currently works only for function fields
-function prime_dec_nonindex(O::GenOrd, p::PolyRingElem, degree_limit::Int = 0, lower_limit::Int = 0)
+function prime_dec_nonindex(O::GenOrd{S, T}, p::PolyRingElem, degree_limit::Int = 0, lower_limit::Int = 0) where {S, T}
   K, mK = residue_field(parent(p),p)
   fact = factor(poly_to_residue(K, O.F.pol))
-  result = []
+  result = Vector{Tuple{GenOrdIdl{S, T}, Int}}(undef, length(fact))
   F = function_field(O)
   a = gen(F)
-  for (fac, e) in fact
+  for (i, (fac, e)) in enumerate(fact)
     f = degree(fac)
     facnew = map_coefficients(y -> preimage(mK, y), fac, cached = false)
     b = O(facnew(a))
@@ -620,19 +620,18 @@ function prime_dec_nonindex(O::GenOrd, p::PolyRingElem, degree_limit::Int = 0, l
     I.splitting_type = e, f
     I.norm = p^f
     I.minimum = p
-    push!(result,(I,e))
+    result[i] = (I,e)
   end
   return result
 end
 
 
-function poly_to_residue(K::AbstractAlgebra.Field, poly:: AbstractAlgebra.Generic.Poly{<:AbstractAlgebra.Generic.RationalFunctionFieldElem{T}}) where T
+function poly_to_residue(K::AbstractAlgebra.Field, poly::AbstractAlgebra.Generic.Poly{<:AbstractAlgebra.Generic.RationalFunctionFieldElem{T}}) where T
+  P, _ = polynomial_ring(K, :y)
   if iszero(poly)
-    return zero(K)
+    return zero(P)
   else
-    P, y = polynomial_ring(K,"y")
-    coeffs = coefficients(poly)
-    return sum([K(numerator(coeffs[i]))//K(denominator(coeffs[i]))*y^i for i in (0:length(poly)-1)])
+    return P([K(numerator(c)) // K(denominator(c)) for c in coefficients(poly)])
   end
 end
 
@@ -658,11 +657,11 @@ function Hecke.valuation(A::GenOrdIdl{S, T}, p::GenOrdIdl{S, T}) where {S, T}
 end
 
 
-function Hecke.factor(A::GenOrdIdl)
+function Hecke.factor(A::GenOrdIdl{S, T}) where {S, T}
   O = A.order
   N = norm(A)
   factors = factor(N)
-  primes = Dict{GenOrdIdl,Int}()
+  primes = Dict{GenOrdIdl{S, T},Int}()
   for (f,e) in factors
     for (p,r) in prime_decomposition(O,f)
       p_val = valuation(A, p)
@@ -674,7 +673,7 @@ function Hecke.factor(A::GenOrdIdl)
   return primes
 end
 
-function prime_decomposition(O::GenOrd, p::RingElem, degree_limit::Int = degree(O), lower_limit::Int = 0; cached::Bool = true)
+function prime_decomposition(O::GenOrd{S, T}, p::RingElem, degree_limit::Int = degree(O), lower_limit::Int = 0; cached::Bool = true) where {S, T}
   #Index not well-defined for infinite maximal order
   if !isa(base_ring(O), KInftyRing) && !(divides(index(O), p)[1])
     return prime_dec_nonindex(O, p, degree_limit, lower_limit)
@@ -683,9 +682,9 @@ function prime_decomposition(O::GenOrd, p::RingElem, degree_limit::Int = degree(
   end
 end
 
-function prime_dec_gen(O::GenOrd, p::RingElem, degree_limit::Int = degree(O), lower_limit::Int = 0)
+function prime_dec_gen(O::GenOrd{S, T}, p::RingElem, degree_limit::Int = degree(O), lower_limit::Int = 0) where {S, T}
   Ip = pradical(O, p)
-  lp = _decomposition(O, GenOrdIdl(O, p), Ip, GenOrdIdl(O, one(O)), p)
+  lp = _decomposition(O, ideal(O, p), Ip, ideal(O, one(O)), p)
   #=z = Tuple{ideal_type(O), Int}[]
   for (Q, e) in lp
     if degree(Q) <= degree_limit && degree(Q) >= lower_limit
@@ -720,14 +719,15 @@ function Hecke.pradical(O::GenOrd, p::RingElem)
   return GenOrdIdl(O,rad(O,p))
 end
 
-function _decomposition(O::GenOrd, I::GenOrdIdl, Ip::GenOrdIdl, T::GenOrdIdl, p::RingElem)
+# WARNING: TI is unused. I guess the idea is to keep signature same as AbsNumField case
+function _decomposition(O::GenOrd{S, T}, I::GenOrdIdl{S, T}, Ip::GenOrdIdl{S, T}, TI::GenOrdIdl{S, T}, p::RingElem) where {S, T}
   #I is an ideal lying over p
   #T is contained in the product of all the prime ideals lying over p that do not appear in the factorization of I
   #Ip is the p-radical
   Ip1 = Ip + I
   A, OtoA = StructureConstantAlgebra(O, Ip1, p)
   AtoO = pseudo_inv(OtoA)
-  ideals , AA = _from_algs_to_ideals(A, OtoA, AtoO, Ip1, p)
+  ideals, _ = _from_algs_to_ideals(A, OtoA, AtoO, Ip1, p)
   for j in 1:length(ideals)
     P = ideals[j][1]
     f = P.splitting_type[2]

--- a/src/GenOrd/Ideal.jl
+++ b/src/GenOrd/Ideal.jl
@@ -448,6 +448,8 @@ function assure_has_minimum(A::GenOrdIdl)
       A.minimum = O.R(Hecke.AbstractAlgebra.MPolyFactor.make_monic(numerator(den))//denominator(den))
     elseif isa(den, PolyRingElem)
       A.minimum = Hecke.AbstractAlgebra.MPolyFactor.make_monic(den)
+    else
+      A.minimum = den
     end
   end
 
@@ -475,34 +477,15 @@ function assure_has_norm(A::GenOrdIdl)
   end
 
   O = order(A)
-
-  if isdefined(A, :basis_matrix)
-    b = det(basis_matrix(A))
-    if isa(b, KInftyElem)
-      A.norm = O.R(Hecke.AbstractAlgebra.MPolyFactor.make_monic(numerator(b))//denominator(b))
-    elseif isa(b, PolyRingElem)
-      A.norm = Hecke.AbstractAlgebra.MPolyFactor.make_monic(b)
-    end
-    return nothing
-  end
-
-  if has_princ_gen(A)
-    b = det(basis_matrix(A))
-    if isa(b, KInftyElem)
-      A.norm = O.R(Hecke.AbstractAlgebra.MPolyFactor.make_monic(numerator(b))//denominator(b))
-    elseif isa(b, PolyRingElem)
-      A.norm = Hecke.AbstractAlgebra.MPolyFactor.make_monic(b)
-    end
-    return nothing
-  end
-
-  assure_has_basis_matrix(A)
-  b = det(basis_matrix(A))
+  b = det(basis_matrix(A; copy = false))
   if isa(b, KInftyElem)
     A.norm = O.R(Hecke.AbstractAlgebra.MPolyFactor.make_monic(numerator(b))//denominator(b))
   elseif isa(b, PolyRingElem)
     A.norm = Hecke.AbstractAlgebra.MPolyFactor.make_monic(b)
+  else
+    A.norm = b
   end
+
   return nothing
 end
 

--- a/src/GenOrd/Types.jl
+++ b/src/GenOrd/Types.jl
@@ -123,7 +123,7 @@ end
     r.is_prime = 0
     r.is_zero = 0
     r.is_principal = 0
-    r.splitting_type = (-1, -1)
+    r.splitting_type = (0, 0)
     return r
   end
 

--- a/src/GenOrd/Types.jl
+++ b/src/GenOrd/Types.jl
@@ -167,7 +167,7 @@ end
   function GenOrdIdl(O::GenOrd, T::Vector{<:GenOrdElem})
     @assert all(x -> parent(x) === O, T)
     # One should do this block by block instead of the big matrix
-    V = hnf(reduce(vcat, [representation_matrix(O) for x in T]), :lowerleft)
+    V = hnf(reduce(vcat, [representation_matrix(x) for x in T]), :lowerleft)
     d = ncols(V)
     n = length(T)
     return GenOrdIdl(O, V[((n - 1)*d + 1):(n*d), :])

--- a/src/HeckeTypes.jl
+++ b/src/HeckeTypes.jl
@@ -2267,21 +2267,21 @@ end
 #
 ###############################################################################
 
-mutable struct KInftyRing{T <: FieldElement} <: Hecke.Ring
-  K::Generic.RationalFunctionField{T}
+mutable struct KInftyRing{T <: FieldElement, U <: PolyRingElem{T}} <: Hecke.Ring
+  K::Generic.RationalFunctionField{T, U}
 
-  function KInftyRing{T}(K::Generic.RationalFunctionField{T}, cached::Bool) where T <: FieldElement
+  function KInftyRing{T,U}(K::Generic.RationalFunctionField{T,U}; cached::Bool = true) where {T,U}
     return AbstractAlgebra.get_cached!(KInftyID, K, cached) do
-      new{T}(K)
-    end::KInftyRing{T}
+      new{T,U}(K)
+    end::KInftyRing{T,U}
   end
 end
 
 const KInftyID = AbstractAlgebra.CacheDictType{Generic.RationalFunctionField, Hecke.Ring}()
 
-mutable struct KInftyElem{T <: FieldElement} <: Hecke.RingElem
-  d::Generic.RationalFunctionFieldElem{T}
-  parent::KInftyRing{T}
+mutable struct KInftyElem{T <: FieldElement, U <: PolyRingElem{T}} <: Hecke.RingElem
+  d::Generic.RationalFunctionFieldElem{T,U}
+  parent::KInftyRing{T,U}
 end
 
 ################################################################################

--- a/test/FunField.jl
+++ b/test/FunField.jl
@@ -1,9 +1,6 @@
-@testset "Function fields" begin
-  include("FunField/DegreeLocalization.jl")
-  include("FunField/Divisor.jl")
-  include("FunField/Differential.jl")
-  include("FunField/Factor.jl")
-  include("FunField/HessQR.jl")
-  include("FunField/IntClsZx.jl")
-end
-
+include("FunField/DegreeLocalization.jl")
+include("FunField/Divisor.jl")
+include("FunField/Differential.jl")
+include("FunField/Factor.jl")
+include("FunField/HessQR.jl")
+include("FunField/IntClsZx.jl")

--- a/test/FunField/DegreeLocalization.jl
+++ b/test/FunField/DegreeLocalization.jl
@@ -6,8 +6,8 @@ L = localization(R, degree)
 
     @testset "Constructor" begin
 
-      @test parent_type(KInftyElem{QQFieldElem}) == KInftyRing{QQFieldElem}
-      @test elem_type(L) == KInftyElem{QQFieldElem}
+      @test parent_type(KInftyElem{QQFieldElem, QQPolyRingElem}) === KInftyRing{QQFieldElem, QQPolyRingElem}
+      @test elem_type(L) === KInftyElem{QQFieldElem, QQPolyRingElem}
       @test function_field(L) == R
 
     end
@@ -26,10 +26,10 @@ L = localization(R, degree)
     end
 
     @testset "Valuation" begin
-      @test valuation(L(x//(x^2 + 1))) == 1
-      @test valuation(L(5//5)) == 0
-      @test valuation(L((x^2 + 1)//(3//5*x^3))) == 1
-      @test valuation(L((2//5)//(x^3 + 3x + 1))) == 3
+      @test 1 == @inferred valuation(L(x//(x^2 + 1)))
+      @test 0 == @inferred valuation(L(5//5))
+      @test 1 == @inferred valuation(L((x^2 + 1)//(3//5*x^3)))
+      @test 3 == @inferred valuation(L((2//5)//(x^3 + 3x + 1)))
 
       for i in 1:300
         a = rand(L, 0:10, -10:10)
@@ -42,11 +42,11 @@ L = localization(R, degree)
 
     @testset "Parent object call overloading" begin
 
-      @test parent(L(3)) == L
-      @test parent(L(1//x)) == L
-      @test parent(L(ZZRingElem(3))) == L
-      @test parent(L(QQFieldElem(3, 2))) == L
-      @test parent(L()) == L
+      @test L == @inferred parent(L(3))
+      @test L == @inferred parent(L(1//x))
+      @test L == @inferred parent(L(ZZRingElem(3)))
+      @test L == @inferred parent(L(QQFieldElem(3, 2)))
+      @test L == @inferred parent(L())
       @test L(6//3) == L(2)
       @test L(R(5)) == L(5)
       @test_throws ErrorException L(x)
@@ -90,13 +90,13 @@ L = localization(R, degree)
     end
 
     @testset "GCDX" begin
-      d, _, _ = gcdx(L(0), L(0))
+      d, _, _ = @inferred gcdx(L(0), L(0))
       @test d == L(0)
 
-      d, _, v = gcdx(L(0), L(1//(x^2-1)))
+      d, _, v = @inferred gcdx(L(0), L(1//(x^2-1)))
       @test d == v*L(1//(x^2-1))
 
-      d, u, _ = gcdx(L(1//(x-1)), L(0))
+      d, u, _ = @inferred gcdx(L(1//(x-1)), L(0))
       @test d == u*L(1//(x-1))
 
       for i in 1:550
@@ -108,15 +108,15 @@ L = localization(R, degree)
     end
 
     @testset "GCD/LCM" begin
-      @test gcd(L(0), L(0)) == L(0)
-      @test gcd(L(1//(x-1)), L(0)) == L(1//x)
-      @test gcd(L(0), L(1//(x^2+1))) == L(1//x^2)
-      @test gcd(L(1//(x-1)), L(1//(x^2+1))) == L(1//x)
+      @test L(0)      == @inferred gcd(L(0), L(0))
+      @test L(1//x)   == @inferred gcd(L(1//(x-1)), L(0))
+      @test L(1//x^2) == @inferred gcd(L(0), L(1//(x^2+1)))
+      @test L(1//x)   == @inferred gcd(L(1//(x-1)), L(1//(x^2+1)))
 
-      @test lcm(L(0), L(0)) == L(0)
-      @test lcm(L(1//(x-1)), L(0)) == L(0)
-      @test lcm(L(0), L(1//(x^2+1))) == L(0)
-      @test lcm(L(1//(x-1)), L(1//(x^2+1))) == L(1//x^2)
+      @test L(0)      == @inferred lcm(L(0), L(0))
+      @test L(0)      == @inferred lcm(L(1//(x-1)), L(0))
+      @test L(0)      == @inferred lcm(L(0), L(1//(x^2+1)))
+      @test L(1//x^2) == @inferred lcm(L(1//(x-1)), L(1//(x^2+1)))
 
       for i in 1:550
         a = rand(L, 0:10, -10:10)
@@ -151,15 +151,15 @@ L = localization(R, degree)
     end
 
     @testset "Binary operators" begin
+      A = L((-1//3)//(x^2 - 3*x))
+      B = L(-1//(x - 1//2))
+      @test @inferred(A + B) == L((-x^2 + 8//3*x + 1//6)//(x^3 - 7//2*x^2 + 3//2*x))
+      @test @inferred(A - B) == L((x^2 - 10//3*x + 1//6)//(x^3 - 7//2*x^2 + 3//2*x))
+      @test @inferred(L((-1//3)//(x - 3)) * L(-1//(x - 1//2))) == (1//3)//(x^2 - 7//2*x + 3//2)
 
-      @test L((-1//3)//(x^2 - 3*x)) + L(-1//(x - 1//2)) == L((-x^2 + 8//3*x + 1//6)//(x^3 - 7//2*x^2 + 3//2*x))
-      @test L((-1//3)//(x^2 - 3*x)) - L(-1//(x - 1//2)) == L((x^2 - 10//3*x + 1//6)//(x^3 - 7//2*x^2 + 3//2*x))
-      @test L((-1//3)//(x - 3))*L(-1//(x - 1//2)) == (1//3)//(x^2 - 7//2*x + 3//2)
-
-
-      @test L(18//2) + L(2//1) == L(11)
-      @test L(18//3) - L(1) == L(5)
-      @test L(32) * L(4) == L(128)
+      @test @inferred(L(18//2) + L(2//1)) == L(11)
+      @test @inferred(L(18//3) - L(1)) == L(5)
+      @test @inferred(L(32) * L(4)) == L(128)
     end
 
     @testset "Basic manipulation" begin

--- a/test/FunField/Divisor.jl
+++ b/test/FunField/Divisor.jl
@@ -7,8 +7,8 @@ import Hecke: divisor
       ky, y = polynomial_ring(kx, :y; cached = false)
 
       F, a = function_field(y^3 - x^3 - 1; cached = false)
-      Ofin = finite_maximal_order(F)
-      Oinf = infinite_maximal_order(F)
+      Ofin = @inferred finite_maximal_order(F)
+      Oinf = @inferred infinite_maximal_order(F)
 
       p1, _ = first(@inferred factor(ideal(Ofin, x-1)))
       p2    = ideal(Ofin, x^2+x+1)
@@ -77,8 +77,8 @@ import Hecke: divisor
     ky, y = polynomial_ring(kx, :y; cached = false)
 
     F, a = function_field(y^3 - x - 1; cached = false)
-    Ofin = finite_maximal_order(F)
-    Oinf = infinite_maximal_order(F)
+    Ofin = @inferred finite_maximal_order(F)
+    Oinf = @inferred infinite_maximal_order(F)
 
     I = ideal(Oinf, 1//(x^2+x+1))
     fac = @inferred factor(I)
@@ -124,7 +124,8 @@ import Hecke: divisor
       ky, y = polynomial_ring(kx, :y; cached = false)
       for poly in [y^3 - x - 1, y^3 - x^3 - 1, y^3 - x^17 - 1]
         F, a = function_field(poly; cached = false)
-        Ofin, Oinf = finite_maximal_order(F), infinite_maximal_order(F)
+        Ofin = @inferred finite_maximal_order(F)
+        Oinf = @inferred infinite_maximal_order(F)
 
         g = genus(F)
         CD = canonical_divisor(F)
@@ -158,8 +159,8 @@ import Hecke: divisor
       kx, x = rational_function_field(QQ, :x; cached = false)
       ky, y = polynomial_ring(kx, :y; cached = false)
       F, a = function_field(y^2 - x^3 - 1; cached = false)
-      Ofin = finite_maximal_order(F)
-      Oinf = infinite_maximal_order(F)
+      Ofin = @inferred finite_maximal_order(F)
+      Oinf = @inferred infinite_maximal_order(F)
 
       p1 = @inferred ideal(Ofin, x-2, Ofin(a - 3))
       p2 = @inferred ideal(Ofin, x-2, Ofin(a + 3))
@@ -232,8 +233,8 @@ import Hecke: divisor
       kx, x = rational_function_field(QQ, :x; cached = false)
       ky, y = polynomial_ring(kx, :y; cached = false)
       F, a = function_field(y^4 - 3*y + x^6 +x^2 - 1; cached = false)
-      Ofin = finite_maximal_order(F)
-      Oinf = infinite_maximal_order(F)
+      Ofin = @inferred finite_maximal_order(F)
+      Oinf = @inferred infinite_maximal_order(F)
 
       p1 = @inferred ideal(Ofin, x-2)
 

--- a/test/FunField/Divisor.jl
+++ b/test/FunField/Divisor.jl
@@ -1,7 +1,6 @@
 import Hecke: divisor
 
 @testset "Divisors" begin
-
   @testset "Basic Operations" begin
     for base_field in [QQ, finite_field(2, 4)[1], finite_field(101)[1]]
       kx, x = rational_function_field(base_field, :x; cached = false)
@@ -71,6 +70,28 @@ import Hecke: divisor
       @test valuation(Dlcm, p1) == valuation(Dlcm.finite_ideal, p1)
       @test valuation(Dlcm, p4) == valuation(Dlcm.infinite_ideal, p4)
     end
+  end
+
+  @testset "Degree" begin
+    kx, x = rational_function_field(GF(2), :x; cached = false)
+    ky, y = polynomial_ring(kx, :y; cached = false)
+
+    F, a = function_field(y^3 - x - 1; cached = false)
+    Ofin = finite_maximal_order(F)
+    Oinf = infinite_maximal_order(F)
+
+    I = ideal(Oinf, 1//(x^2+x+1))
+    P, e = first(factor(I))   # e = 6, f = 1
+    @test e == 6
+    @test 6 == @inferred degree(divisor(I))
+    @test 1 == @inferred degree(divisor(P))
+
+    # currently factor hangs for this ideal
+    # I = ideal(Ofin, x^2+x+1)
+    # P, e = first(factor(I))   # e = 1, f = 3
+    # @test e == 1
+    # @test 6 == @inferred degree(divisor(I))
+    # @test 6 == @inferred degree(divisor(P))
   end
 
   @testset "Not Separable Extension" begin
@@ -202,7 +223,6 @@ import Hecke: divisor
       KF = canonical_divisor(F)
       @test 0 == @inferred degree(KF)
       @test 1 == @inferred genus(F)
-
     end
 
     @testset "Algebraic function field over rationals (2)" begin
@@ -246,6 +266,5 @@ import Hecke: divisor
       for df in L
         @test is_effective(divisor(df.f) + KF)
       end
-
     end
 end

--- a/test/FunField/Divisor.jl
+++ b/test/FunField/Divisor.jl
@@ -81,17 +81,20 @@ import Hecke: divisor
     Oinf = infinite_maximal_order(F)
 
     I = ideal(Oinf, 1//(x^2+x+1))
-    P, e = first(factor(I))   # e = 6, f = 1
+    fac = factor(I)
+    @test length(fac) == 1
+    P, e = first(fac)   # e = 6, f = 1
     @test e == 6
     @test 6 == @inferred degree(divisor(I))
     @test 1 == @inferred degree(divisor(P))
 
-    # currently factor hangs for this ideal
-    # I = ideal(Ofin, x^2+x+1)
-    # P, e = first(factor(I))   # e = 1, f = 3
-    # @test e == 1
-    # @test 6 == @inferred degree(divisor(I))
-    # @test 6 == @inferred degree(divisor(P))
+    I = ideal(Ofin, x^2+x+1)
+    fac = factor(I)
+    @test length(fac) == 1
+    P, e = first(fac)   # e = 1, f = 3
+    @test e == 1
+    @test 6 == @inferred degree(divisor(I))
+    @test 6 == @inferred degree(divisor(P))
   end
 
   @testset "Not Separable Extension" begin

--- a/test/FunField/Divisor.jl
+++ b/test/FunField/Divisor.jl
@@ -10,10 +10,10 @@ import Hecke: divisor
       Ofin = finite_maximal_order(F)
       Oinf = infinite_maximal_order(F)
 
-      p1, _ = first(factor(ideal(Ofin, x-1)))
+      p1, _ = first(@inferred factor(ideal(Ofin, x-1)))
       p2    = ideal(Ofin, x^2+x+1)
       p3    = ideal(Ofin, x-3, Ofin(a+3))
-      p4, _ = first(factor(ideal(Oinf, base_ring(Oinf)(1//x))))
+      p4, _ = first(@inferred factor(ideal(Oinf, base_ring(Oinf)(1//x))))
 
       d1, d2, d3, d4 = divisor.((p1, p2, p3, p4))
       Hecke.assure_has_support.((d1, d2, d3, d4))
@@ -81,7 +81,7 @@ import Hecke: divisor
     Oinf = infinite_maximal_order(F)
 
     I = ideal(Oinf, 1//(x^2+x+1))
-    fac = factor(I)
+    fac = @inferred factor(I)
     @test length(fac) == 1
     P, e = first(fac)   # e = 6, f = 1
     @test e == 6
@@ -89,7 +89,7 @@ import Hecke: divisor
     @test 1 == @inferred degree(divisor(P))
 
     I = ideal(Ofin, x^2+x+1)
-    fac = factor(I)
+    fac = @inferred factor(I)
     @test length(fac) == 1
     P, e = first(fac)   # e = 1, f = 3
     @test e == 1

--- a/test/GenOrd/Ideal.jl
+++ b/test/GenOrd/Ideal.jl
@@ -1,5 +1,85 @@
 @testset "Ideals for orders over function fields" begin
 
+  @testset "minimum" begin
+    function check_ideal(I, expected_min)
+      @test istril(basis_matrix(I))
+      @test divides(norm(I), minimum(I))[1]
+      @test expected_min == @inferred minimum(I)
+    end
+
+    function create_order_with_nontrivial_basis(Omax)
+      kx = base_field(Omax.F)
+      T = identity_matrix(kx, degree(Omax.F))
+      T[1, 2] = one(kx)
+      O = Hecke.GenOrd(Omax, T, one(kx))
+      @assert !is_equation_order(O)
+      @assert !isone(basis(O, copy = false)[1])
+      return O
+    end
+
+    @testset "over F_2(x)" begin
+      kx, x = rational_function_field(GF(2), :x; cached = false)
+      ky, y = polynomial_ring(kx, :y; cached = false)
+      L, t = function_field(y^3 - x^3 - 1; cached = false)
+
+      OL = finite_maximal_order(L)
+      I = ideal(OL, x^3 + y^2)
+      check_ideal(I, norm(OL(x^3 + y^2))) # x^3 + y^2 is irreducible
+
+      I = ideal(OL, representation_matrix(OL(x^2 + 1)))
+      check_ideal(I, x^2 + 1)
+      @test I == ideal(OL, OL(x^2 + 1))
+
+      I = ideal(OL, x*y, OL(x^2))
+      check_ideal(I, x)
+
+      OL = infinite_maximal_order(L)
+      I = ideal(OL, 3//x^2)
+      check_ideal(I, 1//x^2)
+
+      Omax = finite_maximal_order(L)
+      OL = create_order_with_nontrivial_basis(Omax)
+
+      I = ideal(OL, OL(x^2 + x + 1))
+      Imax = ideal(Omax, Omax(x^2 + x + 1))
+      check_ideal(I, @inferred minimum(Imax))
+
+      I = ideal(OL, x, OL(y + 1))
+      Imax = ideal(Omax, x, Omax(y + 1))
+      check_ideal(I, @inferred minimum(Imax))
+    end
+
+    @testset "Q(x) with non-monic defining polynomial" begin
+      kx, x = rational_function_field(QQ, :x; cached = false)
+      ky, y = polynomial_ring(kx, :y; cached = false)
+      L, t = function_field(1//2*y^3 - 1//3*x^3 - 1; cached = false)
+
+      OL = finite_maximal_order(L)
+      @assert !is_equation_order(OL)
+
+      I = ideal(OL, x^3 + y^2)
+      check_ideal(I, norm(OL(x^3 + y^2)))
+
+      I = ideal(OL, x*y, OL(x^2))
+      check_ideal(I, x)
+
+      OL = infinite_maximal_order(L)
+      I = ideal(OL, 3//x^2)
+      check_ideal(I, 1//x^2)
+
+      Omax = finite_maximal_order(L)
+      OL = create_order_with_nontrivial_basis(Omax)
+
+      I = ideal(OL, OL(x^2 + x + 1))
+      Imax = ideal(Omax, Omax(x^2 + x + 1))
+      check_ideal(I, @inferred minimum(Imax))
+
+      I = ideal(OL, x^2*y + y, OL(y^2 + x*y))
+      Imax = ideal(Omax, x^2*y + y, Omax(y^2 + x*y))
+      check_ideal(I, @inferred minimum(Imax))
+    end
+  end
+
   k = GF(7)
   kx, x = rational_function_field(k, "x")
   kt = parent(numerator(x))
@@ -23,7 +103,6 @@
   @test (I,3) in G
   @test (J,1) in G
   @test length(G)==2
-
 
   k = QQ
   kx, x = rational_function_field(k, "x")

--- a/test/GenOrd/Ideal.jl
+++ b/test/GenOrd/Ideal.jl
@@ -171,6 +171,50 @@
       check_ideal(ideal(OK, ZZ(2)), 2)
     end
   end
+
+  @testset "prime decomposition" begin
+    function _test_prime_2elem(P, f, e)
+      @test inertia_degree(P) == f
+      @test ramification_index(P) == e
+      @test Hecke.has_2_elem(P)
+      @test 1 == @inferred valuation(ideal(order(P), P.gen_two), P)
+    end
+
+    @testset "over F_2(x)" begin
+      kx, x = rational_function_field(GF(2), :x; cached = false)
+      ky, y = polynomial_ring(kx, :y; cached = false)
+      L, t = function_field(y^3 - x - 1; cached = false)
+      Ofin = finite_maximal_order(L)
+      Oinf = infinite_maximal_order(L)
+
+      pd = prime_decomposition(Ofin, Ofin.R(x^2 + x + 1))
+      @test length(pd) == 1
+      P, e = first(pd)
+      @test e == 1
+      _test_prime_2elem(P, 3, 1)
+
+      pd = prime_decomposition(Ofin, Ofin.R(x + 1))
+      @test length(pd) == 1
+      P, e = first(pd)
+      @test e == 3
+      _test_prime_2elem(P, 1, 3)
+
+      # modulo x: y^3 - x - 1 = (y+1)(y^2+y+1)
+      pd = prime_decomposition(Ofin, Ofin.R(x))
+      @test length(pd) == 2
+      for (P, e) in pd
+        @test e == 1
+        f_expected = degree(numerator(data(P.gen_two)))
+        _test_prime_2elem(P, f_expected, 1)
+      end
+
+      pd = prime_decomposition(Oinf, Oinf.R(1//x))
+      @test length(pd) == 1
+      P, e = first(pd)
+      @test e == 3
+      @test inertia_degree(P) == 1
+    end
+  end
 end
 
 @testset "Ideals for orders over function fields" begin

--- a/test/GenOrd/Ideal.jl
+++ b/test/GenOrd/Ideal.jl
@@ -211,6 +211,44 @@
       #   since the Lenstra order is a sub-order of the equation order.
     end
   end
+
+  @testset "over number field localized at prime" begin
+    x = gen(Hecke.Globals.Qx)
+    K, a = number_field(x^2 - 2, :a)
+
+    @testset "split (p = 7)" begin
+      R = Hecke.localization(ZZ, 7)
+      OK = integral_closure(R, K)
+
+      check_ideal_norm_min(ideal(OK, R(7)),             R(49), R(7))
+      check_ideal_norm_min(ideal(OK, R(7), OK(a - 3)),  R(7),  R(7))
+
+      pd = @inferred prime_decomposition(OK, R(7))
+      @test length(pd) == 2
+      for (P, e) in pd
+        @test e == 1
+        check_prime_2elem(P, 1, 1)
+      end
+    end
+
+    @testset "inert (p = 3)" begin
+      R = Hecke.localization(ZZ, 3)
+      OK = integral_closure(R, K)
+
+      check_ideal_norm_min(ideal(OK, R(3)), R(9), R(3))
+      check_prime_2elem_single_above(OK, R(3), 2, 1)
+    end
+
+    @testset "ramified (p = 2)" begin
+      R = Hecke.localization(ZZ, 2)
+      OK = integral_closure(R, K)
+
+      check_ideal_norm_min(ideal(OK, R(2)),          R(4), R(2))
+      check_ideal_norm_min(ideal(OK, R(2), OK(a)),   R(2), R(2))
+
+      check_prime_2elem_single_above(OK, R(2), 1, 2)
+    end
+  end
 end
 
 @testset "Ideals for orders over function fields" begin

--- a/test/GenOrd/Ideal.jl
+++ b/test/GenOrd/Ideal.jl
@@ -1,20 +1,88 @@
-@testset "Ideals for orders over function fields" begin
+@testset "Ideals for orders over general PID" begin
+  # Here we test basic ideal operations.
+  # Function fields are the main use case for GenOrd.
+  # We also add tests for other settings where GenOrd is not normally used,
+  #   to make sure our implementation is robust enough to handle a general PID.
+
+  # Builds a non-equation order whose first basis vector isn't 1,
+  # to exercise corner cases.
+  # The lattice itself is unchanged (unimodular change of basis),
+  #   so norms and minima match those in Omax
+  function create_order_with_nontrivial_basis(Omax)
+    K = base_field(Omax.F)
+    T = identity_matrix(K, degree(Omax.F))
+    T[1, 2] = one(K)
+    O = Hecke.GenOrd(Omax, T, one(K))
+    @assert !is_equation_order(O)
+    @assert !isone(basis(O, copy = false)[1])
+    return O
+  end
+
+  @testset "norm" begin
+    @testset "over F_2(x)" begin
+      kx, x = rational_function_field(GF(2), :x; cached = false)
+      ky, y = polynomial_ring(kx, :y; cached = false)
+      L, t = function_field(y^3 - x^3 - 1; cached = false)
+
+      OL = finite_maximal_order(L)
+      @test norm(ideal(OL, x^3 + y^2)) == norm(OL(x^3 + y^2))
+      @test norm(ideal(OL, x*y, OL(x^2))) == x^3
+
+      OL = create_order_with_nontrivial_basis(OL)
+      @test norm(ideal(OL, x^3 + y^2)) == norm(OL(x^3 + y^2))
+      @test norm(ideal(OL, x*y, OL(x^2))) == x^3
+
+      OL = infinite_maximal_order(L)
+      @test norm(ideal(OL, 1//x^2)) == 1//x^6
+    end
+
+    @testset "Q(x) with non-monic defining polynomial" begin
+      kx, x = rational_function_field(QQ, :x; cached = false)
+      ky, y = polynomial_ring(kx, :y; cached = false)
+      L, t = function_field(1//2*y^3 - 1//3*x^3 - 1; cached = false)
+
+      OL = finite_maximal_order(L)
+      @assert !is_equation_order(OL)
+
+      @test norm(ideal(OL, x^3 + y^2)) == norm(OL(x^3 + y^2))
+      @test norm(ideal(OL, x*y, OL(x^2))) == x^3
+
+      OL = create_order_with_nontrivial_basis(OL)
+      @test norm(ideal(OL, x^3 + y^2)) == norm(OL(x^3 + y^2))
+      @test norm(ideal(OL, x*y, OL(x^2))) == x^3
+
+      OL = infinite_maximal_order(L)
+      @test norm(ideal(OL, 3//x^2)) == 27//x^6
+    end
+
+    @testset "number field" begin
+      x = gen(Hecke.Globals.Qx)
+      K, a = number_field(x^2 - 2, :a)
+      OK = Hecke.GenOrd(ZZ, K)
+
+      @test norm(ideal(OK, ZZ(3))) == 9
+      @test norm(ideal(OK, ZZ(2), OK(a))) == 2
+      @test norm(ideal(OK, ZZ(2))) == 4
+
+      OK = create_order_with_nontrivial_basis(OK)
+      @test norm(ideal(OK, ZZ(3))) == 9
+      @test norm(ideal(OK, ZZ(2), OK(a))) == 2
+      @test norm(ideal(OK, ZZ(2))) == 4
+
+      K, a = number_field(2*x^2 - 4, :a)
+      OK = Hecke.GenOrd(ZZ, K)
+
+      @test norm(ideal(OK, ZZ(3))) == 9
+      @test norm(ideal(OK, ZZ(2), OK(2*a))) == 2
+      @test norm(ideal(OK, ZZ(2))) == 4
+    end
+  end
 
   @testset "minimum" begin
     function check_ideal(I, expected_min)
       @test istril(basis_matrix(I))
       @test divides(norm(I), minimum(I))[1]
       @test expected_min == @inferred minimum(I)
-    end
-
-    function create_order_with_nontrivial_basis(Omax)
-      kx = base_field(Omax.F)
-      T = identity_matrix(kx, degree(Omax.F))
-      T[1, 2] = one(kx)
-      O = Hecke.GenOrd(Omax, T, one(kx))
-      @assert !is_equation_order(O)
-      @assert !isone(basis(O, copy = false)[1])
-      return O
     end
 
     @testset "over F_2(x)" begin
@@ -36,6 +104,9 @@
       OL = infinite_maximal_order(L)
       I = ideal(OL, 3//x^2)
       check_ideal(I, 1//x^2)
+
+      I = ideal(OL, L(x^2)//t^3)
+      check_ideal(I, 1//x)
 
       Omax = finite_maximal_order(L)
       OL = create_order_with_nontrivial_basis(Omax)
@@ -78,8 +149,31 @@
       Imax = ideal(Omax, x^2*y + y, Omax(y^2 + x*y))
       check_ideal(I, @inferred minimum(Imax))
     end
-  end
 
+    @testset "number field" begin
+      x = gen(Hecke.Globals.Qx)
+      K, a = number_field(x^2 - 2, :a)
+      OK = Hecke.GenOrd(ZZ, K)
+
+      check_ideal(ideal(OK, ZZ(3)), 3)
+      check_ideal(ideal(OK, ZZ(2), OK(a)), 2)
+      check_ideal(ideal(OK, ZZ(2)), 2)
+
+      OK = create_order_with_nontrivial_basis(OK)
+      check_ideal(ideal(OK, ZZ(3)), 3)
+      check_ideal(ideal(OK, ZZ(2), OK(a)), 2)
+      check_ideal(ideal(OK, ZZ(2)), 2)
+
+      K, a = number_field(2*x^2 - 4, :a)
+      OK = Hecke.GenOrd(ZZ, K)
+      check_ideal(ideal(OK, ZZ(3)), 3)
+      check_ideal(ideal(OK, ZZ(2), OK(2*a)), 2)
+      check_ideal(ideal(OK, ZZ(2)), 2)
+    end
+  end
+end
+
+@testset "Ideals for orders over function fields" begin
   k = GF(7)
   kx, x = rational_function_field(k, "x")
   kt = parent(numerator(x))

--- a/test/GenOrd/Ideal.jl
+++ b/test/GenOrd/Ideal.jl
@@ -194,6 +194,22 @@
         check_ideal_norm_min(ideal(OK, ZZ(2)), 4, 2)
       end
     end
+
+    @testset "prime decomposition" begin
+      check_prime_2elem_single_above(OK, ZZ(3), 2, 1)
+      check_prime_2elem_single_above(OK, ZZ(2), 1, 2)
+
+      pd = @inferred prime_decomposition(OK, ZZ(7))
+      @test length(pd) == 2
+      for (P, e) in pd
+        @test e == 1
+        check_prime_2elem(P, 1, 1)
+      end
+
+      # Currently GenOrd's prime decomposition does not work with
+      #   number fields defined by non-monic polynomials,
+      #   since the Lenstra order is a sub-order of the equation order.
+    end
   end
 end
 

--- a/test/GenOrd/Ideal.jl
+++ b/test/GenOrd/Ideal.jl
@@ -4,8 +4,7 @@
   # We also add tests for other settings where GenOrd is not normally used,
   #   to make sure our implementation is robust enough to handle a general PID.
 
-  # Builds a non-equation order whose first basis vector isn't 1,
-  # to exercise corner cases.
+  # Builds a non-equation order whose first basis vector isn't 1, to exercise corner cases.
   # The lattice itself is unchanged (unimodular change of basis),
   #   so norms and minima match those in Omax
   function create_order_with_nontrivial_basis(Omax)
@@ -18,201 +17,182 @@
     return O
   end
 
-  @testset "norm" begin
-    @testset "over F_2(x)" begin
-      kx, x = rational_function_field(GF(2), :x; cached = false)
-      ky, y = polynomial_ring(kx, :y; cached = false)
-      L, t = function_field(y^3 - x^3 - 1; cached = false)
-
-      OL = finite_maximal_order(L)
-      @test norm(ideal(OL, x^3 + y^2)) == norm(OL(x^3 + y^2))
-      @test norm(ideal(OL, x*y, OL(x^2))) == x^3
-
-      OL = create_order_with_nontrivial_basis(OL)
-      @test norm(ideal(OL, x^3 + y^2)) == norm(OL(x^3 + y^2))
-      @test norm(ideal(OL, x*y, OL(x^2))) == x^3
-
-      OL = infinite_maximal_order(L)
-      @test norm(ideal(OL, 1//x^2)) == 1//x^6
-    end
-
-    @testset "Q(x) with non-monic defining polynomial" begin
-      kx, x = rational_function_field(QQ, :x; cached = false)
-      ky, y = polynomial_ring(kx, :y; cached = false)
-      L, t = function_field(1//2*y^3 - 1//3*x^3 - 1; cached = false)
-
-      OL = finite_maximal_order(L)
-      @assert !is_equation_order(OL)
-
-      @test norm(ideal(OL, x^3 + y^2)) == norm(OL(x^3 + y^2))
-      @test norm(ideal(OL, x*y, OL(x^2))) == x^3
-
-      OL = create_order_with_nontrivial_basis(OL)
-      @test norm(ideal(OL, x^3 + y^2)) == norm(OL(x^3 + y^2))
-      @test norm(ideal(OL, x*y, OL(x^2))) == x^3
-
-      OL = infinite_maximal_order(L)
-      @test norm(ideal(OL, 3//x^2)) == 27//x^6
-    end
-
-    @testset "number field" begin
-      x = gen(Hecke.Globals.Qx)
-      K, a = number_field(x^2 - 2, :a)
-      OK = Hecke.GenOrd(ZZ, K)
-
-      @test norm(ideal(OK, ZZ(3))) == 9
-      @test norm(ideal(OK, ZZ(2), OK(a))) == 2
-      @test norm(ideal(OK, ZZ(2))) == 4
-
-      OK = create_order_with_nontrivial_basis(OK)
-      @test norm(ideal(OK, ZZ(3))) == 9
-      @test norm(ideal(OK, ZZ(2), OK(a))) == 2
-      @test norm(ideal(OK, ZZ(2))) == 4
-
-      K, a = number_field(2*x^2 - 4, :a)
-      OK = Hecke.GenOrd(ZZ, K)
-
-      @test norm(ideal(OK, ZZ(3))) == 9
-      @test norm(ideal(OK, ZZ(2), OK(2*a))) == 2
-      @test norm(ideal(OK, ZZ(2))) == 4
-    end
+  function check_ideal_norm_min(I, expected_norm, expected_min)
+    @test istril(basis_matrix(I))
+    @test divides(norm(I), minimum(I))[1]
+    @test expected_norm == @inferred norm(I)
+    @test expected_min == @inferred minimum(I)
   end
 
-  @testset "minimum" begin
-    function check_ideal(I, expected_min)
-      @test istril(basis_matrix(I))
-      @test divides(norm(I), minimum(I))[1]
-      @test expected_min == @inferred minimum(I)
+  function check_prime_2elem(P, expected_f, expected_e)
+    @test inertia_degree(P) == expected_f
+    @test ramification_index(P) == expected_e
+    @test Hecke.has_2_elem(P)
+    @test 1 == @inferred valuation(ideal(order(P), P.gen_two), P)
+  end
+
+  function check_prime_2elem_single_above(O, a, expected_f, expected_e)
+    pd = @inferred prime_decomposition(O, base_ring(O)(a))
+    @test length(pd) == 1
+    P, e = first(pd)
+    @test e == expected_e
+    check_prime_2elem(P, expected_f, expected_e)
+  end
+
+  @testset "over F_2(x)" begin
+    kx, x = rational_function_field(GF(2), :x; cached = false)
+    ky, y = polynomial_ring(kx, :y; cached = false)
+    L, t = function_field(y^3 - x^3 - 1; cached = false)
+    Ofin = finite_maximal_order(L)
+    Oinf = infinite_maximal_order(L)
+
+    @testset "norm/min: finite maximal order" begin
+      I = ideal(Ofin, representation_matrix(Ofin(x^2 + 1)))
+      @test I == ideal(Ofin, Ofin(x^2 + 1))
+
+      a = Ofin(x^3 + y^2)
+      I = ideal(Ofin, a)
+      check_ideal_norm_min(I, norm(a), norm(a)) # x^3 + y^2 is irreducible
+
+      I = ideal(Ofin, x*y, Ofin(x^2))
+      check_ideal_norm_min(I, x^3, x)
     end
 
-    @testset "over F_2(x)" begin
-      kx, x = rational_function_field(GF(2), :x; cached = false)
-      ky, y = polynomial_ring(kx, :y; cached = false)
-      L, t = function_field(y^3 - x^3 - 1; cached = false)
-
-      OL = finite_maximal_order(L)
-      I = ideal(OL, x^3 + y^2)
-      check_ideal(I, norm(OL(x^3 + y^2))) # x^3 + y^2 is irreducible
-
-      I = ideal(OL, representation_matrix(OL(x^2 + 1)))
-      check_ideal(I, x^2 + 1)
-      @test I == ideal(OL, OL(x^2 + 1))
+    @testset "norm/min: finite non-equation order" begin
+      OL = create_order_with_nontrivial_basis(Ofin)
+      @assert !is_equation_order(OL)
+      a = OL(x^3 + y^2)
+      I = ideal(OL, a)
+      check_ideal_norm_min(I, norm(a), norm(a)) # x^3 + y^2 is irreducible
 
       I = ideal(OL, x*y, OL(x^2))
-      check_ideal(I, x)
-
-      OL = infinite_maximal_order(L)
-      I = ideal(OL, 3//x^2)
-      check_ideal(I, 1//x^2)
-
-      I = ideal(OL, L(x^2)//t^3)
-      check_ideal(I, 1//x)
-
-      Omax = finite_maximal_order(L)
-      OL = create_order_with_nontrivial_basis(Omax)
+      check_ideal_norm_min(I, x^3, x)
 
       I = ideal(OL, OL(x^2 + x + 1))
-      Imax = ideal(Omax, Omax(x^2 + x + 1))
-      check_ideal(I, @inferred minimum(Imax))
+      Imax = ideal(Ofin, Ofin(x^2 + x + 1))
+      check_ideal_norm_min(I, @inferred(norm(Imax)), @inferred(minimum(Imax)))
 
       I = ideal(OL, x, OL(y + 1))
-      Imax = ideal(Omax, x, Omax(y + 1))
-      check_ideal(I, @inferred minimum(Imax))
+      Imax = ideal(Ofin, x, Ofin(y + 1))
+      check_ideal_norm_min(I, @inferred(norm(Imax)), @inferred(minimum(Imax)))
     end
 
-    @testset "Q(x) with non-monic defining polynomial" begin
-      kx, x = rational_function_field(QQ, :x; cached = false)
-      ky, y = polynomial_ring(kx, :y; cached = false)
-      L, t = function_field(1//2*y^3 - 1//3*x^3 - 1; cached = false)
+    @testset "norm/min: infinite maximal order" begin
+      I = ideal(Oinf, 3//x^2)
+      check_ideal_norm_min(I, 1//x^6, 1//x^2)
 
-      OL = finite_maximal_order(L)
-      @assert !is_equation_order(OL)
-
-      I = ideal(OL, x^3 + y^2)
-      check_ideal(I, norm(OL(x^3 + y^2)))
-
-      I = ideal(OL, x*y, OL(x^2))
-      check_ideal(I, x)
-
-      OL = infinite_maximal_order(L)
-      I = ideal(OL, 3//x^2)
-      check_ideal(I, 1//x^2)
-
-      Omax = finite_maximal_order(L)
-      OL = create_order_with_nontrivial_basis(Omax)
-
-      I = ideal(OL, OL(x^2 + x + 1))
-      Imax = ideal(Omax, Omax(x^2 + x + 1))
-      check_ideal(I, @inferred minimum(Imax))
-
-      I = ideal(OL, x^2*y + y, OL(y^2 + x*y))
-      Imax = ideal(Omax, x^2*y + y, Omax(y^2 + x*y))
-      check_ideal(I, @inferred minimum(Imax))
+      I = ideal(Oinf, L(x^2)//t^3)
+      check_ideal_norm_min(I, norm(Oinf(L(x^2)//t^3)), 1//x)
     end
 
-    @testset "number field" begin
-      x = gen(Hecke.Globals.Qx)
-      K, a = number_field(x^2 - 2, :a)
-      OK = Hecke.GenOrd(ZZ, K)
+    @testset "prime decomposition" begin
+      check_prime_2elem_single_above(Ofin, x + 1, 1, 3)
+      check_prime_2elem_single_above(Ofin, x^2 + x + 1, 1, 3)
+      check_prime_2elem_single_above(Ofin, x^4 + x + 1, 3, 1)
 
-      check_ideal(ideal(OK, ZZ(3)), 3)
-      check_ideal(ideal(OK, ZZ(2), OK(a)), 2)
-      check_ideal(ideal(OK, ZZ(2)), 2)
-
-      OK = create_order_with_nontrivial_basis(OK)
-      check_ideal(ideal(OK, ZZ(3)), 3)
-      check_ideal(ideal(OK, ZZ(2), OK(a)), 2)
-      check_ideal(ideal(OK, ZZ(2)), 2)
-
-      K, a = number_field(2*x^2 - 4, :a)
-      OK = Hecke.GenOrd(ZZ, K)
-      check_ideal(ideal(OK, ZZ(3)), 3)
-      check_ideal(ideal(OK, ZZ(2), OK(2*a)), 2)
-      check_ideal(ideal(OK, ZZ(2)), 2)
-    end
-  end
-
-  @testset "prime decomposition" begin
-    function _test_prime_2elem(P, f, e)
-      @test inertia_degree(P) == f
-      @test ramification_index(P) == e
-      @test Hecke.has_2_elem(P)
-      @test 1 == @inferred valuation(ideal(order(P), P.gen_two), P)
-    end
-
-    @testset "over F_2(x)" begin
-      kx, x = rational_function_field(GF(2), :x; cached = false)
-      ky, y = polynomial_ring(kx, :y; cached = false)
-      L, t = function_field(y^3 - x - 1; cached = false)
-      Ofin = finite_maximal_order(L)
-      Oinf = infinite_maximal_order(L)
-
-      pd = @inferred prime_decomposition(Ofin, Ofin.R(x^2 + x + 1))
-      @test length(pd) == 1
-      P, e = first(pd)
-      @test e == 1
-      _test_prime_2elem(P, 3, 1)
-
-      pd = @inferred prime_decomposition(Ofin, Ofin.R(x + 1))
-      @test length(pd) == 1
-      P, e = first(pd)
-      @test e == 3
-      _test_prime_2elem(P, 1, 3)
-
-      # modulo x: y^3 - x - 1 = (y+1)(y^2+y+1)
+      # modulo x: y^3 - x^3 - 1 = (y+1)(y^2+y+1)
       pd = @inferred prime_decomposition(Ofin, Ofin.R(x))
       @test length(pd) == 2
       for (P, e) in pd
         @test e == 1
         f_expected = degree(numerator(data(P.gen_two)))
-        _test_prime_2elem(P, f_expected, 1)
+        check_prime_2elem(P, f_expected, 1)
       end
 
       pd = @inferred prime_decomposition(Oinf, Oinf.R(1//x))
-      @test length(pd) == 1
-      P, e = first(pd)
-      @test e == 3
-      @test inertia_degree(P) == 1
+      @test length(pd) == 2
+      for (P, e) in pd
+        @test e == 1
+        f_expected = (norm(P) == 1//x ? 1 : 2)
+        @test inertia_degree(P) == f_expected
+      end
+
+      let (L, t) = function_field(y^3 - x - 1; cached = false)
+        Ofin = finite_maximal_order(L)
+        Oinf = infinite_maximal_order(L)
+
+        check_prime_2elem_single_above(Ofin, x + 1, 1, 3)
+        check_prime_2elem_single_above(Ofin, x^2 + x + 1, 3, 1)
+
+        # modulo x: y^3 - x - 1 = (y+1)(y^2+y+1)
+        pd = @inferred prime_decomposition(Ofin, Ofin.R(x))
+        @test length(pd) == 2
+        for (P, e) in pd
+          @test e == 1
+          f_expected = degree(numerator(data(P.gen_two)))
+          check_prime_2elem(P, f_expected, 1)
+        end
+
+        pd = @inferred prime_decomposition(Ofin, Ofin.R(x^4 + x^3 + 1))
+        @test length(pd) == 3
+        for (P, e) in pd
+          @test e == 1
+          check_prime_2elem(P, 1, 1)
+        end
+
+        pd = @inferred prime_decomposition(Oinf, Oinf.R(1//x))
+        @test length(pd) == 1
+        P, e = first(pd)
+        @test e == 3
+        @test inertia_degree(P) == 1
+      end
+    end
+  end
+
+  @testset "over Q(x) with non-monic defining polynomial" begin
+    kx, x = rational_function_field(QQ, :x; cached = false)
+    ky, y = polynomial_ring(kx, :y; cached = false)
+    L, t = function_field(1//2*y^3 - 1//3*x^3 - 1; cached = false)
+
+    Ofin = finite_maximal_order(L)
+    Oinf = infinite_maximal_order(L)
+    @assert !is_equation_order(Ofin)
+
+    @testset "norm/min: finite maximal order" begin
+      a = Ofin(x^3 + y^2)
+      I = ideal(Ofin, a)
+      check_ideal_norm_min(I, norm(a), norm(a)) # x^3 + y^2 is irreducible
+
+      I = ideal(Ofin, x*y, Ofin(x^2))
+      check_ideal_norm_min(I, x^3, x)
+    end
+
+    @testset "norm/min: infinite maximal order" begin
+      I = ideal(Oinf, 3//x^2)
+      check_ideal_norm_min(I, 27//x^6, 1//x^2)
+
+      I = ideal(Oinf, L(x^2)//t^3)
+      check_ideal_norm_min(I, norm(Oinf(L(x^2)//t^3)), 1//x)
+    end
+  end
+
+  @testset "over number field" begin
+    x = gen(Hecke.Globals.Qx)
+    K, a = number_field(x^2 - 2, :a)
+    OK = Hecke.GenOrd(ZZ, K)
+
+    @testset "norm/min: maximal order" begin
+      check_ideal_norm_min(ideal(OK, ZZ(3)), 9, 3)
+      check_ideal_norm_min(ideal(OK, ZZ(2), OK(a)), 2, 2)
+      check_ideal_norm_min(ideal(OK, ZZ(2)), 4, 2)
+    end
+
+    @testset "norm/min: non-equation order" begin
+      let OK = create_order_with_nontrivial_basis(OK)
+        @assert !is_equation_order(OK)
+        check_ideal_norm_min(ideal(OK, ZZ(3)), 9, 3)
+        check_ideal_norm_min(ideal(OK, ZZ(2), OK(a)), 2, 2)
+        check_ideal_norm_min(ideal(OK, ZZ(2)), 4, 2)
+      end
+    end
+
+    @testset "norm/min: with non-monic defining polynomial" begin
+      let (K, a) = number_field(2*x^2 - 4, :a), OK = Hecke.GenOrd(ZZ, K)
+        @assert !is_equation_order(OK)
+        check_ideal_norm_min(ideal(OK, ZZ(3)), 9, 3)
+        check_ideal_norm_min(ideal(OK, ZZ(2), OK(2*a)), 2, 2)
+        check_ideal_norm_min(ideal(OK, ZZ(2)), 4, 2)
+      end
     end
   end
 end

--- a/test/GenOrd/Ideal.jl
+++ b/test/GenOrd/Ideal.jl
@@ -187,20 +187,20 @@
       Ofin = finite_maximal_order(L)
       Oinf = infinite_maximal_order(L)
 
-      pd = prime_decomposition(Ofin, Ofin.R(x^2 + x + 1))
+      pd = @inferred prime_decomposition(Ofin, Ofin.R(x^2 + x + 1))
       @test length(pd) == 1
       P, e = first(pd)
       @test e == 1
       _test_prime_2elem(P, 3, 1)
 
-      pd = prime_decomposition(Ofin, Ofin.R(x + 1))
+      pd = @inferred prime_decomposition(Ofin, Ofin.R(x + 1))
       @test length(pd) == 1
       P, e = first(pd)
       @test e == 3
       _test_prime_2elem(P, 1, 3)
 
       # modulo x: y^3 - x - 1 = (y+1)(y^2+y+1)
-      pd = prime_decomposition(Ofin, Ofin.R(x))
+      pd = @inferred prime_decomposition(Ofin, Ofin.R(x))
       @test length(pd) == 2
       for (P, e) in pd
         @test e == 1
@@ -208,7 +208,7 @@
         _test_prime_2elem(P, f_expected, 1)
       end
 
-      pd = prime_decomposition(Oinf, Oinf.R(1//x))
+      pd = @inferred prime_decomposition(Oinf, Oinf.R(1//x))
       @test length(pd) == 1
       P, e = first(pd)
       @test e == 3


### PR DESCRIPTION
- Stricter typing: `KInftyRing{T}` and `KInftyElem{T}` are now `KInftyRing{T, U}`, and `KInftyElem{T, U}`, mirroring AbstractAlgebra's RationalFunctionField{T, U}. Also changed `KInftyRing` constructor to have cached as kwarg. 
- `degree(::GenOrdIdl)` now returns the inertia degree of the ideal (before it was `place` degree: for function field F/K with fields of constants K the place degree of P is [F_P:K]). Divisor code adjusted (divisors care about places).
- Generalization beyond function fields: `norm`, `minimum` and `prime_dec_nonindex` now work for any base ring.
- Fixed `prime_dec_nonindex` to generate normal two element representation. This also fixes issues with `factor`/`valuation` on totally inert primes.
- Ensured we get HNF matrix for principal ideal, thus we now have HNF matrices everywhere.
- Some fixes for type stability (most notably `factor` and `prime_decomposition`) and miscellaneous typos.
- Tests: removed root testset in function fields test (so that categories are visible), added per-field-type testsets to `GenOrdIdl` tests

If we care about somebody using `KInftyRing` and `KInftyElem`: the real breaking change is constructor (since it now demands two types), we can restore old constructor (with one type `T` and cached as positional argument); it was deemed unnecessary since this type is not used directly. 
Also, `degree(::GenOrdIdl)` is actual result change (i've also added explicit `inertia_degree` synonym), but it was deemed pure correction (Magma has degree == intertia_degree, and now our answers agree with Magma)

Known Issue: it turned out that `GenOrd` code cannot handle number fields with non-monic polynomials (Lenstra order is suborder of equation order); should be fixed separately if we really care about this.
