### PR TITLE
GenOrd: ensure principal ideal norm is canonical

### DIFF
--- a/src/GenOrd/GenOrd.jl
+++ b/src/GenOrd/GenOrd.jl
@@ -92,14 +92,10 @@ degree(O::GenOrd) = degree(field(O))
 basis_matrix(O::GenOrd{S}) where {S} = O.trans::dense_matrix_type(elem_type(base_field_type(S)))
 basis_matrix_inverse(O::GenOrd{S}) where {S} = O.itrans::dense_matrix_type(elem_type(base_field_type(S)))
 
-_make_canonical_in(O::GenOrd{S, T}, x) where {S, T} = O.R(x)::elem_type(T)
-
-function _make_canonical_in(O::GenOrd{S, T}, x::KInftyElem) where {S, T}
-  O.R(Hecke.AbstractAlgebra.MPolyFactor.make_monic(numerator(x))//denominator(x))::elem_type(T)
-end
-
-function _make_canonical_in(O::GenOrd{S, T}, x::PolyRingElem) where {S, T}
-  O.R(Hecke.AbstractAlgebra.MPolyFactor.make_monic(x))::elem_type(T)
+function _make_canonical_in(O::GenOrd{S, T}, x) where {S, T}
+  y = O.R(x)
+  iszero(y) && return y::elem_type(T)
+  return divexact(y, canonical_unit(y))::elem_type(T)
 end
 
 ################################################################################

--- a/src/GenOrd/Types.jl
+++ b/src/GenOrd/Types.jl
@@ -154,7 +154,7 @@ end
        r.is_zero = 1
     end
 
-    r.norm = norm(x)
+    r.norm = _make_canonical_in(O, norm(x))
     r.gen_one = r.norm
     r.gen_two = x
     return r

--- a/test/GenOrd/Ideal.jl
+++ b/test/GenOrd/Ideal.jl
@@ -20,8 +20,8 @@
   function check_ideal_norm_min(I, expected_norm, expected_min)
     @test istril(basis_matrix(I))
     @test divides(norm(I), minimum(I))[1]
-    @test expected_norm == @inferred norm(I)
-    @test expected_min == @inferred minimum(I)
+    @test @inferred(norm(I)) == Hecke._make_canonical_in(order(I), expected_norm)
+    @test @inferred(minimum(I)) == Hecke._make_canonical_in(order(I), expected_min)
   end
 
   function check_prime_2elem(P, expected_f, expected_e)
@@ -208,7 +208,7 @@
 
     @testset "norm/min: infinite maximal order" begin
       I = ideal(Oinf, 3//x^2)
-      check_ideal_norm_min(I, 27//x^6, 1//x^2)
+      check_ideal_norm_min(I, 1//x^6, 1//x^2)
 
       I = ideal(Oinf, L(x^2)//t^3)
       check_ideal_norm_min(I, norm(Oinf(L(x^2)//t^3)), 1//x)
@@ -220,6 +220,21 @@
 
     @testset "colon" begin
       test_colon_common(Ofin, x^2 + 1)
+    end
+  end
+
+  @testset "over Q(x)" begin
+    kx, x = rational_function_field(QQ, :x; cached = false)
+    ky, y = polynomial_ring(kx, :y; cached = false)
+    L, t = function_field(y^2 - x^3 - x^2; cached = false)
+
+    Ofin = finite_maximal_order(L)
+    Oinf = infinite_maximal_order(L)
+
+    @testset "norm/min: finite maximal order" begin
+      I = ideal(Ofin, L(y)//L(x))
+      check_ideal_norm_min(I, x + 1, x + 1)
+      @test is_prime(I)
     end
   end
 


### PR DESCRIPTION
- Principal-ideal constructor for `GenOrdIdl` now stores a canonical `norm` (previously the raw element norm, which could differ from the canonical form by a unit).
- `_make_canonical_in` collapsed to a single method built on `canonical_unit`. Removes the no-op generic fallback that silently skipped normalization for inputs whose static type wasn't `PolyRingElem`/`KInftyElem`.

`is_prime(A::GenOrdIdl)` compares `norm(A)` against `norm(P)` for `P` in `factor(A)`. When `A` is built from a single element, `r.norm` was set without canonicalization. 
For the second issue in https://github.com/thofma/Hecke.jl/issues/2266
we had `norm(I) == -(x+1)` and a single prime factor `P` of `I` had  `norm(P) == x+1`, breaking `is_prime(I)` check.
