### PR TITLE
Funfield/GenOrd cleanup

### DIFF
--- a/src/FunField/Divisor.jl
+++ b/src/FunField/Divisor.jl
@@ -568,6 +568,9 @@ end
 #
 #  Riemann-Roch computation
 #
+#  implements Riemann-Roch computation from Hess'
+#  "Computing Riemann-Roch Spaces in Algebraic Function Fields and Related Topics"
+#
 ################################################################################
 @doc raw"""
     riemann_roch_space(D::Divisor) -> Vector{FunFieldElem}
@@ -576,44 +579,73 @@ Return a basis of the Riemann-Roch space L(D).
 """
 function riemann_roch_space(D::Divisor)
   I_fin, I_inf = ideals(D)
-  J_fin = inv(I_fin)
-  J_inf = inv(I_inf)
-
-  F = function_field(D)
-  return _riemann_roch_space(J_fin, J_inf, F)
+  return _riemann_roch_space(inv(I_fin), inv(I_inf), function_field(D))
 end
 
+# we have two functions: _riemann_roch_space to compute Riemann-Roch space itself
+#   and _riemann_roch_dim to compute its dimension
+# Their inputs are:
+#   J_fin is the inverse of the finite ideal
+#   J_inf is the inverse of the infinite ideal
+#   F is the ambient function field
 
-#J_fin is inverse of finite ideal
-#J_inf is inverse of infinite ideal
-#F is functionfield
+# common setup for Riemann-Roch
+function _riemann_roch_common_setup(basis_fin, basis_inf)
+  # express basis_fin in terms of basis_inf
+  B_fin = matrix(map(coordinates, basis_fin))
+  B_inf = matrix(map(coordinates, basis_inf))
+  M = solve(B_inf, B_fin; side = :left)
+
+  # clear denominators
+  d = mapreduce(denominator, lcm, M)
+
+  return change_base_ring(parent(d), d*M), degree(d)
+end
+
+# computes the basis of the Riemann-Roch space
 function _riemann_roch_space(J_fin, J_inf, F)
-
   x = gen(base_ring(F))
   n = degree(F)
 
-  basis_gens = basis(J_fin)
+  basis_fin = basis(J_fin)
+  basis_inf = basis(J_inf)
+  dM, d_deg = _riemann_roch_common_setup(basis_fin, basis_inf)
 
-  B_fin = matrix(map(coordinates, basis_gens))
-  B_inf = matrix(map(coordinates, basis(J_inf)))
+  # weak Popov reduction of dM (no denominators)
+  T, U = weak_popov_with_transform(dM)
 
-  M = solve(B_inf, B_fin; side = :left)
-  d = lcm(vec(map(denominator,collect(M))))
-  d_deg = degree(d)
-  Mnew = change_base_ring(parent(d), d*M)
-
-  T, U = weak_popov_with_transform(Mnew)
-
-  basis_gens = change_base_ring(F, U) * basis(J_fin)
+  # v_i in Hess paper
+  basis_gens = change_base_ring(F, U) * basis_fin
 
   RR_basis = elem_type(F)[]
-  for i in (1:n)
-    d_i = maximum(map(degree, T[i,1:n]))
-    for j in (0: - d_i + d_deg)
-      push!(RR_basis, x^(j) * basis_gens[i])
+  for i in 1:n
+    d_i = maximum(degree(T[i, k]) for k in 1:n)
+    g = basis_gens[i]
+    for _ in 0:(d_deg - d_i)
+      push!(RR_basis, g)
+      g = x*g # this is x^j * basis_gens[i] for j = 0 .. d_deg - d_i
     end
   end
   return RR_basis
+end
+
+# computes the dimension of the Riemann-Roch space
+function _riemann_roch_dim(J_fin, J_inf, F)
+  n = degree(F)
+
+  dM, d_deg = _riemann_roch_common_setup(basis(J_fin), basis(J_inf))
+
+  # we need only weak Popov form itself, without transform
+  T = weak_popov(dM)
+
+  # same as above, but instead of constructing basis vectors we just count them
+  dim = 0
+  for i in 1:n
+    d_i = maximum(degree(T[i, k]) for k in 1:n)
+    dim += max(0, d_deg - d_i + 1)
+  end
+
+  return dim
 end
 
 @doc raw"""
@@ -622,7 +654,8 @@ end
 Return the dimension l(D) of the Riemann-Roch space L(D).
 """
 function dimension(D::Divisor)
-  return length(riemann_roch_space(D))
+  I_fin, I_inf = ideals(D)
+  return _riemann_roch_dim(inv(I_fin), inv(I_inf), function_field(D))
 end
 
 @doc raw"""
@@ -635,7 +668,6 @@ function index_of_speciality(D::Divisor)
   F = function_field(D)
   @req is_separable(defining_polynomial(F)) "Currently assumes separable extension"
 
-  K = canonical_divisor(F)
-  return length(riemann_roch_space(K - D))
+  return dimension(canonical_divisor(F) - D)
 end
 

--- a/src/FunField/Divisor.jl
+++ b/src/FunField/Divisor.jl
@@ -85,8 +85,8 @@ function zero_divisor(f::Generic.FunctionFieldElem{T}) where {T <: FieldElement}
   F = parent(f)
 
   Ofin, Oinf = finite_maximal_order(F), infinite_maximal_order(F)
-  f_num, f_denom = integral_split(f, Ofin)
-  g_num, g_denom = integral_split(f, Oinf)
+  f_num, _ = integral_split(f, Ofin)
+  g_num, _ = integral_split(f, Oinf)
 
   return divisor(ideal(Ofin, f_num), ideal(Oinf, g_num))
 end
@@ -100,8 +100,8 @@ function pole_divisor(f::Generic.FunctionFieldElem{T}) where {T <: FieldElement}
   F = parent(f)
 
   Ofin, Oinf = finite_maximal_order(F), infinite_maximal_order(F)
-  f_num, f_denom = integral_split(f, Ofin)
-  g_num, g_denom = integral_split(f, Oinf)
+  _, f_denom = integral_split(f, Ofin)
+  _, g_denom = integral_split(f, Oinf)
 
   return divisor(ideal(Ofin, f_denom), ideal(Oinf, g_denom))
 end
@@ -439,7 +439,7 @@ Return the divisor whose support consists exactly of all poles in the support of
 """
 function pole_divisor(D::Divisor)
   assure_has_support(D)
-  return _filter_support(D, x -> x.second < 0)
+  return -_filter_support(D, x -> x.second < 0)
 end
 
 ################################################################################

--- a/src/FunField/Divisor.jl
+++ b/src/FunField/Divisor.jl
@@ -496,6 +496,22 @@ function is_principal(D::Divisor)
 end
 
 @doc raw"""
+    is_principal_with_data(D::Divisor) -> Bool, FunFieldElem
+
+Tests if $D$ is principal and returns $(\mathtt{true}, f)$ if $D = \langle f \rangle$ or $(\mathtt{false}, 1)$ otherwise.
+"""
+function is_principal_with_data(D::Divisor)
+  F = function_field(D)
+
+  degree(D) == 0 || return (false, one(F))
+
+  RR = riemann_roch_space(D)
+  length(RR) == 1 || return (false, one(F))
+
+  return (true, inv(RR[1]))
+end
+
+@doc raw"""
     is_zero(D::Divisor) -> Bool
 
 Return true if D is the trivial divisor.

--- a/src/GenOrd/Auxiliary.jl
+++ b/src/GenOrd/Auxiliary.jl
@@ -45,13 +45,15 @@ if `is_prime` is set, then instead of an `hnf` internally a `rref` over the
 residue field modulo `d` is used.
 """
 function hnf_modular(M::MatElem{T}, d::T, is_prime::Bool = false) where {T}
-  if is_prime
-    R, mR = residue_field(parent(d), d)
+  # make sure to pin the type of H: the result of both branches has typeof(M)
+  #   but compiler cannot infer it
+  H::typeof(M) = if is_prime
+    _, mR = residue_field(parent(d), d)
     r, h = rref(map_entries(mR, M))
-    H = map_entries(x->preimage(mR, x), h[1:r, :])
+    map_entries(x->preimage(mR, x), h[1:r, :])
   else
-    R, mR = residue_ring(parent(d), d)
-    H = map_entries(x->preimage(mR, x), hnf(map_entries(mR, M)))
+    _, mR = residue_ring(parent(d), d)
+    map_entries(x->preimage(mR, x), hnf(map_entries(mR, M)))
   end
   H = vcat(H, d*identity_matrix(parent(d), ncols(M)))
   H = hnf(H)

--- a/src/GenOrd/FractionalIdeal.jl
+++ b/src/GenOrd/FractionalIdeal.jl
@@ -11,7 +11,7 @@ function_field(a::GenOrdFracIdl) = a.order.F
 fractional_ideal(h::GenOrdIdl) = GenOrdFracIdl(h)
 
 function fractional_ideal(O::GenOrd, M::MatElem)
-  @assert base_ring(M) == base_ring(function_field(O))
+  @assert base_ring(M) == base_field(function_field(O))
   return GenOrdFracIdl(O, M)
 end
 

--- a/src/GenOrd/GenOrd.jl
+++ b/src/GenOrd/GenOrd.jl
@@ -487,7 +487,7 @@ end
 #
 ################################################################################
 
-function ring_of_multipliers(O::GenOrd, I::MatElem{T}, p::T, is_prime::Bool = false) where {T}
+function ring_of_multipliers(O::GenOrd{S, T}, I::MatElem{P}, p::P, is_prime::Bool = false) where {S, T, P}
   #TODO: modular big hnf, peu-a-peu, not all in one
   @vprintln :AbsNumFieldOrder 2 "ring of multipliers module $p (is_prime: $is_prime) of ideal with basis matrix $I"
   II, d = pseudo_inv(I)
@@ -496,30 +496,39 @@ function ring_of_multipliers(O::GenOrd, I::MatElem{T}, p::T, is_prime::Bool = fa
   m = reduce(hcat, [divexact(representation_matrix(O(vec(collect(I[i, :]))))*II, d) for i=1:nrows(I)])
   m = transpose(m)
 
-  if is_prime
-    R, mR = residue_field(parent(p), p)
-    ref = M -> rref(M)[2]
-  else
-    R, mR = residue_ring(parent(p), p)
-    ref = hnf
-  end
-  m = map_entries(mR, m)
+  mm = is_prime ? _ring_of_multipliers_reduce_prime(m, p, degree(O)) :
+                  _ring_of_multipliers_reduce_nonprime(m, p, degree(O))
+  H = hnf_modular(mm, p, is_prime)
 
-  n = degree(O)
-  mm = ref(m[1:n, 1:n])
-  for i=2:n
-    mm = vcat(mm, ref(m[(i-1)*n+1:i*n, 1:n]))
-    mm = ref(mm)
+  @vtime :AbsNumFieldOrder 2 Hi, d = pseudo_inv(H)
+  return GenOrd(O, transpose(Hi), d, check = false)::GenOrd{S, T}
+end
+
+# ring_of_multipliers function-barrier helpers: it fixes the return type
+function _ring_of_multipliers_reduce_prime(m::M, p, n) where {M <: MatElem}
+  _, mR = residue_field(parent(p), p)
+
+  mp = map_entries(mR, m)
+  mm = rref(mp[1:n, 1:n])[2]
+  for i = 2:n
+    mm = rref(vcat(mm, rref(mp[(i-1)*n+1:i*n, 1:n])[2]))[2]
     @assert iszero(mm[n+1:end, :])
     mm = mm[1:n, 1:n]
   end
-#  H = hnf(map_entries(x->preimage(mR, x), mm))
-  H = hnf_modular(map_entries(x->preimage(mR, x), mm), p, is_prime)
+  return map_entries(x -> preimage(mR, x), mm)::typeof(m)
+end
 
-  @vtime :AbsNumFieldOrder 2 Hi, d = pseudo_inv(H)
+function _ring_of_multipliers_reduce_nonprime(m::M, p, n) where {M <: MatElem}
+  _, mR = residue_ring(parent(p), p)
 
-  O = GenOrd(O, transpose(Hi), d, check = false)
-  return O
+  mp = map_entries(mR, m)
+  mm = hnf(mp[1:n, 1:n])
+  for i = 2:n
+    mm = hnf(vcat(mm, hnf(mp[(i-1)*n+1:i*n, 1:n])))
+    @assert iszero(mm[n+1:end, :])
+    mm = mm[1:n, 1:n]
+  end
+  return map_entries(x -> preimage(mR, x), mm)::typeof(m)
 end
 
 function ring_of_multipliers(O::GenOrd, I::MatElem)
@@ -589,27 +598,29 @@ end
 
 function Hecke.pmaximal_overorder(O::GenOrd, p::RingElem, is_prime::Bool = false)
   @vprintln :AbsNumFieldOrder 1 "computing a $p-maximal overorder"
+  R, _ = residue_field(parent(p), p)
 
-  R, mR = residue_field(parent(p), p)
-
-#  @assert characteristic(F) == 0 || (isfinite(F) && characteristic(F) > degree(O))
   if characteristic(R) == 0 || characteristic(R) > degree(O)
     @vprintln :AbsNumFieldOrder 1 "using trace-radical for $p"
-    rad = radical_basis_trace
+    return _pmaximal_overorder_radical(O, p, is_prime, radical_basis_trace)
   elseif isa(R, Generic.RationalFunctionField)
     @vprintln :AbsNumFieldOrder 1 "non-perfect case for radical for $p"
-    rad = radical_basis_power_non_perfect
+    return _pmaximal_overorder_radical(O, p, is_prime, radical_basis_power_non_perfect)
   else
     @vprintln :AbsNumFieldOrder 1 "using radical-by-power for $p"
-    rad = radical_basis_power
+    return _pmaximal_overorder_radical(O, p, is_prime, radical_basis_power)
   end
+end
+
+# Function-barrier helper: F will be a concrete type here
+function _pmaximal_overorder_radical(O::GenOrd, p::RingElem, is_prime::Bool, rad::F) where {F}
   while true #TODO: check the discriminant to maybe skip the last iteration
     I = rad(O, p)
-    S = ring_of_multipliers(O, I, p, is_prime)
-    if discriminant(O) == discriminant(S)
+    Onew = ring_of_multipliers(O, I, p, is_prime)
+    if discriminant(O) == discriminant(Onew)
       return O
     end
-    O = S
+    O = Onew
   end
 end
 
@@ -800,10 +811,10 @@ function radical_basis_power(O::GenOrd, p::RingElem)
 end
 
 #in char 0 and small char: rad = {x : Tr(xO) in pR} perfect field
-function radical_basis_trace(O::GenOrd, p::RingElem)
+function radical_basis_trace(O::GenOrd{S, T}, p::RingElem) where {S, T}
   R, mR = residue_field(parent(p), p)
-  T = _trace_matrix(O, R, mR)
-  B = kernel(T; side = :right)
+  M = _trace_matrix(O, R, mR)
+  B = kernel(M; side = :right)
   M2 = transpose(map_entries(x->preimage(mR, x), B))
   return Hecke.hnf_modular(M2, p, true)
 end

--- a/src/GenOrd/GenOrd.jl
+++ b/src/GenOrd/GenOrd.jl
@@ -550,21 +550,25 @@ end
 #
 ################################################################################
 
-function trace_matrix(O::GenOrd)
-  return trace_matrix(basis(O))
-end
+trace_matrix(O::GenOrd) = _trace_matrix(O, base_ring(O), identity)
+trace_matrix(b::Vector{<:GenOrdElem}) = _trace_matrix(b, base_ring(b[1]), identity)
 
-function trace_matrix(b::Vector{<:GenOrdElem})
-  O = parent(b[1])
-  m = zero_matrix(base_ring(O), length(b), length(b))
-  for i=1:length(b)
-    m[i, i] = trace(b[i]*b[i])
-    for j=i+1:length(b)
-      m[i, j] = m[j, i] = trace(b[i]*b[j])
+# Build the trace matrix directly over R, applying f to each entry.
+# Used to materialise the trace matrix in a residue field / coefficient field
+#   without an extra map_entries pass.
+function _trace_matrix(b::Vector{<:GenOrdElem}, R::Ring, f)
+  n = length(b)
+  m = zero_matrix(R, n, n)
+  for i = 1:n
+    m[i, i] = f(trace(b[i]*b[i]))
+    for j = i+1:n
+      m[i, j] = m[j, i] = f(trace(b[i]*b[j]))
     end
   end
   return m
 end
+
+_trace_matrix(O::GenOrd, R::Ring, f) = _trace_matrix(basis(O), R, f)
 
 function trace_matrix(b::Vector{<:GenOrdElem}, c::Vector{<:GenOrdElem}, exp::ZZRingElem = ZZRingElem(1))
   O = parent(b[1])
@@ -797,14 +801,11 @@ end
 
 #in char 0 and small char: rad = {x : Tr(xO) in pR} perfect field
 function radical_basis_trace(O::GenOrd, p::RingElem)
-  T = trace_matrix(O)
   R, mR = residue_field(parent(p), p)
-
-  TT = map_entries(mR, T)
-  B = kernel(TT; side = :right)
+  T = _trace_matrix(O, R, mR)
+  B = kernel(T; side = :right)
   M2 = transpose(map_entries(x->preimage(mR, x), B))
-  M3 = Hecke.hnf_modular(M2, p, true)
-  return M3 #[O(vec(collect((M3[i, :])))) for i=1:degree(O)]
+  return Hecke.hnf_modular(M2, p, true)
 end
 
 #pos. char, non-perfect (residue) field
@@ -892,21 +893,13 @@ function different(O::GenOrd)
 end
 
 @doc raw"""
-    codifferent(R::AbsNumFieldOrder) -> AbsNumFieldOrderIdeal{AbsSimpleNumField, AbsSimpleNumFieldElem}
+    codifferent(O::GenOrd) -> GenOrdFracIdl
 
-The codifferent ideal of $R$, i.e. the trace-dual of $R$.
+The codifferent ideal of $O$, i.e. the trace-dual of $O$.
 """
 function codifferent(O::GenOrd)
-   B = basis(O)
-   R = base_ring(O.F)
-   n = degree(O)
-   mat_entries = elem_type(R)[]
-   for u in B
-     for v in B
-       push!(mat_entries, R(trace(u*v)))
-     end
-   end
-  return fractional_ideal(O, inv(matrix(R, n, n, mat_entries)))
+  K = base_field(O.F)
+  return fractional_ideal(O, inv(_trace_matrix(O, K, K)))
 end
 
 ###############################################################################

--- a/src/GenOrd/Types.jl
+++ b/src/GenOrd/Types.jl
@@ -42,26 +42,26 @@
     return GenOrd(r, M, one(Qt), check = check)
   end
 
-  function GenOrd(O::GenOrd, T::MatElem, d::RingElem; check::Bool = true)
+  function GenOrd(O::GenOrd{S, T}, M::MatElem, d::RingElem; check::Bool = true) where {S, T}
     F = base_field(O.F)
-    if base_ring(T) isa ZZPolyRing
+    if base_ring(M) isa ZZPolyRing
       R = base_ring(Hecke.AbstractAlgebra.Generic.underlying_fraction_field(F))
-      T = map_entries(x -> F(change_base_ring(QQ, x; parent = R)), T)
-      T = divexact(T, F(change_base_ring(QQ, d; parent = R)))
+      M = map_entries(x -> F(change_base_ring(QQ, x; parent = R)), M)
+      M = divexact(M, F(change_base_ring(QQ, d; parent = R)))
     else
-      T = map_entries(F, T)
-      T = divexact(T, base_ring(T)(d))
+      M = map_entries(F, M)
+      M = divexact(M, base_ring(M)(d))
     end
-    Ti = inv(T)
-    r = GenOrd(O.R, O.F, true)
+    Mi = inv(M)
+    r = GenOrd(O.R, O.F, true)::GenOrd{S, T}
 
     r.is_equation_order = false
     if is_equation_order(O)
-      r.trans = T
-      r.itrans = Ti
+      r.trans = M
+      r.itrans = Mi
     else
-      r.trans = T*basis_matrix(O)
-      r.itrans = basis_matrix_inverse(O)*Ti
+      r.trans = M*basis_matrix(O)
+      r.itrans = basis_matrix_inverse(O)*Mi
     end
     check && map(representation_matrix, basis(r))
     return r

--- a/test/FunField/Divisor.jl
+++ b/test/FunField/Divisor.jl
@@ -155,6 +155,64 @@ import Hecke: divisor
     end
   end
 
+  @testset "principal with generator: ellcrv" begin
+    function check_principal(D, expected_gen)
+      @test is_principal(D)
+      ok, f = @inferred is_principal_with_data(D)
+      @test ok
+      @test divisor(f) == D                         # witness generates D
+      @test is_zero(divisor(f * inv(expected_gen))) # witness is equivalent to expected_gen
+    end
+
+    function check_not_principal(D)
+      @test !is_principal(D)
+      ok, f = @inferred is_principal_with_data(D)
+      @test !ok
+      @test isone(f) # we document the return value, so let's keep it checked
+    end
+
+    kx, x = rational_function_field(QQ, :x; cached = false)
+    ky, y = polynomial_ring(kx, :y; cached = false)
+    F, a = function_field(y^2 - x^3 - 1; cached = false)   # E: y^2 = x^3 + 1
+    Ofin = finite_maximal_order(F)
+    Oinf = infinite_maximal_order(F)
+
+    point_divisor(X, Y) = divisor(ideal(Ofin, x - X, Ofin(a - Y)))
+    D1, D2 = point_divisor(0, 1), point_divisor(0, -1)  # order 3
+    D3, D4 = point_divisor(2, 3), point_divisor(2, -3)  # order 6
+    D5 = point_divisor(-1, 0)                           # order 2
+
+    p_inf, _ = first(factor(ideal(Oinf, base_ring(Oinf)(1//x))))
+    D6 = divisor(p_inf)                                 # infinity
+
+    for D in (D1, D2, D3, D4, D5, D6) # single-point divisors are non-principal
+      check_not_principal(D)
+    end
+
+    # x - 2 = 0 hits E at (2, 3), (2, -3) and twice at infinity.
+    D = D3 + D4 - 2*D6
+    @test degree(D) == 0
+    check_principal(D, F(x - 2))
+
+    # x + 1 = 0 hits E at (-1, 0) with multiplicity 2 and twice at infinity.
+    D = 2*D5 - 2*D6
+    @test degree(D) == 0
+    check_principal(D, F(x + 1))
+
+    # y = x + 1 meets E at (0, 1), (2, 3), (-1, 0)
+    D = D1 + D3 + D5 - 3*D6
+    @test degree(D) == 0
+    check_principal(D, a - F(x) - 1)
+
+    D = D3 - D6
+    @test degree(D) == 0
+    check_not_principal(D)
+
+    D = D1 + D3 - 2*D6
+    @test degree(D) == 0
+    check_not_principal(D)
+  end
+
     @testset "Algebraic function field over rationals (1)" begin
       kx, x = rational_function_field(QQ, :x; cached = false)
       ky, y = polynomial_ring(kx, :y; cached = false)

--- a/test/FunField/Divisor.jl
+++ b/test/FunField/Divisor.jl
@@ -119,10 +119,10 @@ import Hecke: divisor
   end
 
   @testset "Riemann-Roch" begin
-    for base_field in [QQ, finite_field(2, 4)[1], finite_field(5, 2)[1], finite_field(101)[1]]
+    for base_field in [QQ, finite_field(2, 2)[1], finite_field(13)[1]]
       kx, x = rational_function_field(base_field, :x; cached = false)
       ky, y = polynomial_ring(kx, :y; cached = false)
-      for poly in [y^3 - x - 1, y^3 - x^3 - 1, y^3 - x^17 - 1]
+      for poly in [y^3 - x - 1, y^3 - x^3 - 1, y^3 - x^5 - 1]
         F, a = function_field(poly; cached = false)
         Ofin = @inferred finite_maximal_order(F)
         Oinf = @inferred infinite_maximal_order(F)
@@ -135,12 +135,12 @@ import Hecke: divisor
         D1, D2 = divisor(p1), divisor(p2)
 
         # Riemann-Roch: l(D) - l(K-D) = deg(D) - g + 1
-        for n in -3:3
-          D = n*D1 + D2
-          @test dimension(D) - index_of_speciality(D) == degree(D) - g + 1
-          D = D1 + n*D2
-          @test dimension(D) - index_of_speciality(D) == degree(D) - g + 1
-        end
+        D = -pole_divisor(F(1)//a)  # deg(D) < 0
+        @test dimension(D) - index_of_speciality(D) == degree(D) - g + 1
+        D = 2*zero_divisor(a^2)     # deg(D) > 2g - 2
+        @test dimension(D) - index_of_speciality(D) == degree(D) - g + 1
+        D = 2*D1 + D2
+        @test dimension(D) - index_of_speciality(D) == degree(D) - g + 1
 
         # 2 * (l(K) - l(0)) = deg(K) - deg(0)
         @test degree(CD) == 2*g - 2

--- a/test/FunField/Divisor.jl
+++ b/test/FunField/Divisor.jl
@@ -176,6 +176,8 @@ import Hecke: divisor
 
       @test trivial_divisor(F) == 0 * D1
       @test degree(trivial_divisor(F)) == 0
+      @test 1 == length(@inferred riemann_roch_space(trivial_divisor(F)))
+      @test 1 == @inferred dimension(trivial_divisor(F))
 
       D = 3*D3 - D1
       Do = @inferred divisor(inv(p1), p3^3)
@@ -186,12 +188,15 @@ import Hecke: divisor
 
       #Elliptic curve group law
       @test is_principal(D1 + D2 - 2*D3)
+      @test 1 == length(@inferred riemann_roch_space(D1 + D2 - 2*D3))
+      @test 1 == @inferred dimension(D1 + D2 - 2*D3)
+
       @test is_zero(D - D)
 
       @test D == Do
-      @test 3 == @inferred valuation(D, p3)
+      @test  3 == @inferred valuation(D, p3)
       @test -1 == @inferred valuation(D, p1)
-      @test 0 == @inferred valuation(D, p2)
+      @test  0 == @inferred valuation(D, p2)
 
       @test 2 == @inferred degree(D)
 
@@ -203,7 +208,8 @@ import Hecke: divisor
       @test (D + D2 > D)
 
       L = @inferred riemann_roch_space(DD)
-      @test length(L) == 6
+      @test 6 == length(L)
+      @test 6 == @inferred dimension(DD)
 
       for f in L
         @test is_effective(divisor(f) + DD)
@@ -222,6 +228,7 @@ import Hecke: divisor
       Df = different_divisor(F)
       @test degree(Df) == 4
       @test 0 == @inferred dimension(Df - 6*divisor(p3))
+      @test 0 == length(@inferred riemann_roch_space(Df - 6*divisor(p3)))
       @test 2 == @inferred index_of_speciality(Df-6*divisor(p3))
 
       KF = canonical_divisor(F)

--- a/test/FunField/Divisor.jl
+++ b/test/FunField/Divisor.jl
@@ -215,12 +215,6 @@ import Hecke: divisor
         @test is_effective(divisor(f) + DD)
       end
 
-      D_z = zero_divisor(F(x-3))
-      D_p = pole_divisor(F(x-3))
-      @test is_effective(D_z)
-      @test !is_effective(D)
-      @test (D_z - D_p) == divisor(F(x-3))
-
       @test F == function_field(D)
       Dfin, Dinf = ideals(D)
       @test divisor(Dfin) + divisor(Dinf) == D
@@ -234,6 +228,20 @@ import Hecke: divisor
       KF = canonical_divisor(F)
       @test 0 == @inferred degree(KF)
       @test 1 == @inferred genus(F)
+
+      let D = divisor(F(x-3))
+        D_z = @inferred zero_divisor(F(x-3))
+        D_p = @inferred pole_divisor(F(x-3))
+        @test is_effective(D_z)
+        @test is_effective(D_p)
+        @test D == D_z - D_p
+
+        D_z = @inferred zero_divisor(D)
+        D_p = @inferred pole_divisor(D)
+        @test is_effective(D_z)
+        @test is_effective(D_p)
+        @test D == D_z - D_p
+      end
     end
 
     @testset "Algebraic function field over rationals (2)" begin

--- a/test/GenOrd/GenOrd.jl
+++ b/test/GenOrd/GenOrd.jl
@@ -35,3 +35,99 @@
     @test length(basis(O)) == 2
   end
 end
+
+@testset "Trace matrix and codifferent" begin
+  # for equation order O = R[a], different(O) = (f'(a)) and codifferent(O) = (1/f'(a))
+  function check_equation_order_different(O, f)
+    @assert is_equation_order(O)
+    K = Hecke.field(O)
+    fp_alpha = derivative(f)(gen(K))
+    @test inv(codifferent(O)) == ideal(O, O(fp_alpha))
+    @test 1//fp_alpha in @inferred codifferent(O)
+
+    # simplistic check for public trace matrix api to agree
+    @test @inferred(trace_matrix(O)) == @inferred(trace_matrix(basis(O)))
+  end
+
+  # for every r in the radical Tr(r * basis(O)) is in pR
+  function check_radical_basis_trace(O, p)
+    M = Hecke.radical_basis_trace(O, p)
+    n = degree(O)
+
+    _, mR = residue_field(parent(p), p)
+    B = basis(O)
+    for i = 1:n
+      r = O([M[i, j] for j = 1:n])
+      for k = 1:n
+        @test iszero(mR(trace(r * B[k])))
+      end
+    end
+  end
+
+  @testset "number field over ZZ" begin
+    x = gen(Hecke.Globals.Qx)
+    f = x^2 + 5
+    K, _ = number_field(f, :a; cached = false)
+
+    O = order(ZZ, K)
+    @assert is_equation_order(O)
+    check_equation_order_different(O, f)
+    check_radical_basis_trace(O, ZZ(5)) # p = 5: bigger than the degree and divides disc(O)
+  end
+
+  @testset "number field localization" begin
+    x = gen(Hecke.Globals.Qx)
+    f = x^2 + 5
+    K, _ = number_field(f, :a; cached = false)
+    R = Hecke.localization(ZZ, ZZ(5); cached = false)
+
+    O = integral_closure(R, K)
+    @assert is_equation_order(O)
+    check_equation_order_different(O, f)
+    check_radical_basis_trace(O, R(5)) # p = 5 bigger than the degree and ramified
+
+    R = Hecke.localization(ZZ, ZZ(7); cached = false)
+    O = integral_closure(R, K)
+    @assert is_equation_order(O)
+    check_equation_order_different(O, f)
+  end
+
+  @testset "function field over Q(t)" begin
+    kx, x = rational_function_field(QQ, :x; cached = false)
+    ky, y = polynomial_ring(kx, :y; cached = false)
+    f = y^3 + x*y + (x^2 + 1)
+    L, t = function_field(f; cached = false)
+
+    O = Hecke.GenOrd(parent(numerator(x)), L)
+    @assert is_equation_order(O)
+    check_equation_order_different(O, f)
+
+    fac = collect(factor(discriminant(O)))
+    check_radical_basis_trace(O, fac[1][1])
+  end
+
+  @testset "function field over F_2(x)" begin
+    kx, x = rational_function_field(GF(2), :x; cached = false)
+    ky, y = polynomial_ring(kx, :y; cached = false)
+    f = y^3 - x^3 - 1
+    L, t = function_field(f; cached = false)
+
+    O = Hecke.GenOrd(parent(numerator(x)), L)
+    @assert is_equation_order(O)
+    check_equation_order_different(O, f)
+  end
+
+  @testset "function field over F_5(t)" begin
+    kx, x = rational_function_field(GF(5), :x; cached = false)
+    ky, y = polynomial_ring(kx, :y; cached = false)
+    f = y^2 + x*y + (x^3 + 1)
+    L, t = function_field(f; cached = false)
+
+    O = Hecke.GenOrd(parent(numerator(x)), L)
+    @assert is_equation_order(O)
+    check_equation_order_different(O, f)
+
+    fac = collect(factor(discriminant(O)))
+    check_radical_basis_trace(O, fac[1][1])
+  end
+end

--- a/test/GenOrd/GenOrd.jl
+++ b/test/GenOrd/GenOrd.jl
@@ -51,7 +51,7 @@ end
 
   # for every r in the radical Tr(r * basis(O)) is in pR
   function check_radical_basis_trace(O, p)
-    M = Hecke.radical_basis_trace(O, p)
+    M = @inferred Hecke.radical_basis_trace(O, p)
     n = degree(O)
 
     _, mR = residue_field(parent(p), p)
@@ -129,5 +129,113 @@ end
 
     fac = collect(factor(discriminant(O)))
     check_radical_basis_trace(O, fac[1][1])
+  end
+end
+
+@testset "pmaximal_overorder" begin
+  function check_p_maximal(O, Op, p)
+    # runtime type check (we will do @inferred in tests, so just to be safe)
+    @test Op isa typeof(O)
+
+    # Op contains O (overorder property)
+    for b in basis(O)
+      @test b in Op
+    end
+
+    # disc(Op) divides disc(O)
+    @test iszero(mod(discriminant(O), discriminant(Op)))
+
+    # Idempotent at p: applying pmaximal again is a no-op
+    @test discriminant(Hecke.pmaximal_overorder(Op, p, true)) == discriminant(Op)
+  end
+
+  @testset "number field (trace-radical)" begin
+    x = gen(Hecke.Globals.Qx)
+    K, _ = number_field(x^2 - 18, :a; cached = false)
+    # maximal order: Z[sqrt(2)]
+    # equation order: Z[3*sqrt(2)] has index 3 in maximal order
+    O = order(ZZ, K)
+    @assert discriminant(O) == 72   # = 9 · 8
+
+    Op = @inferred Hecke.pmaximal_overorder(O, ZZ(3), true)
+    check_p_maximal(O, Op, ZZ(3))
+    @test discriminant(Op) == 8     # 72 / 3^2 = 8 (= disc Q(sqrt(2)))
+
+    Op_np = @inferred Hecke.pmaximal_overorder(O, ZZ(3), false)
+    check_p_maximal(O, Op_np, ZZ(3))
+    @test discriminant(Op_np) == 8
+  end
+
+  @testset "number field 2 (radical-by-power)" begin
+    x = gen(Hecke.Globals.Qx)
+    K, _ = number_field(x^2 - 12, :a; cached = false)
+    # maximal order: Z[sqrt(3)]
+    # equation order: Z[2*sqrt(3)] has index 2 in maximal order
+    O = order(ZZ, K)
+    @assert discriminant(O) == 48     # = 4 · 12
+
+    Op = @inferred Hecke.pmaximal_overorder(O, ZZ(2), true)
+    check_p_maximal(O, Op, ZZ(2))
+    @test discriminant(Op) == 12      # 48 / 2^2 = 12 (= disc Q(sqrt(3)))
+
+    Op_np = @inferred Hecke.pmaximal_overorder(O, ZZ(2), false)
+    check_p_maximal(O, Op_np, ZZ(2))
+    @test discriminant(Op_np) == 12
+  end
+
+  @testset "function field over Q(t) (trace-radical)" begin
+    kx, x = rational_function_field(QQ, :x; cached = false)
+    ky, y = polynomial_ring(kx, :y; cached = false)
+    f = y^2 - x^2*(x + 1)           # disc = 4*x^2*(x+1)
+    L, _ = function_field(f; cached = false)
+
+    Zx = parent(numerator(x))
+    O = Hecke.GenOrd(Zx, L)
+    p = gen(Zx)                     # prime = x
+
+    Op = @inferred Hecke.pmaximal_overorder(O, p, true)
+    check_p_maximal(O, Op, p)
+    # the x^2 factor in the equation-order discriminant goes away
+    @test  iszero(mod(discriminant(O),  p^2))
+    @test !iszero(mod(discriminant(Op), p^2))
+
+    # TODO: results in
+    #   function divrem is not implemented for arguments
+    #   EuclideanRingResidueRingElem{QQPolyRingElem}: 1
+    #   EuclideanRingResidueRingElem{QQPolyRingElem}: 1
+
+    # Op_np = @inferred Hecke.pmaximal_overorder(O, p, false)
+    # check_p_maximal(O, Op_np, p)
+    # @test !iszero(mod(discriminant(Op_np), p^2))
+  end
+
+  @testset "function field over F_2(x) (radical-by-power)" begin
+    kx, x = rational_function_field(GF(2), :x; cached = false)
+    ky, y = polynomial_ring(kx, :y; cached = false)
+    f = y^3 + x*y + x^2             # disc = x^4, non-maximal equation order
+    L, _ = function_field(f; cached = false)
+
+    Zx = parent(numerator(x))
+    O = Hecke.GenOrd(Zx, L)
+
+    fac = collect(factor(discriminant(O)))
+    p = fac[1][1]
+
+    # discriminant Op is x^2
+    Op = @inferred Hecke.pmaximal_overorder(O, p, true)
+    check_p_maximal(O, Op, p)
+    @test  iszero(mod(discriminant(O),  p^4))
+    @test !iszero(mod(discriminant(Op), p^4))
+    @test  iszero(mod(discriminant(Op), p^2))
+
+    # TODO: results in
+    #   function divrem is not implemented for arguments
+    #   EuclideanRingResidueRingElem{QQPolyRingElem}: 1
+    #   EuclideanRingResidueRingElem{QQPolyRingElem}: 1
+
+    # Op_np = @inferred Hecke.pmaximal_overorder(O, p, false)
+    # check_p_maximal(O, Op_np, p)
+    # @test !iszero(mod(discriminant(Op_np), p^4))
+    # @test  iszero(mod(discriminant(Op_np), p^2))
   end
 end

--- a/test/GenOrd/Ideal.jl
+++ b/test/GenOrd/Ideal.jl
@@ -282,7 +282,7 @@
     K, a = number_field(x^2 - 2, :a)
 
     @testset "split (p = 7)" begin
-      R = Hecke.localization(ZZ, 7)
+      R = Hecke.localization(ZZ, 7; cached = false)
       OK = integral_closure(R, K)
 
       check_ideal_norm_min(ideal(OK, R(7)),             R(49), R(7))
@@ -300,7 +300,7 @@
     end
 
     @testset "inert (p = 3)" begin
-      R = Hecke.localization(ZZ, 3)
+      R = Hecke.localization(ZZ, 3; cached = false)
       OK = integral_closure(R, K)
 
       check_ideal_norm_min(ideal(OK, R(3)), R(9), R(3))
@@ -311,7 +311,7 @@
     end
 
     @testset "ramified (p = 2)" begin
-      R = Hecke.localization(ZZ, 2)
+      R = Hecke.localization(ZZ, 2; cached = false)
       OK = integral_closure(R, K)
 
       check_ideal_norm_min(ideal(OK, R(2)),          R(4), R(2))


### PR DESCRIPTION
Cleanup and improvements to the GenOrd / FunField stack, focused on type stability and code prettification. 
Fixed a `pole_divisor(D::Divisor)` bug, and added `is_principal_with_data(D::Divisor)`.

GenOrd: 
- Type stability for `pmaximal_overorder` (and the whole chain)/
  - `hnf_modular`: pinned `H::typeof(M)` making the inferred return type concrete/
  - `ring_of_multipliers`: split into function-barrier helpers to help the compiler to infer the concrete type/
  - `pmaximal_overorder`: routed through helper with radical function having a concrete type/
- Trace Matrix: added internal helper to generate trace matrix directly over given ring. `radical_basis_trace` and `codifferent` now route through it, simplifying code.
- `codifferent` now works for number fields too/

FunField:
- fixed `pole_divisor(D::Divisor)` to return an effective divisor/
- added `is_principal_with_data(D::Divisor)` mirroring number-field and associative-algebra ideals: it returns `(true, f)` with `f` generating `D` when principal, and `(false, 1)` otherwise.
- slight refactor of `_riemann_roch_space`. Added `_riemann_roch_dim` for cases where we care only about the dimension of Riemann-Roch space.

For all the additions/changes, tests are added. Also optimized existing Riemann-Roch tests (now they run twice faster while still testing all the cases we wanted).
