### PR TITLE
fix: isometry of `TorQuadModule` as bilinear modules

### DIFF
--- a/src/QuadForm/Torsion.jl
+++ b/src/QuadForm/Torsion.jl
@@ -97,6 +97,7 @@ function torsion_quadratic_module(M::ZZLat, N::ZZLat; gens::Union{Nothing, Vecto
   T.value_module = QmodnZ(_modulus)
   T.value_module_qf = QmodnZ(_modulus_qf)
   T.is_normal = false
+  T.is_normal_bilinear = false
   return T
 end
 
@@ -1104,8 +1105,8 @@ function _isometry_semiregular(
 )
   # the zero map for default output
   hz = hom(T, U, zero_matrix(ZZ, ngens(T), ngens(U)))
-  NT, TtoNT = normal_form(T)
-  NU, UtoNU = normal_form(U)
+  NT, TtoNT = normal_form(T; as_bilinear_module)
+  NU, UtoNU = normal_form(U; as_bilinear_module)
   if as_bilinear_module
     gqNT = gram_matrix_bilinear(NT)
     gqNU = gram_matrix_bilinear(NU)
@@ -1706,12 +1707,19 @@ Let `K` be the radical of the quadratic form of `T`. Then `N = T/K` is
 half-regular. Two half-regular torsion quadratic modules are isometric
 if and only if they have equal normal forms.
 """
-function normal_form(T::TorQuadModule; partial=false)
-  if T.is_normal
+function normal_form(
+  T::TorQuadModule;
+  partial::Bool=false,
+  as_bilinear_module::Bool=false,
+)
+  if !as_bilinear_module && T.is_normal
+    return T, id_hom(T)
+  elseif as_bilinear_module && T.is_normal_bilinear
     return T, id_hom(T)
   end
+
   if is_degenerate(T)
-    K, _ = radical_quadratic(T)
+    K, _ = as_bilinear_module ? radical_bilinear(T) : radical_quadratic(T)
     N = torsion_quadratic_module(cover(T), cover(K); modulus=modulus_bilinear_form(T), modulus_qf=modulus_quadratic_form(T))
     i = hom(T, N, TorQuadModuleElem[N(lift(g)) for g in gens(T)]; check=false)
   else
@@ -1722,8 +1730,12 @@ function normal_form(T::TorQuadModule; partial=false)
   prime_div = sort!(prime_divisors(exponent(N)))
   for p in prime_div
     D_p, I_p = primary_part(N, p)
-    q_p = gram_matrix_quadratic(D_p)
-    if p == 2
+    if as_bilinear_module
+      q_p = gram_matrix_bilinear(D_p)
+    else
+      q_p = gram_matrix_quadratic(D_p)
+    end
+    if !as_bilinear_module && p == 2
       q_p = q_p * modulus_quadratic_form(D_p)^-1
     else
       q_p = q_p * modulus_bilinear_form(D_p)^-1
@@ -1745,7 +1757,7 @@ function normal_form(T::TorQuadModule; partial=false)
     q_pR = map_entries(x->R(ZZ(x)), denom*q_p)
     D = UR * q_pR * transpose(UR)
     D = map_entries(x->R(mod(lift(x),denom)), D)
-    if p != 2
+    if p != 2 && !as_bilinear_module
       # follow the conventions of Miranda-Morrison
       m = ZZ(modulus_quadratic_form(D_p)//modulus_bilinear_form(D_p))
       D = R(m)^-1*D
@@ -1765,7 +1777,11 @@ function normal_form(T::TorQuadModule; partial=false)
   S, j =  sub(N, normal_gens)
   J = compose(i,inv(j))
   if !partial
-    S.is_normal = true
+    if as_bilinear_module
+      S.is_normal_bilinear = true
+    else
+      S.is_normal = true
+    end
   end
   return S, J
 end

--- a/src/QuadForm/Types.jl
+++ b/src/QuadForm/Types.jl
@@ -280,6 +280,7 @@ then the coordinates with respec to the basis of `M` are given by
   gram_matrix_quadratic::QQMatrix
   gens
   is_normal::Bool
+  is_normal_bilinear::Bool
 
   TorQuadModule() = new()
 end

--- a/test/QuadForm/Torsion.jl
+++ b/test/QuadForm/Torsion.jl
@@ -138,8 +138,10 @@
             0 1//4   0;
             0   0 5//4]
   @test Hecke.gram_matrix_quadratic(n1) == g1
+  @test gram_matrix_bilinear(first(normal_form(AL1; as_bilinear_module=true))) == gram_matrix_quadratic(first(normal_form(Hecke._as_finite_bilinear_module(AL1))))
   n2 = normal_form(AL2)[1]
   @test Hecke.gram_matrix_quadratic(n2) == g1
+  @test gram_matrix_bilinear(first(normal_form(AL2; as_bilinear_module=true))) == gram_matrix_quadratic(first(normal_form(Hecke._as_finite_bilinear_module(AL2))))
   L3 = integer_lattice(gram=matrix(ZZ, [[2,0,0,-1],[0,2,0,-1],[0,0,2,-1],[-1,-1,-1,2]]))
   T=torsion_quadratic_module((1//6)*dual(L3), L3)
   n3 = normal_form(T)[1]
@@ -501,4 +503,10 @@ end
   @test is_bijective(psi)
   phi = @inferred hom(q, q2, elem_type(q2)[])
   @test is_injective(phi)
+end
+
+@testset "Isometric as bilinear modules" begin
+  T1 = torsion_quadratic_module(QQ[4//5 0; 0 1//5])
+  T2 = torsion_quadratic_module(QQ[2//5 0; 0 2//5])
+  @test first(is_isometric_with_isometry(T1, T2; as_bilinear_module=true))
 end


### PR DESCRIPTION
Somehow, the `gram_matrix_bilinear` of the normal form of a quadratic module might not agree with the `gram_matrix_bilinear` of the normal form of the associated bilinear module. I had an example of `TorQuadModule` which are isometric as bilinear modules but the function said it was not. So I have added the option to create a "normal form" by only working with the `gram_matrix_bilinear` if we are only interested in the bilinear form.