### PR TITLE
fix: radical for algebras and residue fields for QQbar

### DIFF
--- a/src/AlgAss/Decompose.jl
+++ b/src/AlgAss/Decompose.jl
@@ -194,7 +194,7 @@ function _dec_com_gen(A::AbstractAssociativeAlgebra{T}) where {T <: FieldElem}
       error("something is wrong, please report this")
       # either something is really wrong, or we need to adjust the randomization
     end
-    c = elem_type(F)[ rand(F, -10:10) for i = 1:k ]
+    c = elem_type(F)[ !(F isa NumField) ? F(rand(-10:10)) : rand(F, -10:10) for i = 1:k ]
     a = dot(c, V)
     f = minpoly(a)
 

--- a/src/AlgAss/radical.jl
+++ b/src/AlgAss/radical.jl
@@ -52,7 +52,8 @@ end
 #
 ################################################################################
 
-function _radical_zero(A::AbstractAssociativeAlgebra{T}) where { T <: Union{ QQFieldElem, NumFieldElem } }
+function _radical_zero(A::AbstractAssociativeAlgebra)
+  @assert is_zero(characteristic(base_ring(A)))
   M = trace_matrix(A)
   N = kernel(M; side = :right)
   n = ncols(N)

--- a/src/GenOrd/Ideal.jl
+++ b/src/GenOrd/Ideal.jl
@@ -674,6 +674,15 @@ function prime_dec_gen(O::GenOrd{S, T}, p::RingElem, degree_limit::Int = degree(
   return lp
 end
 
+function residue_field(R::PolyRing{QQBarFieldElem}, p::PolyRingElem{QQBarFieldElem})
+  @assert degree(p) == 1
+  @assert is_monic(p)
+  c = -coeff(p, 0)
+  K = base_ring(R)
+  f = MapFromFunc(R, K, q -> q(c), x -> R(x))
+  return K, f
+end
+
 function Hecke.pradical(O::GenOrd, p::RingElem)
   R, mR = residue_field(parent(p), p)
 

--- a/test/AlgAss/AbsAlgAss.jl
+++ b/test/AlgAss/AbsAlgAss.jl
@@ -163,7 +163,7 @@
     I = radical(A)
     @test nrows(basis_matrix(I, copy = false)) == 0
 
-    for K in [ F2, F4, QQ ]
+    for K in [ F2, F4, QQ, algebraic_closure(QQ) ]
       A = matrix_algebra(K, [ matrix(K, 2, 2, [ 1, 0, 0, 0 ]), matrix(K, 2, 2, [ 0, 1, 0, 0 ]), matrix(K, 2, 2, [ 0, 0, 0, 1]) ]) # i. e. upper triangular matrices
       I = radical(A)
       @test nrows(basis_matrix(I, copy = false)) == 1

--- a/test/AlgAss/Decompose.jl
+++ b/test/AlgAss/Decompose.jl
@@ -25,4 +25,3 @@
   @test dim(A1) + dim(A2) == dim(A)
 
 end
-

--- a/test/GenOrd/Ideal.jl
+++ b/test/GenOrd/Ideal.jl
@@ -430,3 +430,16 @@ let
 
   @test a * O + a * O == a * O
 end
+
+let # 2266
+  K = algebraic_closure(QQ)
+  Kx, x = rational_function_field(K,"x")
+  KxY, Y = polynomial_ring(Kx, "Y")
+  P = Y^2 - x^3 - x^2
+  kC, y = function_field(P, "y")
+  OC = finite_maximal_order(kC)
+  I = ideal(OC(x),OC(y))
+  lp = factor(I)
+  @test all(is_prime(p) for (p,_) in lp)
+  @test prod(p^e for (p, e) in lp) == I
+end


### PR DESCRIPTION
- Relax signature to allow QQBar in radical computation
- Make the residue_field of QQBar[x] equal to QQBar

Fixes the remaining issues of #2266.

@alexey-orlov-math does the fix with the residue field make sense to you? Otherwise we would have to implement `factor` for R[X], where `R::EuclideanRingResidueField{AbstractAlgebra.Generic.Poly{QQBarFieldElem}}`.