### PR TITLE
FunField: compute basis_of_differentials via fractional ideals directly

### DIFF
--- a/src/FunField/Differential.jl
+++ b/src/FunField/Differential.jl
@@ -204,13 +204,22 @@ end
 Return a basis of the first order differential forms of F.
 """
 function basis_of_differentials(F::Generic.AbsSimpleFunctionField{T, U}) where {T, U}
-  x = separating_element(F)
-  dx = differential(x)
+  @req _is_separable(F) "Currently assumes separable extension"
+  # We assume a separable extension.
+  # The anticanonical divisor is 2*(x)_inf + codifferent_divisor.
+  # As an ideal pair, 2*(x)_inf is (O_fin, (1/x^2)*O_inf).
+  # We can build the sum of these divisors as fractional ideals directly,
+  #   without materializing a GenOrdIdl (via num/den), by scaling the basis
+  #   matrices instead.
+  # NOTE: for Riemann-Roch we do NOT need the basis matrix in HNF.
 
-  codiff_divisor = divisor(codifferent(finite_maximal_order(F)), codifferent(infinite_maximal_order(F)))
-  D = (-divisor(dx.f) + 2*pole_divisor(F(x)) + codiff_divisor)
+  Ofin = finite_maximal_order(F)
+  J_fin = codifferent(Ofin)
 
-  J_fin, J_inf = ideals(D)
+  Oinf = infinite_maximal_order(F)
+  x = gen(base_ring(F))
+  J_inf = (1//x)^2 * codifferent(Oinf)
+
   RR = _riemann_roch_space(J_fin, J_inf, F)
 
   # We were using `map` before, but it cannot infer a concrete return type,


### PR DESCRIPTION
### Context

HNF over Q(x) behaves badly due to coefficient swell, making it generally slow. We have several ideas for fighting this, all variations on "do not do HNF unless you need to". We plan to attack it from two directions:
- Make the divisor's support representation a first-class citizen. With the work on 2-element normal representation on the way, materializing ideals from support will be fast (and avoids HNF).
- For fractional ideals (at least over function fields), work with basis_matrix (not in HNF) and do intermediate operations via weak Popov form (which should be much faster), materializing HNF only when really needed.

### This PR

Speeds up basis_of_differentials by building its Riemann-Roch input ideals directly instead of going through divisor arithmetic. This is essentialy in the spirit of the point 2 above, applied *just* to basis_of_differentials. Instead of assembling anti-canonical divisor "by the book", we construct its ideals directly (as fractional ideals, making sure we never never materialize "integral" ideals with HNF). For Riemann-Roch we do not need HNF, just some basis.

### Explicitly out of scope

As noted above, we DO want to give more divisor operations the same HNF-avoiding treatment — that is for a separate, larger PR. We will also need the reduced Riemann-Roch algorithm and should consider reducing the generated basis; also out of scope for now.

### Timing

With Jeroen example

```
kx, x = rational_function_field(QQ, :x; cached = false);
ky, y = polynomial_ring(kx, :y; cached = false);

f = 18*x^4*y^9 - 4*x^4*y^8 - 20*x^4*y^7 - 2*x^4*y^6 + 7*x^4*y^5 - 6*x^4*y^4 + 8*x^4*y^2 + 12*x^4*y - 19*x^4 - 17*x^3*y^9 + 8*x^3*y^8 - 20*x^3*y^7 + 13*x^3*y^6 + 13*x^3*y^5 + 6*x^3*y^4 + 14*x^3*y^3 + 2*x^3*y^2 + 5*x^3*y + 18*x^3 + 9*x^2*y^9 + 18*x^2*y^8 - x^2*y^6 + 6*x^2*y^5 + 8*x^2*y^4 + 6*x^2*y^3 - 2*x^2*y^2 + 5*x^2*y + 10*x^2 + 18*x*y^9 + 3*x*y^8 + 5*x*y^7 - 16*x*y^6 + 9*x*y^5 + 7*x*y^4 + 7*x*y^3 + 14*x*y^2 - 14*x*y + 14*x - 19*y^9 - 9*y^8 - 18*y^7 - 12*y^6 + 8*y^5 - 18*y^4 - 15*y^3 + 17*y^2 + 5*y - 2;

F, t = function_field(f; cached = false);
```
we go from
```
julia> @time basis_of_differentials(F);
 67.573318 seconds (23.31 M allocations: 124.819 GiB, 0.61% gc time)
```
to 
```
julia> @btime basis_of_differentials(F);
  233.848 ms (1203170 allocations: 180.94 MiB)
```

Similarly, extra examples provided by Jeroen are all completing well under a second