### PR TITLE
FunField: Riemann-Roch test coverage, plus fixes found along the way

### DIFF
--- a/src/FunField/Divisor.jl
+++ b/src/FunField/Divisor.jl
@@ -553,10 +553,20 @@ end
 
 Return the genus of F.
 """
-function genus(F::AbstractAlgebra.Generic.FunctionField)
+@attr Int function genus(F::AbstractAlgebra.Generic.FunctionField)
   @req is_separable(defining_polynomial(F)) "Currently assumes separable extension"
+  # g = (degree(K) + 2) / 2, where K is the canonical divisor.
+  # Since K = (dx) = Diff_{F/k(x)} - 2(x)_inf, we have
+  # deg(K) = deg(Diff_{F/k(x)}) - 2*[F:k(x)], and
+  # g = 1 - n + deg(Diff_{F/k(x)}) / 2
 
-  return length(basis_of_differentials(F))
+  d1 = degree(discriminant(finite_maximal_order(F)))
+  d2 = degree(discriminant(infinite_maximal_order(F)))
+  # note that we need valuation at infinity: degree in t = 1/x (hence minus)
+  dDiff = d1 - d2
+  @assert iseven(dDiff)
+
+  return 1 - degree(F) + divexact(dDiff, 2)
 end
 
 ################################################################################

--- a/src/FunField/Divisor.jl
+++ b/src/FunField/Divisor.jl
@@ -83,12 +83,7 @@ Return the divisor consisting of the zeroes of f
 """
 function zero_divisor(f::Generic.FunctionFieldElem{T, U}) where {T, U}
   F = parent(f)
-
-  Ofin, Oinf = finite_maximal_order(F), infinite_maximal_order(F)
-  f_num, _ = integral_split(f, Ofin)
-  g_num, _ = integral_split(f, Oinf)
-
-  return divisor(ideal(Ofin, f_num), ideal(Oinf, g_num))
+  return lcm(divisor(f), trivial_divisor(F))
 end
 
 @doc raw"""
@@ -98,12 +93,7 @@ Return the divisor consisting of the poles of f
 """
 function pole_divisor(f::Generic.FunctionFieldElem{T, U}) where {T, U}
   F = parent(f)
-
-  Ofin, Oinf = finite_maximal_order(F), infinite_maximal_order(F)
-  _, f_denom = integral_split(f, Ofin)
-  _, g_denom = integral_split(f, Oinf)
-
-  return divisor(ideal(Ofin, f_denom), ideal(Oinf, g_denom))
+  return lcm(divisor(inv(f)), trivial_divisor(F))
 end
 
 ################################################################################
@@ -411,8 +401,11 @@ end
 Return the divisor whose support consists exactly of all zeroes in the support of D.
 """
 function zero_divisor(D::Divisor)
-  assure_has_support(D)
-  return _filter_support(D, x -> x.second > 0)
+  if has_support(D)
+    return _filter_support(D, x -> x.second > 0)
+  else
+    return lcm(D, trivial_divisor(function_field(D)))
+  end
 end
 
 @doc raw"""
@@ -421,8 +414,11 @@ end
 Return the divisor whose support consists exactly of all poles in the support of D.
 """
 function pole_divisor(D::Divisor)
-  assure_has_support(D)
-  return -_filter_support(D, x -> x.second < 0)
+  if has_support(D)
+    return -_filter_support(D, x -> x.second < 0)
+  else
+    return lcm(-D, trivial_divisor(function_field(D)))
+  end
 end
 
 ################################################################################

--- a/src/FunField/Divisor.jl
+++ b/src/FunField/Divisor.jl
@@ -437,21 +437,46 @@ function degree(D::Divisor)
   # For a place P lying over a (finite) prime p in the base ring,
   #   deg(P) = [F_P : K] = f(P) * deg(p),
   # where f(P) is the inertia degree and deg(p) is the degree of p as a
-  # polynomial in the base ring.
+  #   polynomial in the base ring.
   #
   # For infinite places, p lies in KInftyRing.
   # The formula above stays correct if we read deg(p) as the degree of p
-  # as a polynomial in the local parameter t = 1/x.
-  # However, `degree(::KInftyElem)` returns the degree in x, which is -(degree in t).
-  # We therefore compensate by subtracting the infinite contribution rather than adding it.
-  function deg_place(p::GenOrdIdl, e::Integer)
-    return degree(p)*degree(minimum(p))*e
+  #   as a polynomial in the local parameter t = 1/x.
+  #
+  # If we do NOT know the support, we proceed via the ideals directly.
+  # let D = D_fin + D_inf with fractional ideals
+  #   J_fin = I_fin / d_fin and J_inf = I_inf / d_inf. Then
+  # deg(D) = deg_x(det(basis_matrix(J_fin))) + v_inf(det(basis_matrix(J_inf)))
+  #        = deg_x( norm(I_fin) / d_fin^n ) + v_inf( norm(I_inf) / d_inf^n ),
+  #   where we write n = [F : k(x)] for a degree.
+  #
+  # As before, v_inf(f) = -deg_x(f) is the degree in the local parameter t = 1/x, so
+  #   we always compute degrees in x and SUBTRACT the infinite contribution.
+  # This matches the support branch, where `degree(::KInftyElem)` also returns
+  #   the degree in x.
+
+  if has_support(D)
+    function deg_place(p::GenOrdIdl, e::Integer)
+      return degree(p)*degree(minimum(p))*e
+    end
+
+    fin_deg = sum(deg_place(f, e) for (f, e) in D.finite_support; init = zero(Int))
+    inf_deg = sum(deg_place(f, e) for (f, e) in D.infinite_support; init = zero(Int))
+
+    return fin_deg - inf_deg
+  else
+    n = degree(function_field(D))
+
+    I_fin = numerator(D.finite_ideal; copy = false)
+    d_fin = denominator(D.finite_ideal; copy = false)
+    fin_deg = degree(norm(I_fin)) - n*degree(d_fin)
+
+    I_inf = numerator(D.infinite_ideal; copy = false)
+    d_inf = denominator(D.infinite_ideal; copy = false)
+    inf_deg = degree(norm(I_inf)) - n*degree(d_inf)
+
+    return fin_deg - inf_deg
   end
-
-  fin_deg = sum(deg_place(f, e) for (f, e) in finite_support(D); init = zero(Int))
-  inf_deg = sum(deg_place(f, e) for (f, e) in infinite_support(D); init = zero(Int))
-
-  return fin_deg - inf_deg
 end
 
 @doc raw"""

--- a/src/FunField/Divisor.jl
+++ b/src/FunField/Divisor.jl
@@ -27,8 +27,6 @@ mutable struct Divisor{S <: Generic.FunctionField, T1 <: PolyRing, T2 <: KInftyR
 
 end
 
-@attributes AbstractAlgebra.Generic.FunctionField
-
 function trivial_divisor(F::Generic.FunctionField)
   return divisor(one(F))
 end
@@ -510,8 +508,9 @@ end
 
 Return the different divisor of F.
 """
-function different_divisor(F::Generic.FunctionField{T, U}) where {T, U}
-  return divisor(different(finite_maximal_order(F)), different(infinite_maximal_order(F)))
+@attr Divisor{Generic.FunctionField{T, U}, parent_type(U), KInftyRing{T, U}} function
+different_divisor(K::Generic.FunctionField{T, U}) where {T, U}
+  return divisor(different(finite_maximal_order(K)), different(infinite_maximal_order(K)))
 end
 
 @doc raw"""
@@ -534,10 +533,11 @@ end
 
 Return the canonical divisor of F.
 """
-function canonical_divisor(F::AbstractAlgebra.Generic.FunctionField)
-  @req is_separable(defining_polynomial(F)) "Currently assumes separable extension"
+@attr Divisor{Generic.FunctionField{T, U}, parent_type(U), KInftyRing{T, U}} function
+canonical_divisor(K::Generic.FunctionField{T, U}) where {T, U}
+  @req is_separable(defining_polynomial(K)) "Currently assumes separable extension"
 
-  dx = differential(separating_element(F))
+  dx = differential(separating_element(K))
   return divisor(dx)
 end
 

--- a/src/FunField/Divisor.jl
+++ b/src/FunField/Divisor.jl
@@ -485,7 +485,14 @@ end
 Return true if D is an effective divisor.
 """
 function is_effective(D::Divisor)
-  return isempty(support(pole_divisor(D)))
+  # effective = no poles
+  # if we know the support: check multiplicities (all non-negative)
+  # otherwise check that ideals are integral (that is, no denominators)
+  if has_support(D)
+    return all(>=(0), values(D.finite_support)) && all(>=(0), values(D.infinite_support))
+  else
+    return is_integral(D.finite_ideal) && is_integral(D.infinite_ideal)
+  end
 end
 
 @doc raw"""

--- a/src/GenOrd/Auxiliary.jl
+++ b/src/GenOrd/Auxiliary.jl
@@ -123,6 +123,12 @@ function base_field_type(::Type{Generic.FunctionField{T, U}}) where {T, U}
   return Generic.RationalFunctionField{T, U}
 end
 
+function is_defining_polynomial_nice(F::Generic.FunctionField)
+  f = defining_polynomial(F)
+  is_one(leading_coefficient(f)) || return false
+  return all(is_one(denominator(c)) for c in coefficients(f))
+end
+
 #######################################################################
 #
 # support for ZZ

--- a/src/GenOrd/FractionalIdeal.jl
+++ b/src/GenOrd/FractionalIdeal.jl
@@ -278,10 +278,10 @@ function Base.:*(x::GenOrdElem, I::GenOrdFracIdl)
   return GenOrdIdl(parent(x), x) * I
 end
 
-function Base.:*(f::Generic.FunctionFieldElem, O::GenOrd)
-  @req parent(f) === field(O) "Element must lie in the function field of the order"
-  f_num, f_denom = integral_split(f, O)
-  return GenOrdFracIdl(ideal(O, f_num), f_denom)
+function Base.:*(x::FieldElem, O::GenOrd)
+  @req parent(x) === field(O) "Element must lie in the field of the order"
+  x_num, x_denom = integral_split(x, O)
+  return GenOrdFracIdl(ideal(O, x_num), x_denom)
 end
 
 function Base.:*(c::Generic.RationalFunctionFieldElem, I::GenOrdFracIdl)
@@ -295,7 +295,7 @@ function Base.:*(c::Generic.RationalFunctionFieldElem, I::GenOrdIdl)
 end
 
 Base.:*(I::GenOrdFracIdl, x::GenOrdElem) = x * I
-Base.:*(O::GenOrd, f::Generic.FunctionFieldElem) = f * O
+Base.:*(O::GenOrd, f::FieldElem) = f * O
 Base.:*(I::GenOrdFracIdl, c::Generic.RationalFunctionFieldElem) = c * I
 Base.:*(I::GenOrdIdl, c::Generic.RationalFunctionFieldElem) = c * I
 
@@ -384,8 +384,15 @@ function Hecke.colon(I::GenOrdFracIdl, J::GenOrdIdl)
 end
 
 function inv(A::GenOrdFracIdl)
+  # inv(N/d) = d * inv(N): factor the scalar denominator out
+  #   instead of routing the whole fractional ideal through colon
+  #   which involves O(denominator) and extra ideal arithmetic
   O = order(A)
-  return colon(O(1)*O, A)
+  k = base_field(field(O))
+
+  invN = inv(numerator(A; copy = false))
+  M = k(denominator(A; copy = false)) * basis_matrix(invN; copy = false)
+  return GenOrdFracIdl(O, M)
 end
 
 Base.://(I::GenOrdFracIdl, J::GenOrdFracIdl) = colon(I, J)

--- a/src/GenOrd/FractionalIdeal.jl
+++ b/src/GenOrd/FractionalIdeal.jl
@@ -263,29 +263,41 @@ end
 #
 ################################################################################
 
-function Base.:*(A::GenOrdIdl, B::GenOrdFracIdl)
+function Base.:*(A::GenOrdIdl{S, T}, B::GenOrdFracIdl{S, T}) where {S, T}
+  @req order(A) === order(B) "Ideals must have same order"
   return GenOrdFracIdl(A*numerator(B; copy = false), denominator(B; copy = false))
 end
 
-function Base.:*(A::GenOrdFracIdl, B::GenOrdIdl)
+function Base.:*(A::GenOrdFracIdl{S, T}, B::GenOrdIdl{S, T}) where {S, T}
+  @req order(A) === order(B) "Ideals must have same order"
   return GenOrdFracIdl(numerator(A; copy = false)*B, denominator(A; copy = false))
 end
 
-function Base.:*(x::GenOrdElem, y::GenOrdFracIdl)
-  #parent(x) !== order(y) && error("GenOrds of element and ideal must be equal")
-  return GenOrdIdl(parent(x), x) * y
+function Base.:*(x::GenOrdElem, I::GenOrdFracIdl)
+  @req parent(x) === order(I) "Element and ideal must belong to the same order"
+  return GenOrdIdl(parent(x), x) * I
 end
 
 function Base.:*(f::Generic.FunctionFieldElem, O::GenOrd)
-  @assert parent(f) == O.F
+  @req parent(f) === field(O) "Element must lie in the function field of the order"
   f_num, f_denom = integral_split(f, O)
   return GenOrdFracIdl(ideal(O, f_num), f_denom)
 end
 
+function Base.:*(c::Generic.RationalFunctionFieldElem, I::GenOrdFracIdl)
+  @req parent(c) === base_field(function_field(order(I))) "scalar must lie in the base field of the function field"
+  return GenOrdFracIdl(order(I), c * basis_matrix(I; copy = false))
+end
 
+# multiplying by field element always returns fractional ideal (for type stability)
+function Base.:*(c::Generic.RationalFunctionFieldElem, I::GenOrdIdl)
+  return c * fractional_ideal(I)
+end
 
-Base.:*(x::GenOrdFracIdl, y::GenOrdElem) = y * x
-Base.:*(x::GenOrd, y::Generic.FunctionFieldElem) = y * x
+Base.:*(I::GenOrdFracIdl, x::GenOrdElem) = x * I
+Base.:*(O::GenOrd, f::Generic.FunctionFieldElem) = f * O
+Base.:*(I::GenOrdFracIdl, c::Generic.RationalFunctionFieldElem) = c * I
+Base.:*(I::GenOrdIdl, c::Generic.RationalFunctionFieldElem) = c * I
 
 ################################################################################
 #

--- a/src/GenOrd/FractionalIdeal.jl
+++ b/src/GenOrd/FractionalIdeal.jl
@@ -47,27 +47,20 @@ end
 #
 ################################################################################
 
-function assure_has_basis_matrix(a::GenOrdFracIdl)
-  if isdefined(a, :basis_matrix)
-    return nothing
-  end
-  if !isdefined(a, :num)
-    error("Not a valid fractional ideal")
-  end
+function assure_has_basis_matrix(a::GenOrdFracIdl{S, T}) where {S, T}
+  isdefined(a, :basis_matrix) && return nothing
+  isdefined(a, :num) || error("Not a valid fractional ideal")
 
-  k = base_field(function_field(order(a)))
-
+  k = base_field(field(order(a)))::base_field_type(S)
   a.basis_matrix = divexact(change_base_ring(k, basis_matrix(numerator(a; copy = false))), k(denominator(a)))
   return nothing
 end
 
-function Hecke.basis_matrix(x::GenOrdFracIdl; copy::Bool = true)
+function Hecke.basis_matrix(x::GenOrdFracIdl{S, T}; copy::Bool = true) where {S, T}
   assure_has_basis_matrix(x)
-  if copy
-    return deepcopy(x.basis_matrix)
-  else
-    return x.basis_matrix
-  end
+
+  M = x.basis_matrix::dense_matrix_type(elem_type(base_field_type(S)))
+  return copy ? deepcopy(M) : M
 end
 
 

--- a/src/GenOrd/GenOrd.jl
+++ b/src/GenOrd/GenOrd.jl
@@ -733,17 +733,13 @@ end
 
 function Hecke.discriminant(O::GenOrd)
   if is_monic(defining_polynomial(O.F))
-    #"the" example from Jeroen is
-    #   x*y^3 + (-x + 1)*y^2 - y + x^3 + x^2
-    # and the problem is the correct power of x.
-    # The disc. is "well definined" up to the correct power of the
-    # leading coeff....
-    # The bypass is to use det(trace_mat) which is correct for orders
+    # a polynomial discriminant is only well-defined up to a power of leading coefficient
     d = discriminant(O.F)
     if !is_equation_order(O)
       d *= det(basis_matrix(O))^2
     end
   else
+    # going through trace matrix is correct in every order
     d = det(trace_matrix(O))
   end
   return O.R(d)

--- a/src/GenOrd/GenOrd.jl
+++ b/src/GenOrd/GenOrd.jl
@@ -189,15 +189,12 @@ end
 #
 ################################################################################
 
-function in(a::GenOrdElem, O::GenOrd)
-  @assert field(parent(a)) === field(O)
-  return isone(integral_split(data(a), O)[2])
+function in(a::FieldElem, O::GenOrd)
+  @req parent(a) === field(O) "Element and order must come from the same field"
+  return is_one(integral_split(a, O)[2])
 end
 
-function Base.in(a::FieldElem, O::GenOrd)
-  @assert parent(a) === field(O)
-  return isone(integral_split(data(a), O)[2])
-end
+in(a::GenOrdElem, O::GenOrd) = data(a) in O
 
 ################################################################################
 #

--- a/src/GenOrd/Ideal.jl
+++ b/src/GenOrd/Ideal.jl
@@ -652,14 +652,26 @@ function Hecke.factor(A::GenOrdIdl{S, T}) where {S, T}
 end
 
 function prime_decomposition(O::GenOrd{S, T}, p::RingElem, degree_limit::Int = degree(O), lower_limit::Int = 0; cached::Bool = true) where {S, T}
-  #Index not well-defined for infinite maximal order
-  if !isa(base_ring(O), KInftyRing) && !(divides(index(O), p)[1])
+  # Fast path needs:
+  # 1. well-defined equation order: we need defining polynomial to be "nice",
+  #    that is, monic and integral
+  # 2. finite maximal order setting, since index is ill-defined for KInftyRing
+  # 3. p coprime to index
+  # Note: for non-nice polynomials the index has a denominator.
+  #       We could check divisibility by p of both numerator and denominator,
+  #       but that is a bit hacky, so we mimic number fields and instead
+  #       check that the defining polynomial is nice.
+  if !isa(base_ring(O), KInftyRing) &&
+     is_defining_polynomial_nice(O.F) &&
+     !(divides(index(O), p)[1])
     return prime_dec_nonindex(O, p, degree_limit, lower_limit)
   else
     return prime_dec_gen(O, p, degree_limit, lower_limit)
   end
 end
 
+# TODO: prime_dec_gen currently does NOT set gen_two
+# TODO: we should mimic number fields by adding a search for a uniformizer
 function prime_dec_gen(O::GenOrd{S, T}, p::RingElem, degree_limit::Int = degree(O), lower_limit::Int = 0) where {S, T}
   Ip = pradical(O, p)
   lp = _decomposition(O, ideal(O, p), Ip, ideal(O, one(O)), p)
@@ -895,7 +907,17 @@ function is_prime(A::GenOrdIdl)
     if norm(A) != norm(P)
       continue
     end
-    if P.gen_two in A
+
+    # from factorization we know already that A is in P
+    # TODO: for non-maximal orders we need to check both generators
+    # TODO: though most of our code around primes assumes maximal order
+    PinA = if has_2_elem(P)
+      P.gen_two in A
+    else
+      A == P
+    end
+
+    if PinA
       A.is_prime = 1
       A.splitting_type = P.splitting_type
       return true

--- a/src/GenOrd/Ideal.jl
+++ b/src/GenOrd/Ideal.jl
@@ -287,6 +287,8 @@ function Base.isequal(a::GenOrdIdl{S, T}, b::GenOrdIdl{S, T}) where {S, T}
 end
 
 function Base.:(*)(a::GenOrdIdl{S, T}, b::GenOrdIdl{S, T}) where {S, T}
+  @req order(a) === order(b) "Ideals must have same order"
+
   O = order(a)
   Ma = basis_matrix(a)
   Mb = basis_matrix(b)
@@ -339,15 +341,13 @@ function Base.:*(x::GenOrdElem, O::GenOrd)
   return ideal(O, x)
 end
 
-function Base.:*(x::GenOrdElem, y::GenOrdIdl{S, T}) where {S, T}
-  parent(x) !== order(y) && error("GenOrds of element and ideal must be equal")
-  # note that we use order(y) and not parent(x),
-  #   because it provides concrete GenOrd{S,T} for type inference
-  return GenOrdIdl(order(y), x) * y
+function Base.:*(x::GenOrdElem, I::GenOrdIdl{S, T}) where {S, T}
+  @req parent(x) === order(I) "Element and ideal must belong to the same order"
+  # NOTE: we use order(I) because it provides concrete GenOrd{S,T} for type inference
+  return GenOrdIdl(order(I), x) * I
 end
 
 Base.:*(x::GenOrdIdl, y::GenOrdElem) = y * x
-
 
 function Hecke.colon(a::GenOrdIdl{S, T}, b::GenOrdIdl{S, T}) where {S, T}
   @req order(a) === order(b) "Ideals must lie in the same order"

--- a/test/FunField.jl
+++ b/test/FunField.jl
@@ -1,6 +1,7 @@
 include("FunField/DegreeLocalization.jl")
-include("FunField/Divisor.jl")
 include("FunField/Differential.jl")
+include("FunField/Divisor.jl")
 include("FunField/Factor.jl")
 include("FunField/HessQR.jl")
 include("FunField/IntClsZx.jl")
+include("FunField/RiemannRoch.jl")

--- a/test/FunField/Differential.jl
+++ b/test/FunField/Differential.jl
@@ -120,9 +120,9 @@ import Hecke: divisor
     _test_basis_of_differentials(F, w)
   end
 
-  @testset "Hyperelliptic Curve Differentials" begin
+  @testset "Curve Differentials and genus" begin
     # Check for the basis of differentials:
-    # length should equal to genus (we compute genus ourselves)
+    # length should equal genus
     # elements of basis should be non-zero, give effective divisor of a specific degree
     function _test_basis_of_differentials(F, g)
       B = @inferred basis_of_differentials(F)
@@ -135,11 +135,37 @@ import Hecke: divisor
       end
     end
 
+    # genus 1, ramification at infinity = 3
+    let (kx, x) = rational_function_field(GF(5), :x; cached = false),
+        (ky, y) = polynomial_ring(kx, :y; cached = false)
+      F, a = function_field(y^3 - x^2 - 1; cached = false)
+      @test genus(F) == 1
+      _test_basis_of_differentials(F, 1)
+    end
+
+    # genus 1, ramification at infinity = 3 (wild)
+    let (kx, x) = rational_function_field(GF(3), :x; cached = false),
+        (ky, y) = polynomial_ring(kx, :y; cached = false)
+      F, a = function_field(y^3 + y - x^2 - 1; cached = false)
+      @test genus(F) == 1
+      _test_basis_of_differentials(F, 1)
+    end
+
     # genus 2
     for base_field in [QQ, finite_field(3, 3)[1], finite_field(7, 2)[1], finite_field(101)[1]]
       kx, x = rational_function_field(base_field, :x; cached = false)
       ky, y = polynomial_ring(kx, :y; cached = false)
       F, a = function_field(y^2 - x^5 - 1; cached=false)
+      @test genus(F) == 2
+      _test_basis_of_differentials(F, 2)
+    end
+
+    # genus 2, unramified at infinity
+    let (kx, x) = rational_function_field(QQ, :x; cached = false),
+        (ky, y) = polynomial_ring(kx, :y; cached = false)
+      F, a = function_field(y^2 - x^6 - 2; cached = false)
+      @test genus(F) == 2
+      @test degree(discriminant(infinite_maximal_order(F))) == 0
       _test_basis_of_differentials(F, 2)
     end
 
@@ -148,16 +174,27 @@ import Hecke: divisor
       kx, x = rational_function_field(base_field, :x; cached = false)
       ky, y = polynomial_ring(kx, :y; cached = false)
       F, a = function_field(y^2 - x^7 - 1; cached=false)
+      @test genus(F) == 3
       _test_basis_of_differentials(F, 3)
     end
 
     # characteristic 2
-    BF, t = finite_field(2, 4)
-    kx, x = rational_function_field(BF, :x; cached = false)
-    ky, y = polynomial_ring(kx, :y; cached = false)
-    for (p, g) in [(y^2 + y + x^5 + 1, 2), (y^2 + y + x^7 + 1, 3), (y^2 + (x + t)*y + x^5 + x^3, 2)]
-      F, a = function_field(p; cached=false)
-      _test_basis_of_differentials(F, g)
+    let (BF, t) = finite_field(2, 4),
+        (kx, x) = rational_function_field(BF, :x; cached = false),
+        (ky, y) = polynomial_ring(kx, :y; cached = false)
+      for (p, g) in [(y^2 + y + x^5 + 1, 2), (y^2 + y + x^7 + 1, 3), (y^2 + (x + t)*y + x^5 + x^3, 2)]
+        F, a = function_field(p; cached=false)
+        @test genus(F) == g
+        _test_basis_of_differentials(F, g)
+      end
+    end
+
+    # non-monic defining polynomial
+    let (kx, x) = rational_function_field(QQ, :x; cached = false),
+        (ky, y) = polynomial_ring(kx, :y; cached = false)
+      F, a = function_field(x^3 + x^2 + x*y^3 - x*y^2 + y^2 - y; cached = false)
+      @test genus(F) == 3
+      _test_basis_of_differentials(F, 3)
     end
   end
 end

--- a/test/FunField/Divisor.jl
+++ b/test/FunField/Divisor.jl
@@ -179,43 +179,6 @@ import Hecke: divisor
     @test_throws ArgumentError Hecke.genus(F)
   end
 
-  @testset "Riemann-Roch" begin
-    for base_field in [QQ, finite_field(2, 2)[1], finite_field(13)[1]]
-      kx, x = rational_function_field(base_field, :x; cached = false)
-      ky, y = polynomial_ring(kx, :y; cached = false)
-      for poly in [y^3 - x - 1, y^3 - x^3 - 1, y^3 - x^5 - 1]
-        F, a = function_field(poly; cached = false)
-        Ofin = @inferred finite_maximal_order(F)
-        Oinf = @inferred infinite_maximal_order(F)
-
-        g = genus(F)
-        CD = canonical_divisor(F)
-
-        p1, _ = @inferred first(factor(ideal(Ofin, x - 13)))
-        p2, _ = first(factor(ideal(Oinf, base_ring(Oinf)(1//x))))
-        D1, D2 = divisor(p1), divisor(p2)
-
-        # Riemann-Roch: l(D) - l(K-D) = deg(D) - g + 1
-        D = -pole_divisor(F(1)//a)  # deg(D) < 0
-        @test dimension(D) - index_of_speciality(D) == degree(D) - g + 1
-        D = 2*zero_divisor(a^2)     # deg(D) > 2g - 2
-        @test dimension(D) - index_of_speciality(D) == degree(D) - g + 1
-        D = 2*D1 + D2
-        @test dimension(D) - index_of_speciality(D) == degree(D) - g + 1
-
-        # 2 * (l(K) - l(0)) = deg(K) - deg(0)
-        @test degree(CD) == 2*g - 2
-        @test degree(trivial_divisor(F)) == 0
-        @test dimension(CD) - dimension(trivial_divisor(F)) == g - 1
-
-        # l(D) = 0 for deg(D) < 0
-        @test dimension(-3*D1) == 0
-        @test dimension(-D2) == 0
-        @test dimension(-D1 - 3*D2) == 0
-      end
-    end
-  end
-
   @testset "principal with generator: ellcrv" begin
     function check_principal(D, expected_gen)
       @test is_principal(D)

--- a/test/FunField/Divisor.jl
+++ b/test/FunField/Divisor.jl
@@ -73,6 +73,16 @@ import Hecke: divisor
   end
 
   @testset "Degree" begin
+    function test_degree(I, d)
+      D = divisor(I)
+
+      @assert !Hecke.has_support(D)
+      @test d == @inferred degree(D)
+
+      Hecke.assure_has_support(D)
+      @test d == @inferred degree(D)
+    end
+
     kx, x = rational_function_field(GF(2), :x; cached = false)
     ky, y = polynomial_ring(kx, :y; cached = false)
 
@@ -85,16 +95,16 @@ import Hecke: divisor
     @test length(fac) == 1
     P, e = first(fac)   # e = 6, f = 1
     @test e == 6
-    @test 6 == @inferred degree(divisor(I))
-    @test 1 == @inferred degree(divisor(P))
+    test_degree(I, 6)
+    test_degree(P, 1)
 
     I = ideal(Ofin, x^2+x+1)
     fac = @inferred factor(I)
     @test length(fac) == 1
     P, e = first(fac)   # e = 1, f = 3
     @test e == 1
-    @test 6 == @inferred degree(divisor(I))
-    @test 6 == @inferred degree(divisor(P))
+    test_degree(I, 6)
+    test_degree(P, 6)
   end
 
   @testset "Pole/Zero divisors" begin

--- a/test/FunField/Divisor.jl
+++ b/test/FunField/Divisor.jl
@@ -331,7 +331,11 @@ import Hecke: divisor
       @test 6 == @inferred dimension(DD)
 
       for f in L
-        @test is_effective(divisor(f) + DD)
+        D = divisor(f) + DD
+        @test is_effective(D)
+
+        Hecke.assure_has_support(D)
+        @test is_effective(D)
       end
 
       @test F == function_field(D)
@@ -402,7 +406,11 @@ import Hecke: divisor
 
       L = @inferred basis_of_differentials(F)
       for df in L
-        @test is_effective(divisor(df.f) + KF)
+        D = divisor(df.f) + KF
+        @test is_effective(D)
+
+        Hecke.assure_has_support(D)
+        @test is_effective(D)
       end
     end
 end

--- a/test/FunField/Divisor.jl
+++ b/test/FunField/Divisor.jl
@@ -97,6 +97,57 @@ import Hecke: divisor
     @test 6 == @inferred degree(divisor(P))
   end
 
+  @testset "Pole/Zero divisors" begin
+    kx, x = rational_function_field(GF(5), :x; cached = false)
+    ky, y = polynomial_ring(kx, :y; cached = false)
+
+    function test_pole_degree(f, d)
+      @test degree(pole_divisor(f)) == d
+
+      D = divisor(f)
+      @assert !Hecke.has_support(D)
+      @test degree(pole_divisor(D)) == d
+
+      Hecke.assure_has_support(D)
+      @test degree(pole_divisor(D)) == d
+    end
+
+    function test_pole_zero(D_or_f)
+      @test degree(pole_divisor(D_or_f)) == degree(zero_divisor(D_or_f))
+      @test is_effective(pole_divisor(D_or_f))
+      @test is_effective(zero_divisor(D_or_f))
+    end
+
+    function test_pole_zero_f(f)
+      test_pole_zero(f)
+
+      D = divisor(f)
+      @assert !Hecke.has_support(D)
+      test_pole_zero(D)
+
+      Hecke.assure_has_support(D)
+      test_pole_zero(D)
+    end
+
+    # ramification at infinity is 2
+    F, a = function_field(y^2 - x^3 - x - 1; cached = false)
+    @test genus(F) == 1
+    test_pole_degree(F(x), 2)
+    test_pole_degree(F(y), 3)
+    for f in (F(x), F(y))
+      test_pole_zero_f(f)
+    end
+
+    # ramification at infinity is 3
+    F, a = function_field(y^3 - x^2 - 1; cached = false)
+    @test genus(F) == 1
+    test_pole_degree(F(x), 3)
+    test_pole_degree(F(y), 2)
+    for f in (F(x), F(y))
+      test_pole_zero_f(f)
+    end
+  end
+
   @testset "Not Separable Extension" begin
     k = finite_field(3; cached = false)[1]
     kx, x = rational_function_field(k, :x; cached = false)

--- a/test/FunField/RiemannRoch.jl
+++ b/test/FunField/RiemannRoch.jl
@@ -1,0 +1,378 @@
+import Hecke: divisor
+
+in_RR(f, D) = is_zero(f) || is_effective(divisor(f) + D)
+
+function test_rr_simple(D, RR)
+  for f in RR
+    @test in_RR(f, D)
+  end
+  # TODO: it might make sense to test linear independence
+
+  g = genus(function_field(D))
+
+  # Riemann-Roch: l(D) - l(K-D) = deg(D) - g + 1
+  @test dimension(D) - index_of_speciality(D) == degree(D) + 1 - g
+
+  if degree(D) < 0
+    @test length(RR) == 0
+  end
+
+  if degree(D) > 2*g - 2
+    @test length(RR) == degree(D) + 1 - g
+  end
+end
+
+function test_RR_dim1_with_generator(RR, f)
+  @test length(RR) == 1
+  @test is_zero(divisor(f * inv(RR[1])))
+end
+
+function test_RR_for_one_place(P)
+  for m in (-10, -2, 2, 10)
+    D = m*P
+    test_rr_simple(D, riemann_roch_space(D))
+  end
+end
+
+function test_RR_for_principal_divisor(f)
+  D = divisor(f)
+  test_RR_dim1_with_generator(riemann_roch_space(D), inv(f))
+end
+
+function test_divisors_different_degree(Ofin, x, a, O)
+  p1, _ = @inferred first(factor(ideal(Ofin, x - 1)))
+  p2, _ = @inferred first(factor(ideal(Ofin, a + 1)))
+  D1, D2 = divisor(p1), divisor(p2)
+
+  D = -pole_divisor(inv(a))   # negative degree
+  test_rr_simple(D, riemann_roch_space(D))
+  D = 5*zero_divisor(a^2)     # degree bigger than 2g - 2
+  test_rr_simple(D, riemann_roch_space(D))
+  D = 3*D1 - D2 + 2*O         # mixed degree
+  test_rr_simple(D, riemann_roch_space(D))
+end
+
+@testset "Riemann-Roch" begin
+  @testset "Elliptic Curve over F_5" begin
+    kx, x = rational_function_field(GF(5), :x; cached = false)
+    ky, y = polynomial_ring(kx, :y; cached = false)
+    F, a = function_field(y^2 - x^3 - x - 1; cached = false)
+    Ofin = @inferred finite_maximal_order(F)
+    Oinf = @inferred infinite_maximal_order(F)
+
+    @test genus(F) == 1
+    @test dimension(canonical_divisor(F)) - dimension(trivial_divisor(F)) == 0
+
+    pinf, _ = first(factor(ideal(Oinf, base_ring(Oinf)(1//x))))
+    O = divisor(pinf)
+
+    # (x)_inf = 2*O, (y)_inf = 3*O
+    @test pole_divisor(F(x)) == 2*O
+    @test pole_divisor(a) == 3*O
+
+    # basis of L(mO) is {x^k, 2k <= m} + {x^k*y,  2k+3 <= m}
+    for (m, d) in [(0, 1), (1, 1), (2, 2), (3, 3), (4, 4), (5, 5)]
+      D = m*O
+      RR = riemann_roch_space(D)
+      @test length(RR) == d
+      test_rr_simple(D, RR)
+    end
+
+    # for P = (0, 1), Q = (0,4) we have (x) = P + Q - 2*O
+    P = divisor(ideal(Ofin, x, Ofin(y-1)))
+    Q = divisor(ideal(Ofin, x, Ofin(y-4)))
+
+    # for elliptic curves: g = 1 and canonical divisor is trivial
+    # giving for D with degree 0: l(D) = l(-D)
+    # for principal D (tested above) this gives dimension 1
+    # for non-principal this gives l(D) = 0
+    @test dimension(P - O) == 0
+
+    # L(2*O) = [1, x] and x(P) = 0
+    D = 2*O - P
+    RR = riemann_roch_space(D)
+    test_RR_dim1_with_generator(RR, x)
+
+    # L(3*O) = [1, x, y], vanishing at P gives [x, y-1]
+    D = 3*O - P
+    RR = riemann_roch_space(D)
+    test_rr_simple(D, RR)
+    @test length(RR) == 2
+
+    test_divisors_different_degree(Ofin, x, a, O)
+    test_RR_for_one_place(P)
+    test_RR_for_principal_divisor(F(x))
+  end
+
+  @testset "Hyperelliptic Curve over F_3" begin
+    kx, x = rational_function_field(GF(3), :x; cached = false)
+    ky, y = polynomial_ring(kx, :y; cached = false)
+    # has no finite affine points
+    F, a = function_field(y^2 - x^5 - 2*x^4 - 2*x^3 - x^2 - 2; cached = false)
+    Ofin = @inferred finite_maximal_order(F)
+    Oinf = @inferred infinite_maximal_order(F)
+
+    @test genus(F) == 2
+    @test dimension(canonical_divisor(F)) - dimension(trivial_divisor(F)) == 1
+
+    pinf, _ = first(factor(ideal(Oinf, base_ring(Oinf)(1//x))))
+    O = divisor(pinf)
+
+    # (x)_inf = 2*O, (y)_inf = 5*O
+    @test pole_divisor(F(x)) == 2*O
+    @test pole_divisor(a) == 5*O
+
+    # basis of L(mO) is {x^k, 2k <= m} + {x^k*y,  2k+5 <= m}
+    for (m, d) in [(0, 1), (1, 1), (2, 2), (3, 2), (4, 3), (5, 4), (6, 5)]
+      D = m*O
+      RR = riemann_roch_space(D)
+      @test length(RR) == d
+      test_rr_simple(D, RR)
+    end
+
+    u = F(x^2) + 1
+
+    # P1, P2 are conjugate degree 2 places
+    # (x^2 + 1) = P1 + P2 - 4*O
+    P1 = divisor(ideal(Ofin, x^2 + 1, Ofin(y - (x + 1))))
+    P2 = divisor(ideal(Ofin, x^2 + 1, Ofin(y - (2*x + 2))))
+
+    # L(2*O) = [1, x], no non-zero linear polynomial in x vanishes at P1
+    @test dimension(2*O - P1) == 0
+
+    # L(4*O) = [1, x, x^2], x^2+1 vanishes at P1
+    D = 4*O - P1
+    RR = riemann_roch_space(D)
+    test_RR_dim1_with_generator(RR, u)
+
+    test_divisors_different_degree(Ofin, x, a, O)
+    test_RR_for_one_place(P1)
+    test_RR_for_principal_divisor(u)
+  end
+
+  @testset "Hyperelliptic Curve over F_5" begin
+    kx, x = rational_function_field(GF(5), :x; cached = false)
+    ky, y = polynomial_ring(kx, :y; cached = false)
+    # has two points at infinity
+    F, a = function_field(y^2 - x^6 - x - 1; cached = false)
+    Ofin = @inferred finite_maximal_order(F)
+    Oinf = @inferred infinite_maximal_order(F)
+
+    @test genus(F) == 2
+    @test dimension(canonical_divisor(F)) - dimension(trivial_divisor(F)) == 1
+
+    # (x)_inf = O1 + O2
+    inf_factor = collect(factor(ideal(Oinf, base_ring(Oinf)(1//x))))
+    O1 = divisor(inf_factor[1][1])
+    O2 = divisor(inf_factor[2][1])
+    O = pole_divisor(F(x))
+    @test O == O1 + O2
+
+    # basis of L(m*(x)) is {x^k, k <= m} + {x^k*y,  k+3 <= m}
+    for (m, d) in [(0, 1), (1, 2), (2, 3), (3, 5), (4, 7)]
+      D = m*O
+      RR = riemann_roch_space(D)
+      @test length(RR) == d
+      test_rr_simple(D, RR)
+    end
+
+    test_divisors_different_degree(Ofin, x, a, O1)
+    test_RR_for_one_place(O2)
+    test_RR_for_principal_divisor(F(x))
+  end
+
+  @testset "Non-monic Curve over F_5" begin
+    kx, x = rational_function_field(GF(5), :x; cached = false)
+    ky, y = polynomial_ring(kx, :y; cached = false)
+    F, a = function_field(x^3 + x^2 + x*y^3 - x*y^2 + y^2 - y; cached = false)
+    Ofin = @inferred finite_maximal_order(F)
+    Oinf = @inferred infinite_maximal_order(F)
+
+    @test genus(F) == 3
+    @test dimension(canonical_divisor(F)) - dimension(trivial_divisor(F)) == 2
+
+    pinf, _ = first(factor(ideal(Oinf, base_ring(Oinf)(1//x))))
+    O = divisor(pinf)
+    Q = divisor(ideal(Ofin, x, Ofin(x*a + x + 1)))
+
+    @test pole_divisor(F(x)) == 3*O
+    @test pole_divisor(a) == 2*O + Q
+
+    for (m, d) in [(0, 1), (1, 1), (2, 1), (3, 2), (4, 2), (5, 3), (6, 4), (7, 5)]
+      D = m*O
+      RR = riemann_roch_space(D)
+      @test length(RR) == d
+      test_rr_simple(D, RR)
+    end
+
+    b = F(x)^2*a
+    @assert !(a in Ofin)
+    @assert b in Ofin
+
+    p1, _ = @inferred first(factor(ideal(Ofin, F(x) - 1)))
+    p2, _ = @inferred first(factor(ideal(Ofin, b + 1)))
+    D1, D2 = divisor(p1), divisor(p2)
+
+    D = -pole_divisor(inv(F(x)))
+    test_rr_simple(D, riemann_roch_space(D))
+    D = 5*zero_divisor(F(x)^2)
+    test_rr_simple(D, riemann_roch_space(D))
+    D = 3*D1 - D2 + 2*O
+    test_rr_simple(D, riemann_roch_space(D))
+
+    test_RR_for_one_place(O)
+    test_RR_for_principal_divisor(F(x))
+  end
+
+  @testset "Artin-Schreier Curve over F_2" begin
+    kx, x = rational_function_field(GF(2), :x; cached = false)
+    ky, y = polynomial_ring(kx, :y; cached = false)
+    # has wild ramification at infinity
+    F, a = function_field(y^2 + y - x^5 - x; cached = false)
+    Ofin = @inferred finite_maximal_order(F)
+    Oinf = @inferred infinite_maximal_order(F)
+
+    @test genus(F) == 2
+    @test dimension(canonical_divisor(F)) - dimension(trivial_divisor(F)) == 1
+
+    pinf, _ = first(factor(ideal(Oinf, base_ring(Oinf)(1//x))))
+    O = divisor(pinf)
+
+    # (x)_inf = 2*O, (y)_inf = 5*O
+    @test pole_divisor(F(x)) == 2*O
+    @test pole_divisor(a) == 5*O
+
+    # basis of L(mO) is {x^k, 2k <= m} + {x^k*y,  2k+5 <= m}
+    for (m, d) in [(0, 1), (1, 1), (2, 2), (3, 2), (4, 3), (5, 4), (6, 5)]
+      D = m*O
+      RR = riemann_roch_space(D)
+      @test length(RR) == d
+      test_rr_simple(D, RR)
+    end
+
+    test_divisors_different_degree(Ofin, x, a, O)
+    test_RR_for_one_place(O)
+    test_RR_for_principal_divisor(a)
+  end
+
+  @testset "Artin-Schreier Curve over F_3" begin
+    kx, x = rational_function_field(GF(3), :x; cached = false)
+    ky, y = polynomial_ring(kx, :y; cached = false)
+    # has wild ramification at infinity
+    F, a = function_field(y^3 - y - x^4 - x^2 - x; cached = false)
+    Ofin = @inferred finite_maximal_order(F)
+    Oinf = @inferred infinite_maximal_order(F)
+
+    @test genus(F) == 3
+    @test dimension(canonical_divisor(F)) - dimension(trivial_divisor(F)) == 2
+
+    pinf, _ = first(factor(ideal(Oinf, base_ring(Oinf)(1//x))))
+    O = divisor(pinf)
+
+    # (x)_inf = 3*O, (y)_inf = 4*O, canonical divisor is 4*O
+    @test pole_divisor(F(x)) == 3*O
+    @test pole_divisor(a) == 4*O
+    @test canonical_divisor(F) == 4*O
+
+    for (m, d) in [(0, 1), (1, 1), (2, 1), (3, 2), (4, 3), (5, 3), (6, 4), (7, 5)]
+      D = m*O
+      RR = riemann_roch_space(D)
+      @test length(RR) == d
+      test_rr_simple(D, RR)
+    end
+
+    test_divisors_different_degree(Ofin, x, a, O)
+    test_RR_for_one_place(O)
+    test_RR_for_principal_divisor(a-1)
+  end
+
+  @testset "Artin-Schreier Curve over F_5" begin
+    kx, x = rational_function_field(GF(5), :x; cached = false)
+    ky, y = polynomial_ring(kx, :y; cached = false)
+    # has wild ramification at infinity
+    F, a = function_field(y^5 - y - x^3 - x; cached = false)
+    Ofin = @inferred finite_maximal_order(F)
+    Oinf = @inferred infinite_maximal_order(F)
+
+    @test genus(F) == 4
+    @test dimension(canonical_divisor(F)) - dimension(trivial_divisor(F)) == 3
+
+    pinf, _ = first(factor(ideal(Oinf, base_ring(Oinf)(1//x))))
+    O = divisor(pinf)
+
+    # (x)_inf = 5*O, (y)_inf = 3*O, canonical divisor is 6*O
+    @test pole_divisor(F(x)) == 5*O
+    @test pole_divisor(a) == 3*O
+    @test canonical_divisor(F) == 6*O
+
+    for (m, d) in [(0, 1), (1, 1), (2, 1), (3, 2), (4, 2), (5, 3), (6, 4), (7, 4)]
+      D = m*O
+      RR = riemann_roch_space(D)
+      @test length(RR) == d
+      test_rr_simple(D, RR)
+    end
+
+    test_divisors_different_degree(Ofin, x, a, O)
+    test_RR_for_one_place(O)
+    test_RR_for_principal_divisor(a-1)
+  end
+
+  @testset "Superelliptic Curve over Q" begin
+    kx, x = rational_function_field(QQ, :x; cached = false)
+    ky, y = polynomial_ring(kx, :y; cached = false)
+    F, a = function_field(y^3 - x^5 - 1; cached = false)
+    Ofin = @inferred finite_maximal_order(F)
+    Oinf = @inferred infinite_maximal_order(F)
+
+    @test genus(F) == 4
+    @test dimension(canonical_divisor(F)) - dimension(trivial_divisor(F)) == 3
+
+    pinf, _ = first(factor(ideal(Oinf, base_ring(Oinf)(1//x))))
+    O = divisor(pinf)
+
+    p1, _ = @inferred first(factor(ideal(Ofin, x - 13)))
+    p2, _ = @inferred first(factor(ideal(Ofin, a - 2)))
+    D1, D2 = divisor(p1), divisor(p2)
+
+    for (m, d) in [(0, 1), (1, 1), (2, 1), (3, 2), (4, 2), (5, 3), (6, 4), (7, 4)]
+      D = m*O
+      RR = riemann_roch_space(D)
+      @test length(RR) == d
+      test_rr_simple(D, RR)
+    end
+
+    test_divisors_different_degree(Ofin, x, a, O)
+    test_RR_for_one_place(D2)
+    test_RR_for_principal_divisor(a-1)
+  end
+
+  @testset "Superelliptic Curve over F_4" begin
+    B = finite_field(2, 2; cached = false)[1]
+    kx, x = rational_function_field(B, :x; cached = false)
+    ky, y = polynomial_ring(kx, :y; cached = false)
+    F, a = function_field(y^3 - x^5 - 1; cached = false)
+    Ofin = @inferred finite_maximal_order(F)
+    Oinf = @inferred infinite_maximal_order(F)
+
+    @test genus(F) == 4
+    @test dimension(canonical_divisor(F)) - dimension(trivial_divisor(F)) == 3
+
+    pinf, _ = first(factor(ideal(Oinf, base_ring(Oinf)(1//x))))
+    O = divisor(pinf)
+
+    p1, _ = @inferred first(factor(ideal(Ofin, x - 1)))
+    p2, _ = @inferred first(factor(ideal(Ofin, a - gen(B))))
+    D1, D2 = divisor(p1), divisor(p2)
+
+    for (m, d) in [(0, 1), (1, 1), (2, 1), (3, 2), (4, 2), (5, 3), (6, 4), (7, 4)]
+      D = m*O
+      RR = riemann_roch_space(D)
+      @test length(RR) == d
+      test_rr_simple(D, RR)
+    end
+
+    test_divisors_different_degree(Ofin, x, a, O)
+    test_RR_for_one_place(D1)
+    test_RR_for_principal_divisor(a-gen(B))
+  end
+end

--- a/test/GenOrd/Ideal.jl
+++ b/test/GenOrd/Ideal.jl
@@ -191,35 +191,31 @@
   @testset "over Q(x) with non-monic defining polynomial" begin
     kx, x = rational_function_field(QQ, :x; cached = false)
     ky, y = polynomial_ring(kx, :y; cached = false)
-    L, t = function_field(1//2*y^3 - 1//3*x^3 - 1; cached = false)
+    L, t = function_field(x^3 + x^2 + x*y^3 - x*y^2 + y^2 - y; cached = false)
 
     Ofin = finite_maximal_order(L)
     Oinf = infinite_maximal_order(L)
-    @assert !is_equation_order(Ofin)
 
-    @testset "norm/min: finite maximal order" begin
-      a = Ofin(x^3 + y^2)
-      I = ideal(Ofin, a)
-      check_ideal_norm_min(I, norm(a), norm(a)) # x^3 + y^2 is irreducible
+    @testset "norm/min" begin
+      I = ideal(Ofin, x*t)
+      check_ideal_norm_min(I, x^5 + x^4, x^4 + x^3)
 
-      I = ideal(Ofin, x*y, Ofin(x^2))
-      check_ideal_norm_min(I, x^3, x)
+      I = ideal(Oinf, 3//(x^2*t^2))
+      check_ideal_norm_min(I, 1//x^10, 1//x^4)
     end
 
-    @testset "norm/min: infinite maximal order" begin
-      I = ideal(Oinf, 3//x^2)
-      check_ideal_norm_min(I, 1//x^6, 1//x^2)
-
-      I = ideal(Oinf, L(x^2)//t^3)
-      check_ideal_norm_min(I, norm(Oinf(L(x^2)//t^3)), 1//x)
+    @testset "prime decomposition" begin
+      # <x + 1> = <x + 1, x*y> * <x + 1, x*y + 1>^2
+      pd = @inferred prime_decomposition(Ofin, Ofin.R(x + 1))
+      @test length(pd) == 2
     end
 
     @testset "containment" begin
-      test_containment_common(Ofin, x^2 + 1, t)
+      test_containment_common(Ofin, x^2 + x*t + 1, x*t)
     end
 
     @testset "colon" begin
-      test_colon_common(Ofin, x^2 + 1)
+      test_colon_common(Ofin, x^2 + 2)
     end
   end
 
@@ -235,6 +231,14 @@
       I = ideal(Ofin, L(y)//L(x))
       check_ideal_norm_min(I, x + 1, x + 1)
       @test is_prime(I)
+    end
+
+    @testset "containment" begin
+      test_containment_common(Ofin, x^2 + 1, t)
+    end
+
+    @testset "colon" begin
+      test_colon_common(Ofin, x^2 + 1)
     end
   end
 

--- a/test/GenOrd/Ideal.jl
+++ b/test/GenOrd/Ideal.jl
@@ -447,3 +447,41 @@ let # 2266
   @test all(is_prime(p) for (p,_) in lp)
   @test prod(p^e for (p, e) in lp) == I
 end
+
+@testset "Scaling ideals in function field by base-field elements" begin
+  kx, x = rational_function_field(GF(5), :x; cached = false)
+  ky, y = polynomial_ring(kx, :y; cached = false)
+  F, a = function_field(y^2 - x^3 - x - 1; cached = false)
+
+  function check_scaling(I, c)
+    O = order(I)
+    cI = @inferred c*I
+    @test order(cI) === O
+    @test cI == I*c
+    @test inv(c)*cI == I
+    @test cI == @inferred (F(c)*O)*I
+    @test basis(cI) == [F(c)*b for b in basis(I)]
+  end
+
+  Ofin = finite_maximal_order(F)
+  Oinf = infinite_maximal_order(F)
+
+  for (O, c) in ((Ofin, x), (Ofin, x^2+1), (Ofin, x//(x + 1)),
+                 (Oinf, 1//x), (Oinf, 1//(x^2+1)), (Oinf, (x + 1)//x))
+    # a*O is GenOrdFracIdl
+    check_scaling(a*O, c)
+  end
+
+  # check multiplication of "integral" ideal by the scalar in the base field
+  I0 = ideal(Ofin, Ofin(x^2 + 1))
+  @test @inferred(x*I0) isa GenOrdFracIdl
+  @test @inferred((x//(x + 1))*I0) isa GenOrdFracIdl
+  @test @inferred(x*I0) == @inferred(x*fractional_ideal(I0))
+
+  # x has a pole at infinity so we cannot construct (x)_inf directly
+  #   yet scaling must work
+  I = @inferred a*Oinf
+  @test_throws ErrorException Oinf(x)
+  @test_throws ErrorException ideal(Oinf, x) * I
+  check_scaling(I, x)
+end

--- a/test/GenOrd/Ideal.jl
+++ b/test/GenOrd/Ideal.jl
@@ -79,6 +79,15 @@
     @test Hecke.colon(U, I) * I == U
   end
 
+  function test_frac_ideal_inv(O, I_list)
+    U = ideal(O, O(1))
+    for I in I_list
+      @test inv(I) == colon(U, I)     # identical to the old colon-based inv
+      @test is_one(I * inv(I))        # defining property: A * A^{-1} = O
+      @test inv(inv(I)) == I
+    end
+  end
+
   test_colon_common(O, p) = test_colon_common_ideal(O, ideal(O, O(p)))
 
   @testset "over F_2(x)" begin
@@ -186,6 +195,13 @@
     @testset "colon" begin
       test_colon_common(Ofin, x^4 + x + 1)
     end
+
+    @testset "fractional_ideal inv" begin
+      O = Ofin
+      test_frac_ideal_inv(O, (t*O, (t + 1)*O, (1//x)*(t*O), (x//(x + 1))*(t*O)))
+      O = Oinf
+      test_frac_ideal_inv(O, (t*O, (t + 1)*O, (1//x)*(t*O), (x//(x + 1))*(t*O)))
+    end
   end
 
   @testset "over Q(x) with non-monic defining polynomial" begin
@@ -217,6 +233,13 @@
     @testset "colon" begin
       test_colon_common(Ofin, x^2 + 2)
     end
+
+    @testset "fractional_ideal inv" begin
+      O = Ofin
+      test_frac_ideal_inv(O, (t*O, (t + 1)*O, (1//x)*(t*O), (x//(x + 1))*(t*O)))
+      O = Oinf
+      test_frac_ideal_inv(O, (t*O, (t + 1)*O, (1//x)*(t*O), (x//(x + 1))*(t*O)))
+    end
   end
 
   @testset "over Q(x)" begin
@@ -239,6 +262,13 @@
 
     @testset "colon" begin
       test_colon_common(Ofin, x^2 + 1)
+    end
+
+    @testset "fractional_ideal inv" begin
+      O = Ofin
+      test_frac_ideal_inv(O, (t*O, (t + 1)*O, (1//x)*(t*O), (x//(x + 1))*(t*O)))
+      O = Oinf
+      test_frac_ideal_inv(O, (t*O, (t + 1)*O, (1//x)*(t*O), (x//(x + 1))*(t*O)))
     end
   end
 
@@ -294,6 +324,10 @@
     @testset "colon" begin
       test_colon_common(OK, ZZ(3))
     end
+
+    @testset "fractional_ideal inv" begin
+      test_frac_ideal_inv(OK, (a*OK, (a + 1)*OK, ((a//ZZ(3))*OK)))
+    end
   end
 
   @testset "over number field localized at prime" begin
@@ -316,6 +350,7 @@
 
       test_containment_common(OK, R(7), R(5))
       test_colon_common_ideal(OK, ideal(OK, R(7), OK(a - 3)))
+      test_frac_ideal_inv(OK, (a*OK, (a + 1)*OK, (a//49)*OK))
     end
 
     @testset "inert (p = 3)" begin
@@ -327,6 +362,7 @@
 
       test_containment_common(OK, R(3), R(5))
       test_colon_common(OK, R(3))
+      test_frac_ideal_inv(OK, (a*OK, (a + 1)*OK, (a//3)*OK))
     end
 
     @testset "ramified (p = 2)" begin
@@ -340,6 +376,7 @@
 
       test_containment_common(OK, R(2), R(5))
       test_colon_common_ideal(OK, ideal(OK, R(2), OK(a)))
+      test_frac_ideal_inv(OK, (a*OK, (a + 1)*OK, (a//16)*OK))
     end
   end
 end

--- a/test/GenOrd/MaximalOrder.jl
+++ b/test/GenOrd/MaximalOrder.jl
@@ -57,12 +57,3 @@ end
   S = ring_of_multipliers(O, I, p, true)
   @test basis(O, F20) == basis(S, F20)
 end
-
-@testset "Jeroen" begin
-  kx, x = rational_function_field(QQ)
-  kxy, y = polynomial_ring(kx, "y")
-  f = x^3 + x^2 +x*y^3 -x*y^2 +y^2 -y
-  F, a = function_field(f)
-  @test genus(F) == 3
-end
-


### PR DESCRIPTION
# Context

This is step 0 towards optimized Riemann-Roch computation. Adds an extensive test suite for Riemann-Roch and fixes the bugs and inefficiencies it uncovered in FunField/Divisor and GenOrd.

The next steps would be
- Implement proper (modular) HNF for function field ideals
- Implement Riemann-Roch via divisor reduction

Originally we added test suite and implemented Riemann-Roch only to find that there were no performance gains, but only because everything else is very slow. This PR is literally "make sure the tests we added run in sane amount of time" (plus some bug fixes) before embarking on bigger optimizations

# Tests

- New `test/FunField/RiemannRoch.jl`: verifies the Riemann-Roch theorem, genus, and canonical/different divisors across elliptic (F_5), hyperelliptic (F_3, F_5), non-monic, Artin-Schreier (F_2, F_3, F_5), and superelliptic (Q, F_4) curves.
- Expanded `GenOrd`/`Ideal` tests: fractional ideal inversion, norm/minimum, prime decomposition, containment, colon, and scaling by base-field elements.

# Bug fixes

- `prime_decomposition`: gate the non-index fast path on `is_defining_polynomial_nice` — the index is ill-defined for non-monic/non-integral defining polynomials (mirrors the number field convention).
- `zero_divisor`/`pole_divisor` of a field element: the integral_split-based construction was wrong; now derived from divisor(f) via lcm with the trivial divisor.
- `in(a, O)` for field elements called data on a FieldElem; membership now works for both field and order elements.
- `is_prime`: handle prime ideals without a two-element representation instead of accessing an undefined gen_two.

# Performance

- `degree(D)`: computed from ideal norms when the support is unknown, avoiding a forced factorization.
- `is_effective(D)`: reduced to integrality checks on the underlying fractional ideals (no factorization).
- `genus`: rewritten via discriminant degrees of the finite/infinite maximal orders instead of `basis_of_differentials`; cached with @attr, as are `different_divisor` and `canonical_divisor`.
- Fractional ideal `inv`: factors the scalar denominator out instead of routing through colon.

We note again that faster HNF (for function fields) is a goal of a subsequent PRs. 

# Minor

- Multiplication of `GenOrdIdl`/`GenOrdFracIdl` by rational function field elements (always returning a fractional ideal, for type stability).
- Type assertions in `basis_matrix(::GenOrdFracIdl)` for inference; @req same-order checks on ideal arithmetic.