### PR TITLE
Fix UndefRefError in ZLatAutoCtx init for r>2 (#2311)

### DIFF
--- a/src/QuadForm/Morphism.jl
+++ b/src/QuadForm/Morphism.jl
@@ -170,7 +170,7 @@ function init(
     w = Vector{ZZRingElem}(undef, r)
     w[1] = numerator(cand[2])
     for k in 2:r
-      w[2] = _norm(vfmpz, C.G[k], tmp)
+      w[k] = _norm(vfmpz, C.G[k], tmp)
     end
 
     lengths[i] = w

--- a/test/QuadForm/Morphism.jl
+++ b/test/QuadForm/Morphism.jl
@@ -13,4 +13,20 @@
   A2 = root_lattice(:A, 2)
   Hecke.assert_has_automorphisms(A2, redo=true, try_small=false)
   @test automorphism_group_order(A2) == 12
+
+  # Issue #2311: `ZLatAutoCtx`'s `init` threw `UndefRefError` whenever
+  # more than 2 simultaneous Gram matrices were used, because the
+  # short-vector length loop inside `init` always wrote to `w[2]`
+  # instead of `w[k]`, leaving `w[3:r]` permanently undefined.
+  # G4 == G2 is deliberate: it makes fingerprint's length comparison
+  # loop reach (and previously crash on) the undefined w[3] slot
+  # instead of bailing out earlier on an unrelated mismatch.
+  let
+    G1 = 2 * identity_matrix(ZZ, 3)
+    G2 = 3 * identity_matrix(ZZ, 3)
+    G3 = 5 * identity_matrix(ZZ, 3)
+    G4 = 3 * identity_matrix(ZZ, 3)
+    C = Hecke.ZLatAutoCtx([G1, G2, G3, G4])
+    @test (Hecke.init(C, true); true)  # used to throw UndefRefError
+  end
 end


### PR DESCRIPTION
   The short-vector length loop always wrote w[2] instead of w[k],
   leaving w[3:r] undefined whenever r > 2. Fixes issue #2311 