### PR TITLE
GenOrd: cleanup, type stability, generic ideal arithmetic

### DIFF
--- a/src/FunField/IntClsZx.jl
+++ b/src/FunField/IntClsZx.jl
@@ -138,9 +138,9 @@ function Hecke.integral_closure(Zx::ZZPolyRing, F::Generic.FunctionField)
   R = parent(numerator(t))
   o1 = integral_closure(S, F)
   o2 = integral_closure(R, F)
-  T = o1.trans
+  T = basis_matrix(o1)
   if !is_equation_order(o2)
-    T = T * o2.itrans
+    T = T * basis_matrix_inverse(o2)
   end
   _, T1, T2 = florian(T, R, S)
 
@@ -148,7 +148,7 @@ function Hecke.integral_closure(Zx::ZZPolyRing, F::Generic.FunctionField)
   if is_equation_order(o2)
     oo2 = order(o3, integral_split(inv(T2), Zx)..., check = false)
   else
-    oo2 = order(o3, integral_split(inv(T2)*o2.trans, Zx)..., check = false)
+    oo2 = order(o3, integral_split(inv(T2)*basis_matrix(o2), Zx)..., check = false)
   end
   return oo2
 
@@ -156,7 +156,7 @@ function Hecke.integral_closure(Zx::ZZPolyRing, F::Generic.FunctionField)
   H, TT1 = hnf_with_transform(map_entries(S, T1*T*T2))
   @assert isone(H)
   T1 = map_entries(Qt, TT1)*T1
-  oo1 = order(o3, integral_split(T1*o1.trans, Zx)..., check = false)
+  oo1 = order(o3, integral_split(T1*basis_matrix(o1), Zx)..., check = false)
   return oo1, oo2
 end
 

--- a/src/GenOrd/Auxiliary.jl
+++ b/src/GenOrd/Auxiliary.jl
@@ -117,6 +117,10 @@ function Hecke.discriminant(F::Generic.FunctionField)
   return discriminant(defining_polynomial(F))
 end
 
+function base_field_type(::Type{Generic.FunctionField{T}}) where T <: FieldElement
+  return Generic.RationalFunctionField{T, poly_type(T)}
+end
+
 #######################################################################
 #
 # support for ZZ

--- a/src/GenOrd/Auxiliary.jl
+++ b/src/GenOrd/Auxiliary.jl
@@ -46,23 +46,11 @@ residue field modulo `d` is used.
 """
 function hnf_modular(M::MatElem{T}, d::T, is_prime::Bool = false) where {T}
   if is_prime
-    x = residue_field(parent(d), d)
-    if isa(x, Tuple)
-      R, mR = x
-    else
-      R = x
-      mR = MapFromFunc(parent(d), R, x->R(x), x->lift(x))
-    end
+    R, mR = residue_field(parent(d), d)
     r, h = rref(map_entries(mR, M))
     H = map_entries(x->preimage(mR, x), h[1:r, :])
   else
-    x = residue_ring(parent(d), d)
-    if isa(x, Tuple)
-      R, mR = x
-    else
-      R = x
-      mR = MapFromFunc(parent(d), R, x->R(x), x->lift(x))
-    end
+    R, mR = residue_ring(parent(d), d)
     H = map_entries(x->preimage(mR, x), hnf(map_entries(mR, M)))
   end
   H = vcat(H, d*identity_matrix(parent(d), ncols(M)))

--- a/src/GenOrd/FractionalIdeal.jl
+++ b/src/GenOrd/FractionalIdeal.jl
@@ -1,17 +1,3 @@
-fractional_ideal(h::GenOrdIdl) = GenOrdFracIdl(h)
-
-function fractional_ideal(O::GenOrd, M::MatElem)
-  @assert base_ring(M) == base_ring(function_field(O))
-  return GenOrdFracIdl(O, M)
-end
-
-function Base.isone(A::GenOrdFracIdl)
-  A = simplify(A)
-  return isone(denominator(A)) && isone(numerator(A))
-end
-
-
-
 ################################################################################
 #
 #  Fractional Ideals
@@ -22,8 +8,20 @@ Hecke.order(a::GenOrdFracIdl) = a.order
 
 function_field(a::GenOrdFracIdl) = a.order.F
 
-function AbstractAlgebra.iszero(x::GenOrdFracIdl)
-  return iszero(numerator(x))
+fractional_ideal(h::GenOrdIdl) = GenOrdFracIdl(h)
+
+function fractional_ideal(O::GenOrd, M::MatElem)
+  @assert base_ring(M) == base_ring(function_field(O))
+  return GenOrdFracIdl(O, M)
+end
+
+function is_one(A::GenOrdFracIdl)
+  A = simplify(A)
+  return is_one(denominator(A; copy = false)) && is_one(numerator(A; copy = false))
+end
+
+function is_zero(x::GenOrdFracIdl)
+  return is_zero(numerator(x; copy = false))
 end
 
 ################################################################################
@@ -35,11 +33,11 @@ end
 
 function show(io::IO, id::GenOrdFracIdl)
   if isdefined(id, :num) && isdefined(id, :den)
-    print(io, "1//(", denominator(id, copy = false), ") * ")
-    print(io, numerator(id, copy = false))
+    print(io, "1//(", denominator(id; copy = false), ") * ")
+    print(io, numerator(id; copy = false))
   else
     print(io, "Fractional ideal of ",id.order ," with basis matrix\n")
-    print(io, basis_matrix(id, copy = false))
+    print(io, basis_matrix(id; copy = false))
   end
 end
 
@@ -59,7 +57,7 @@ function assure_has_basis_matrix(a::GenOrdFracIdl)
 
   k = base_field(function_field(order(a)))
 
-  a.basis_matrix = divexact(change_base_ring(k, basis_matrix(numerator(a, copy = false))), k(denominator(a)))
+  a.basis_matrix = divexact(change_base_ring(k, basis_matrix(numerator(a; copy = false))), k(denominator(a)))
   return nothing
 end
 
@@ -122,9 +120,9 @@ function assure_has_numerator_and_denominator(a::GenOrdFracIdl{S, T}) where {S, 
   return nothing
 end
 
-function Base.numerator(x::GenOrdFracIdl; copy::Bool = true)
+function Base.numerator(x::GenOrdFracIdl{S, T}; copy::Bool = true) where {S, T}
   assure_has_numerator_and_denominator(x)
-  return x.num
+  return (copy ? deepcopy(x.num) : x.num)::GenOrdIdl{S, T}
 end
 
 function Base.denominator(x::GenOrdFracIdl{S, T}; copy::Bool = true) where {S, T}
@@ -142,8 +140,8 @@ end
 
 
 function Base.prod(a::GenOrdFracIdl{S, T}, b::GenOrdFracIdl{S, T}) where {S, T}
-  A = numerator(a)*numerator(b)
-  return GenOrdFracIdl(A, denominator(a)*denominator(b))
+  A = numerator(a; copy = false)*numerator(b; copy = false)
+  return GenOrdFracIdl(A, denominator(a; copy = false)*denominator(b; copy = false))
 end
 
 function Base.:*(a::GenOrdFracIdl{S, T}, b::GenOrdFracIdl{S, T}) where {S, T}
@@ -218,7 +216,7 @@ function Hecke.simplify(A::GenOrdFracIdl)
   end
 
   b = basis_matrix(A.num)
-  g = gcd(denominator(A), content(b))
+  g = gcd(denominator(A; copy = false), content(b))
 
   if g != 1
     A.num = divexact(A.num, g)
@@ -238,7 +236,7 @@ Hecke.is_integral(I::GenOrdIdl) = true
 
 function Hecke.is_integral(I::GenOrdFracIdl)
   simplify(I)
-  return is_one(denominator(I))
+  return is_one(denominator(I; copy = false))
 end
 
 ################################################################################
@@ -248,12 +246,12 @@ end
 ################################################################################
 
 function Base.:*(A::GenOrdIdl, B::GenOrdFracIdl)
-  z = GenOrdFracIdl(A*numerator(B, copy = false), denominator(B))
-  return z
+  return GenOrdFracIdl(A*numerator(B; copy = false), denominator(B; copy = false))
 end
 
-Base.:*(A::GenOrdFracIdl, B::GenOrdIdl) = GenOrdFracIdl(numerator(A, copy = false)*B, denominator(A))
-
+function Base.:*(A::GenOrdFracIdl, B::GenOrdIdl)
+  return GenOrdFracIdl(numerator(A; copy = false)*B, denominator(A; copy = false))
+end
 
 function Base.:*(x::GenOrdElem, y::GenOrdFracIdl)
   #parent(x) !== order(y) && error("GenOrds of element and ideal must be equal")
@@ -286,9 +284,26 @@ function norm(A::GenOrdFracIdl)
   if isdefined(A, :norm)
     return deepcopy(A.norm)
   else
-    A.norm = norm(numerator(A, copy = false))//denominator(A, copy = false)^degree(order(A))
+    A.norm = norm(numerator(A; copy = false))//denominator(A; copy = false)^degree(order(A))
     return deepcopy(A.norm)
   end
+end
+
+################################################################################
+#
+#  Copy
+#
+################################################################################
+
+function Base.deepcopy_internal(I::GenOrdFracIdl{S, T}, dict::IdDict) where {S, T}
+  J = GenOrdFracIdl(order(I))
+  for f in fieldnames(typeof(I))
+    f === :order && continue
+    if isdefined(I, f)
+      setfield!(J, f, Base.deepcopy_internal(getfield(I, f), dict))
+    end
+  end
+  return J
 end
 
 ################################################################################
@@ -301,7 +316,7 @@ function ==(A::GenOrdFracIdl, B::GenOrdFracIdl)
   D = inv(B)
   E = prod(A, D)
   C = simplify(E)
-  return isone(denominator(C, copy = false)) && isone(norm(C))
+  return isone(denominator(C; copy = false)) && isone(norm(C))
 end
 
 function Base.hash(A::GenOrdFracIdl, h::UInt)
@@ -319,8 +334,8 @@ function Hecke.colon(I::GenOrdFracIdl, J::GenOrdFracIdl)
   # \{ x \in K | xJ \subseteq I \} = \{ x \in K | xcb \subseteq da \}
 
   O = order(I)
-  II = numerator(I, copy = false)*O(denominator(J, copy = false))
-  JJ = numerator(J, copy = false)*O(denominator(I, copy = false))
+  II = numerator(I; copy = false)*O(denominator(J; copy = false))
+  JJ = numerator(J; copy = false)*O(denominator(I; copy = false))
   return Hecke.colon(II, JJ)
 end
 
@@ -349,8 +364,8 @@ function Hecke.factor(A::GenOrdFracIdl)
   O = A.order
   N = numerator(norm(A)) * denominator(norm(A))
 
-  A_num = numerator(A)
-  A_den = ideal(O, denominator(A))
+  A_num = numerator(A; copy = false)
+  A_den = ideal(O, denominator(A; copy = false))
 
   factors = factor(N)
   primes = Dict{GenOrdIdl,Int}()
@@ -368,7 +383,7 @@ end
 
 function Hecke.valuation(A::GenOrdFracIdl{S, T}, p::GenOrdIdl{S, T}) where {S, T}
   O = A.order
-  A_num = numerator(A)
-  A_den = ideal(O, denominator(A))
+  A_num = numerator(A; copy = false)
+  A_den = ideal(O, denominator(A; copy = false))
   return valuation(A_num, p) - valuation(A_den, p)
 end

--- a/src/GenOrd/FractionalIdeal.jl
+++ b/src/GenOrd/FractionalIdeal.jl
@@ -130,7 +130,25 @@ function Base.denominator(x::GenOrdFracIdl{S, T}; copy::Bool = true) where {S, T
   return (copy ? deepcopy(x.den) : x.den)::elem_type(T)
 end
 
+################################################################################
+#
+#  Containment
+#
+################################################################################
 
+function Base.in(x::FieldElem, A::GenOrdFracIdl)
+  O = order(A)
+  @req parent(x) === field(O) "Element must be in field(order(A))"
+  # x is in I/d iff d*x is in I (and integral)
+  # note that den lives in the order ring, which lies in the base field
+  K  = field(O)
+  den = K(base_field(K)(denominator(A; copy = false)))
+  y = x * den
+  dy = integral_split(y, O)[2]
+  return isone(dy) && O(y; check = false) in numerator(A; copy = false)
+end
+
+Base.in(x::GenOrdElem, A::GenOrdFracIdl) = data(x) in A
 
 ################################################################################
 #
@@ -312,11 +330,17 @@ end
 #
 ################################################################################
 
-function ==(A::GenOrdFracIdl, B::GenOrdFracIdl)
-  D = inv(B)
-  E = prod(A, D)
-  C = simplify(E)
+function ==(A::GenOrdFracIdl{S, T}, B::GenOrdFracIdl{S, T}) where {S, T}
+  C = simplify(A * inv(B))
   return isone(denominator(C; copy = false)) && isone(norm(C))
+end
+
+function ==(A::GenOrdFracIdl{S, T}, B::GenOrdIdl{S, T}) where {S, T}
+  return A == fractional_ideal(B)
+end
+
+function ==(A::GenOrdIdl{S, T}, B::GenOrdFracIdl{S, T}) where {S, T}
+  return fractional_ideal(A) == B
 end
 
 function Base.hash(A::GenOrdFracIdl, h::UInt)

--- a/src/GenOrd/GenOrd.jl
+++ b/src/GenOrd/GenOrd.jl
@@ -92,6 +92,16 @@ degree(O::GenOrd) = degree(field(O))
 basis_matrix(O::GenOrd{S}) where {S} = O.trans::dense_matrix_type(elem_type(base_field_type(S)))
 basis_matrix_inverse(O::GenOrd{S}) where {S} = O.itrans::dense_matrix_type(elem_type(base_field_type(S)))
 
+_make_canonical_in(O::GenOrd{S, T}, x) where {S, T} = O.R(x)::elem_type(T)
+
+function _make_canonical_in(O::GenOrd{S, T}, x::KInftyElem) where {S, T}
+  O.R(Hecke.AbstractAlgebra.MPolyFactor.make_monic(numerator(x))//denominator(x))::elem_type(T)
+end
+
+function _make_canonical_in(O::GenOrd{S, T}, x::PolyRingElem) where {S, T}
+  O.R(Hecke.AbstractAlgebra.MPolyFactor.make_monic(x))::elem_type(T)
+end
+
 ################################################################################
 #
 #  Basis

--- a/src/GenOrd/GenOrd.jl
+++ b/src/GenOrd/GenOrd.jl
@@ -89,9 +89,8 @@ field(O::GenOrd) = O.F
 
 degree(O::GenOrd) = degree(field(O))
 
-basis_matrix(O::GenOrd{S}) where {S} = O.trans::dense_matrix_type(elem_type(base_field(field(O))))
-
-basis_matrix_inverse(O::GenOrd{S}) where {S} = O.itrans::dense_matrix_type(elem_type(base_field(field(O))))
+basis_matrix(O::GenOrd{S}) where {S} = O.trans::dense_matrix_type(elem_type(base_field_type(S)))
+basis_matrix_inverse(O::GenOrd{S}) where {S} = O.itrans::dense_matrix_type(elem_type(base_field_type(S)))
 
 ################################################################################
 #
@@ -104,7 +103,7 @@ function basis(O::GenOrd; copy::Bool = true)
     if is_equation_order(O)
       return map(O, basis(field(O)))
     else
-      return [O(O.F(vec(collect(O.trans[i,:])))) for i=1:degree(O)]
+      return [O(O.F(vec(collect(basis_matrix(O)[i,:])))) for i=1:degree(O)]
     end
   end::Vector{elem_type(O)}
 end
@@ -169,11 +168,12 @@ function (R::GenOrd{S, T})(a::RingElement; check::Bool = true) where {S, T}
   end
 end
 
-function (O::GenOrd)(c::Vector)
+function (O::GenOrd{S, T})(c::Vector) where {S, T}
   if is_equation_order(O)
     return O(O.F(c))
   else
-    return O(O.F(vec(collect(map(base_ring(O.trans), c)*O.trans))))
+    M = basis_matrix(O)
+    return O(O.F(vec(collect(map(base_ring(M), c)*M))))
   end
 end
 
@@ -454,7 +454,7 @@ function mod(a::GenOrdElem, p::RingElem)
     return O(O.F(mu))
   else
     a = map(x->S(R(x) % p), coordinates(a))
-    b = a*O.trans
+    b = a*basis_matrix(O)
     return O(O.F(b))
   end
 end
@@ -659,11 +659,11 @@ end
 #
 ################################################################################
 
-function trans_mat(O::GenOrd, OO::GenOrd)
+function trans_mat(O::GenOrd{S}, OO::GenOrd{S}) where S
   if is_equation_order(O)
-    return OO.trans
+    return basis_matrix(OO)
   else
-    return is_equation_order(OO) ? O.itrans : OO.trans*O.itrans
+    return is_equation_order(OO) ? basis_matrix_inverse(O) : basis_matrix(OO) * basis_matrix_inverse(O)
   end
 end
 
@@ -720,7 +720,7 @@ function Hecke.discriminant(O::GenOrd)
     # The bypass is to use det(trace_mat) which is correct for orders
     d = discriminant(O.F)
     if !is_equation_order(O)
-      d *= det(O.trans)^2
+      d *= det(basis_matrix(O))^2
     end
   else
     d = det(trace_matrix(O))

--- a/src/GenOrd/GenOrd.jl
+++ b/src/GenOrd/GenOrd.jl
@@ -485,25 +485,12 @@ function ring_of_multipliers(O::GenOrd, I::MatElem{T}, p::T, is_prime::Bool = fa
 
   m = reduce(hcat, [divexact(representation_matrix(O(vec(collect(I[i, :]))))*II, d) for i=1:nrows(I)])
   m = transpose(m)
+
   if is_prime
-    x = residue_field(parent(p), p)
-    if isa(x, Tuple)
-      R, mR = x
-    else
-      R = x
-      mR = MapFromFunc(parent(p), R, x->R(x), x->lift(x))
-    end
-    ref = x->rref(x)[2]
+    R, mR = residue_field(parent(p), p)
+    ref = M -> rref(M)[2]
   else
-    x = residue_ring(parent(p), p)
-    if isa(x, Tuple)
-      R, mR = x
-    else
-      R = x
-      mR = MapFromFunc(parent(p), R, x->R(x), x->lift(x))
-    end
-#    R = parent(p)
-#    mR = MapFromFunc(R, R, x->x, x->x)
+    R, mR = residue_ring(parent(p), p)
     ref = hnf
   end
   m = map_entries(mR, m)
@@ -589,14 +576,8 @@ end
 function Hecke.pmaximal_overorder(O::GenOrd, p::RingElem, is_prime::Bool = false)
   @vprintln :AbsNumFieldOrder 1 "computing a $p-maximal overorder"
 
-  t = residue_field(parent(p), p)
+  R, mR = residue_field(parent(p), p)
 
-  if isa(t, Tuple)
-    R, mR = t
-  else
-    R = t
-    mR = MapFromFunc(parent(p), R, x->R(x), y->lift(y))
-  end
 #  @assert characteristic(F) == 0 || (isfinite(F) && characteristic(F) > degree(O))
   if characteristic(R) == 0 || characteristic(R) > degree(O)
     @vprintln :AbsNumFieldOrder 1 "using trace-radical for $p"
@@ -778,13 +759,7 @@ end
 # rows are an S-basis
 #in pos. char: O/p -> O/p : x-> x^(p^l) has the radical as kernel, perfect field
 function radical_basis_power(O::GenOrd, p::RingElem)
-  t = residue_field(parent(p), p)
-  if isa(t, Tuple)
-    F, mF = t
-  else
-    F = t
-    mF = MapFromFunc(parent(p), F, x->F(x), y->lift(y))
-  end
+  F, mF = residue_field(parent(p), p)
 
   q = order(F)
   d = q
@@ -813,14 +788,7 @@ end
 #in char 0 and small char: rad = {x : Tr(xO) in pR} perfect field
 function radical_basis_trace(O::GenOrd, p::RingElem)
   T = trace_matrix(O)
-
-  t = residue_field(parent(p), p)
-  if isa(t, Tuple)
-    R, mR = t
-  else
-    R = t
-    mR = MapFromFunc(parent(p), R, x->R(x), y->lift(y))
-  end
+  R, mR = residue_field(parent(p), p)
 
   TT = map_entries(mR, T)
   B = kernel(TT; side = :right)
@@ -831,13 +799,7 @@ end
 
 #pos. char, non-perfect (residue) field
 function radical_basis_power_non_perfect(O::GenOrd, p::RingElem)
-  t = residue_field(parent(p), p)
-  if isa(t, Tuple)
-    F, mF = t
-  else
-    F = t
-    mF = MapFromFunc(parent(p), F, x->F(x), y->lift(y))
-  end
+  F, mF = residue_field(parent(p), p)
   @assert isa(F, Generic.RationalFunctionField) && characteristic(F) != 0
   q = characteristic(F)
   @assert q > 0

--- a/src/GenOrd/Ideal.jl
+++ b/src/GenOrd/Ideal.jl
@@ -349,44 +349,26 @@ end
 Base.:*(x::GenOrdIdl, y::GenOrdElem) = y * x
 
 
-function Hecke.colon(a::GenOrdIdl, b::GenOrdIdl)
-
+function Hecke.colon(a::GenOrdIdl{S, T}, b::GenOrdIdl{S, T}) where {S, T}
+  @req order(a) === order(b) "Ideals must lie in the same order"
   O = order(a)
-  n = degree(O)
-  if isdefined(b, :gens)
-    B = b.gens
-  else
-    B = basis(b)
-  end
-
+  Kt = base_field(field(O))
+  B = basis(b)
   bmatinv = basis_mat_inv(a, copy = false)
 
-  R = base_ring(bmatinv)
+  # For each generator b_i of b, compute (mult-by-b_i) * A^{-1} = M_i / d_i,
+  #   and concatenate the M_i side-by-side into one matrix m with common denominator d.
+  mult_matrix(x) = change_base_ring(Kt, representation_matrix(x)) * bmatinv
+  base_num_den = [integral_split(mult_matrix(b_i), coefficient_ring(O)) for b_i in B]
+  d = reduce(lcm, (den for (_, den) in base_num_den))
+  m = reduce(hcat, (num * div(d, den) for (num, den) in base_num_den))
 
-  n = change_base_ring(R, representation_matrix(B[1]))*bmatinv
-  m, d = integral_split(n, coefficient_ring(O))
-  for i in 2:length(B)
-    n = change_base_ring(R, representation_matrix(B[i]))*bmatinv
-    mm, dd = integral_split(n, coefficient_ring(O))
-    l = lcm(dd, d)
-    if l == d && l == dd
-      m = hcat(m, mm)
-    elseif l == d
-      m = hcat(m, div(d, dd)*mm)
-    elseif l == dd
-      m = hcat(div(dd, d)*m, mm)
-      d = dd
-    else
-      m = hcat(m*div(l, d), mm*div(l, dd))
-      d = l
-    end
-  end
-  m = transpose(m)
-  m = hnf(m)
-  # m is upper right HNF
-  m = transpose(sub(m, 1:degree(O), 1:degree(O)))
-  b = inv(divexact(change_base_ring(base_field(field(O)), m), base_field(field(O))(d)))
-  return GenOrdFracIdl(O, b)
+  # m is shape n x (n*|B|). HNF on its transpose gives a basis in the first n rows
+  #   so we transpose back to columns.
+  m = transpose(sub(hnf(transpose(m)), 1:degree(O), 1:degree(O)))
+  # Lift, divide by d, invert: that's (a:b) as a fractional ideal.
+  basis_mat = inv(divexact(change_base_ring(Kt, m), Kt(d)))
+  return GenOrdFracIdl(O, basis_mat)
 end
 
 # If I is not coprime to the conductor of O in the maximal order, then this might

--- a/src/GenOrd/Ideal.jl
+++ b/src/GenOrd/Ideal.jl
@@ -385,7 +385,7 @@ function Hecke.colon(a::GenOrdIdl, b::GenOrdIdl)
   m = hnf(m)
   # m is upper right HNF
   m = transpose(sub(m, 1:degree(O), 1:degree(O)))
-  b = inv(divexact(change_base_ring(base_ring(field(O)), m), base_field(field(O))(d)))
+  b = inv(divexact(change_base_ring(base_field(field(O)), m), base_field(field(O))(d)))
   return GenOrdFracIdl(O, b)
 end
 
@@ -926,8 +926,7 @@ end
 Returns whether $x$ is contained in $y$.
 """
 function in(x::GenOrdElem, y::GenOrdIdl)
-  O = order(y)
-  parent(x) !== order(y) && error("Order of element and ideal must be equal")
+  @req parent(x) === order(y) "Both element and ideal must come from the same order"
   return containment_by_matrices(x, y)
 end
 
@@ -935,10 +934,12 @@ function containment_by_matrices(x::GenOrdElem, y::GenOrdIdl)
   A = basis_mat_inv(y)
   den = lcm(collect(map(denominator, A)))
   kx = base_ring(order(y))
-  num = map_entries(kx,A*den)
-  R = residue_ring(kx, den, cached = false)[1]
+  num = map_entries(kx, A*den)
+  R = residue_ring(kx, den; cached = false)[1]
   M = map_entries(R, num)
-  v = matrix(R, 1, degree(parent(x)), coordinates(x))
+  # coordinates(x) are in base field: lift through O.R
+  coords = map(c -> numerator(c, kx), coordinates(x))
+  v = matrix(R, 1, degree(parent(x)), coords)
   #mul!(v, v, M) This didn't work
   v = v*M
   return iszero(v)

--- a/src/GenOrd/Ideal.jl
+++ b/src/GenOrd/Ideal.jl
@@ -51,6 +51,23 @@ Hecke.order(a::GenOrdIdl) = a.order
 
 ################################################################################
 #
+#  Copy
+#
+################################################################################
+
+function Base.deepcopy_internal(I::GenOrdIdl{S, T}, dict::IdDict) where {S, T}
+  J = GenOrdIdl(order(I))
+  for f in fieldnames(typeof(I))
+    f === :order && continue
+    if isdefined(I, f)
+      setfield!(J, f, Base.deepcopy_internal(getfield(I, f), dict))
+    end
+  end
+  return J
+end
+
+################################################################################
+#
 #  Hash
 #
 ################################################################################
@@ -623,7 +640,7 @@ function Hecke.valuation(A::GenOrdIdl{S, T}, p::GenOrdIdl{S, T}) where {S, T}
     newA = GenOrdFracIdl(beta*A,p.gen_one)
     while is_integral(newA)
       e += 1
-      newA = GenOrdFracIdl(numerator(beta*newA),p.gen_one)
+      newA = GenOrdFracIdl(numerator(beta*newA; copy = false), p.gen_one)
     end
   else
     newA = Hecke.colon(A,p)

--- a/src/GenOrd/Ideal.jl
+++ b/src/GenOrd/Ideal.jl
@@ -695,14 +695,8 @@ function prime_dec_gen(O::GenOrd{S, T}, p::RingElem, degree_limit::Int = degree(
 end
 
 function Hecke.pradical(O::GenOrd, p::RingElem)
-  t = residue_field(parent(p), p)
+  R, mR = residue_field(parent(p), p)
 
-  if isa(t, Tuple)
-    R, mR = t
-  else
-    R = t
-    mR = MapFromFunc(parent(p), R, x->R(x), y->lift(y))
-  end
 #  @assert characteristic(F) == 0 || (isfinite(F) && characteristic(F) > degree(O))
   if characteristic(R) == 0 || characteristic(R) > degree(O)
     @vprintln :AbsNumFieldOrder 1 "using trace-radical for $p"

--- a/src/GenOrd/Ideal.jl
+++ b/src/GenOrd/Ideal.jl
@@ -392,11 +392,7 @@ function Hecke.divexact(A::GenOrdIdl, b::RingElem)
     return A
   end
   O = order(A)
-  if isa(b, KInftyElem)
-    b = O.R(Hecke.AbstractAlgebra.MPolyFactor.make_monic(numerator(b))//denominator(b))
-  elseif isa(b, PolyRingElem)
-    b = Hecke.AbstractAlgebra.MPolyFactor.make_monic(b)
-  end
+  b = _make_canonical_in(O, b)
   bm = divexact(basis_matrix(A), b)
   B = GenOrdIdl(O, bm)
   if false && has_basis_mat_inv(A)
@@ -444,13 +440,7 @@ function assure_has_minimum(A::GenOrdIdl)
       den = lcm(den, denominator(s[i]//d))
     end
 
-    if isa(den, KInftyElem)
-      A.minimum = O.R(Hecke.AbstractAlgebra.MPolyFactor.make_monic(numerator(den))//denominator(den))
-    elseif isa(den, PolyRingElem)
-      A.minimum = Hecke.AbstractAlgebra.MPolyFactor.make_monic(den)
-    else
-      A.minimum = den
-    end
+    A.minimum = _make_canonical_in(O, den)
   end
 
   return nothing
@@ -476,16 +466,7 @@ function assure_has_norm(A::GenOrdIdl)
     return nothing
   end
 
-  O = order(A)
-  b = det(basis_matrix(A; copy = false))
-  if isa(b, KInftyElem)
-    A.norm = O.R(Hecke.AbstractAlgebra.MPolyFactor.make_monic(numerator(b))//denominator(b))
-  elseif isa(b, PolyRingElem)
-    A.norm = Hecke.AbstractAlgebra.MPolyFactor.make_monic(b)
-  else
-    A.norm = b
-  end
-
+  A.norm = _make_canonical_in(order(A), det(basis_matrix(A; copy = false)))
   return nothing
 end
 

--- a/src/GenOrd/Types.jl
+++ b/src/GenOrd/Types.jl
@@ -199,13 +199,8 @@ end
     z = new{S, T}()
     O = order(a)
     z.order = O
-    if isa(b, KInftyElem)
-      b = O.R(Hecke.AbstractAlgebra.MPolyFactor.make_monic(numerator(b))//denominator(b))
-    elseif isa(b, PolyRingElem)
-      b = Hecke.AbstractAlgebra.MPolyFactor.make_monic(b)
-    end
     z.num = a
-    z.den = b
+    z.den = _make_canonical_in(O, b)
     return z
   end
 

--- a/src/GenOrd/Types.jl
+++ b/src/GenOrd/Types.jl
@@ -1,8 +1,8 @@
 @attributes mutable struct GenOrd{S, T} <: Ring
   F::S
   R::T
-  trans#::dense_matrix_type(elem_type(S))
-  itrans#::dense_matrix_type(elem_type(S))
+  trans  #::dense_matrix_type(elem_type(base_field_type(S)))
+  itrans #::dense_matrix_type(elem_type(base_field_type(S)))
   is_equation_order::Bool
 
   function GenOrd(R::AbstractAlgebra.Ring, F::AbstractAlgebra.Field, empty::Bool = false; check::Bool = true)
@@ -60,8 +60,8 @@
       r.trans = T
       r.itrans = Ti
     else
-      r.trans = T*O.trans
-      r.itrans = O.itrans*Ti
+      r.trans = T*basis_matrix(O)
+      r.itrans = basis_matrix_inverse(O)*Ti
     end
     check && map(representation_matrix, basis(r))
     return r

--- a/test/GenOrd/Ideal.jl
+++ b/test/GenOrd/Ideal.jl
@@ -39,6 +39,48 @@
     check_prime_2elem(P, expected_f, expected_e)
   end
 
+  function test_containment_common(O, a, t)
+    L = Hecke.field(O)
+
+    a = O(a)
+    I = ideal(O, a)
+    Ifrac = fractional_ideal(I)
+
+    for v in (a, a * O(t), O(0))
+      @test v in I
+      @test v in Ifrac
+    end
+    for v in (O(1), O(t))
+      @test !(v in I)
+      @test !(v in Ifrac)
+    end
+
+    Iinv = inv(I)
+    for v in (zero(L), one(L), L(a), L(1)//L(a))
+      @test v in Iinv
+    end
+    @test a in Iinv
+
+    @test !(L(1)//L(a)^2 in Iinv)
+
+    # In a local ring O.R, units are everything coprime to the prime, so this test doesnt make sense
+    if !isa(O.R, LocalizedEuclideanRing)
+      @test !(L(1)//L(t) in Iinv)
+    end
+  end
+
+  function test_colon_common_ideal(O, I)
+    @assert is_prime(I)
+
+    L = Hecke.field(O)
+    U = ideal(O, O(1))
+    @test Hecke.colon(I, U) == fractional_ideal(I)
+    @test one(L) in Hecke.colon(I, I)
+    @test Hecke.colon(U, I) * I == U
+  end
+
+  test_colon_common(O, p) = test_colon_common_ideal(O, ideal(O, O(p)))
+
   @testset "over F_2(x)" begin
     kx, x = rational_function_field(GF(2), :x; cached = false)
     ky, y = polynomial_ring(kx, :y; cached = false)
@@ -107,10 +149,9 @@
         @test inertia_degree(P) == f_expected
       end
 
-      let (L, t) = function_field(y^3 - x - 1; cached = false)
-        Ofin = finite_maximal_order(L)
-        Oinf = infinite_maximal_order(L)
-
+      let (L, t) = function_field(y^3 - x - 1; cached = false),
+          Ofin = finite_maximal_order(L),
+          Oinf = infinite_maximal_order(L)
         check_prime_2elem_single_above(Ofin, x + 1, 1, 3)
         check_prime_2elem_single_above(Ofin, x^2 + x + 1, 3, 1)
 
@@ -136,6 +177,14 @@
         @test e == 3
         @test inertia_degree(P) == 1
       end
+    end
+
+    @testset "containment" begin
+      test_containment_common(Ofin, x^4 + x + 1, t)
+    end
+
+    @testset "colon" begin
+      test_colon_common(Ofin, x^4 + x + 1)
     end
   end
 
@@ -163,6 +212,14 @@
 
       I = ideal(Oinf, L(x^2)//t^3)
       check_ideal_norm_min(I, norm(Oinf(L(x^2)//t^3)), 1//x)
+    end
+
+    @testset "containment" begin
+      test_containment_common(Ofin, x^2 + 1, t)
+    end
+
+    @testset "colon" begin
+      test_colon_common(Ofin, x^2 + 1)
     end
   end
 
@@ -210,6 +267,14 @@
       #   number fields defined by non-monic polynomials,
       #   since the Lenstra order is a sub-order of the equation order.
     end
+
+    @testset "containment" begin
+      test_containment_common(OK, ZZ(3), ZZ(5))
+    end
+
+    @testset "colon" begin
+      test_colon_common(OK, ZZ(3))
+    end
   end
 
   @testset "over number field localized at prime" begin
@@ -229,6 +294,9 @@
         @test e == 1
         check_prime_2elem(P, 1, 1)
       end
+
+      test_containment_common(OK, R(7), R(5))
+      test_colon_common_ideal(OK, ideal(OK, R(7), OK(a - 3)))
     end
 
     @testset "inert (p = 3)" begin
@@ -237,6 +305,9 @@
 
       check_ideal_norm_min(ideal(OK, R(3)), R(9), R(3))
       check_prime_2elem_single_above(OK, R(3), 2, 1)
+
+      test_containment_common(OK, R(3), R(5))
+      test_colon_common(OK, R(3))
     end
 
     @testset "ramified (p = 2)" begin
@@ -247,6 +318,9 @@
       check_ideal_norm_min(ideal(OK, R(2), OK(a)),   R(2), R(2))
 
       check_prime_2elem_single_above(OK, R(2), 1, 2)
+
+      test_containment_common(OK, R(2), R(5))
+      test_colon_common_ideal(OK, ideal(OK, R(2), OK(a)))
     end
   end
 end


### PR DESCRIPTION
Continuation of prev pr.

- Route `O.trans` / `O.itrans` access through typed accessors, and make accessors' type annotations to be compile time deducible
- In several places we had duplicated `KInftyElem`/`PolyRingElem` dispatch to put a polynomial element into monic form. Extracted common helper to do it uniformly for all the types we care about. This coerces to `O.R`, making users have inferred concrete type
- Drop `isa(_, Tuple)` wrappers around `residue_field` / `residue_ring`. In all the cases we have these return a tuple, so no more boxing and type confusion for the compiler.
- Implemented `deepcopy_internal` for `GenOrdIdl` / `GenOrdFracIdl` preserving order, and fixed `numerator(::GenOrdFracIdl; copy=true)` to actually copy when requested.
- Extended ideal containment and colon beyond function fields, added `Base.in(::FieldElem, ::GenOrdFracIdl)`, and refactored colon for implementation clarity.
