### PR TITLE
opt: Require assumptions in isomorphism test for fractional ideals

### DIFF
--- a/src/AlgAssAbsOrd/ICM.jl
+++ b/src/AlgAssAbsOrd/ICM.jl
@@ -189,11 +189,8 @@ function ideals_containing(S::T, a::T2, R::T) where { T <: Union{ AbsNumFieldOrd
     return [ a ]
   end
 
-  K = _algebra(S)
   d = degree(S)
-
   potential_basis = Vector{elem_type(_algebra(S))}(undef, d)
-  ideals = fractional_ideal_type(R)[]
 
   for i = 1:mQ.offset
     potential_basis[i] = mQ.bottom_snf_basis[i]
@@ -297,7 +294,7 @@ matrix exists and `false` and $0$ otherwise.
 The characteristic polynomial of $M$ is required to be square-free.
 """
 function is_conjugate(M::ZZMatrix, N::ZZMatrix)
-  Zx, x = ZZ["x"]
+  Zx, _ = ZZ["x"]
   f = charpoly(Zx, M)
   if f != charpoly(Zx, N)
     return false, zero_matrix(ZZ, nrows(M), ncols(M))
@@ -314,7 +311,7 @@ function is_conjugate(M::ZZMatrix, N::ZZMatrix)
     return _isconjugate(equation_order(fields[1]), M, N)
   end
 
-  A, AtoK = direct_product(fields)::Tuple{StructureConstantAlgebra{QQFieldElem}, Vector{AbsAlgAssToNfAbsMor{StructureConstantAlgebra{QQFieldElem}, elem_type(StructureConstantAlgebra{QQFieldElem}), AbsSimpleNumField, QQMatrix}}}
+  A, _ = direct_product(fields)::Tuple{StructureConstantAlgebra{QQFieldElem}, Vector{AbsAlgAssToNfAbsMor{StructureConstantAlgebra{QQFieldElem}, elem_type(StructureConstantAlgebra{QQFieldElem}), AbsSimpleNumField, QQMatrix}}}
   O = _equation_order(A)
   return _isconjugate(O, M, N)
 end

--- a/src/AlgAssAbsOrd/ICM.jl
+++ b/src/AlgAssAbsOrd/ICM.jl
@@ -6,19 +6,17 @@
 
 # Stefano Marseglia "Computing the ideal class monoid of an order"
 @doc raw"""
-    ideal_class_monoid(R::AbsNumFieldOrder; check::Bool=true)
+    ideal_class_monoid(R::AbsNumFieldOrder)
       -> Vector{FacElem{AbsSimpleNumFieldOrderFractionalIdeal, AbsNumFieldOrderFractionalIdealSet{AbsSimpleNumField, AbsSimpleNumFieldElem}}}
-    ideal_class_monoid(R::AlgAssAbsOrd; check::Bool=true)
+    ideal_class_monoid(R::AlgAssAbsOrd)
       -> Vector{FacElem{AlgAssAbsOrdIdl, AlgAssAbsOrdIdlSet}}
 
 Given an order $R$ in a number field or a finite product of number fields, this
 function returns representatives of the isomorphism classes of fractional
 ideals in $R$.
 """
-function ideal_class_monoid(R::T; check::Bool=true) where {T <: Union{AbsNumFieldOrder, AlgAssAbsOrd}}
-  if check
-    @assert is_commutative(R)
-  end
+function ideal_class_monoid(R::T) where {T <: Union{AbsNumFieldOrder, AlgAssAbsOrd}}
+  @req is_commutative(R) "Order must be commutative"
   orders = overorders(R)
   result = Vector{FacElem{fractional_ideal_type(R)}}()
   for S in orders
@@ -29,18 +27,17 @@ end
 
 # Stefano Marseglia "Computing the ideal class monoid of an order", Prop. 4.1
 @doc raw"""
-    is_locally_isomorphic(I::AbsNumFieldOrderIdeal, J::AbsNumFieldOrderIdeal; check::Bool=true) -> Bool
-    is_locally_isomorphic(I::NfFracOrdIdl, J::NfFracOrdIdl; check::Bool=true) -> Bool
-    is_locally_isomorphic(I::AlgAssAbsOrdIdl, J::AlgAssAbsOrdIdl; check::Bool=true) -> Bool
+    is_locally_isomorphic(I::AbsNumFieldOrderIdeal, J::AbsNumFieldOrderIdeal) -> Bool
+    is_locally_isomorphic(I::NfFracOrdIdl, J::NfFracOrdIdl) -> Bool
+    is_locally_isomorphic(I::AlgAssAbsOrdIdl, J::AlgAssAbsOrdIdl) -> Bool
 
 Given two (fractional) ideals $I$ and $J$ of an order $R$ of an $Q$-étale
 algebra, this function returns `true` if $I_p$ and $J_p$ are isomorphic for
 all primes $p$ of $R$ and `false` otherwise.
 """
-function is_locally_isomorphic(I::T, J::T; check::Bool=true) where {T <: Union{AbsNumFieldOrderIdeal, AbsSimpleNumFieldOrderFractionalIdeal, AlgAssAbsOrdIdl}}
-  if check
-    @assert is_commutative(order(I))
-  end
+function is_locally_isomorphic(I::T, J::T) where {T <: Union{AbsNumFieldOrderIdeal, AbsSimpleNumFieldOrderFractionalIdeal, AlgAssAbsOrdIdl}}
+  @req order(I) == order(J) "Fractional ideals must be defined over same order"
+  @req is_commutative(order(I)) "Ambient order of ideal must be commutative"
   IJ = colon(I, J)
   JI = colon(J, I)
   return one(_algebra(order(I))) in IJ*JI
@@ -48,18 +45,17 @@ end
 
 # Stefano Marseglia "Computing the ideal class monoid of an order", Cor. 4.5
 @doc raw"""
-    is_isomorphic_with_map(I::AbsNumFieldOrderIdeal, J::AbsNumFieldOrderIdeal; check::Bool=true) -> Bool, AbsSimpleNumFieldElem
-    is_isomorphic_with_map(I::NfFracOrdIdl, J::NfFracOrdIdl; check::Bool=true) -> Bool, AbsSimpleNumFieldElem
-    is_isomorphic_with_map(I::AlgAssAbsOrdIdl, J::AlgAssAbsOrdIdl; check::Bool=true) -> Bool, AbstractAssociativeAlgebraElem
+    is_isomorphic_with_map(I::AbsNumFieldOrderIdeal, J::AbsNumFieldOrderIdeal) -> Bool, AbsSimpleNumFieldElem
+    is_isomorphic_with_map(I::NfFracOrdIdl, J::NfFracOrdIdl) -> Bool, AbsSimpleNumFieldElem
+    is_isomorphic_with_map(I::AlgAssAbsOrdIdl, J::AlgAssAbsOrdIdl) -> Bool, AbstractAssociativeAlgebraElem
 
 Given two (fractional) ideals $I$ and $J$ of an order $R$ of an $Q$-étale
 algebra $A$, this function returns `true` and an element $a \in A$ such that
 $I = aJ$ if such an element exists and `false` and $0$ otherwise.
 """
-function is_isomorphic_with_map(I::T, J::T; check::Bool=true) where {T <: Union{AbsNumFieldOrderIdeal, AbsSimpleNumFieldOrderFractionalIdeal, AlgAssAbsOrdIdl}}
-  if check
-    @assert is_commutative(order(I))
-  end
+function is_isomorphic_with_map(I::T, J::T) where {T <: Union{AbsNumFieldOrderIdeal, AbsSimpleNumFieldOrderFractionalIdeal, AlgAssAbsOrdIdl}}
+  @req order(I) == order(J) "Fractional ideals must be defined over same order"
+  @req is_commutative(order(I)) "Ambient order of ideal must be commutative"
   A = _algebra(order(I))
   if !is_locally_isomorphic(I, J)
     return false, zero(A)
@@ -79,16 +75,16 @@ function is_isomorphic_with_map(I::T, J::T; check::Bool=true) where {T <: Union{
 end
 
 @doc raw"""
-    is_isomorphic(I::AbsNumFieldOrderIdeal, J::AbsNumFieldOrderIdeal; check::Bool=true) -> Bool, AbsSimpleNumFieldElem
-    is_isomorphic(I::NfFracOrdIdl, J::NfFracOrdIdl; check::Bool=true) -> Bool, AbsSimpleNumFieldElem
-    is_isomorphic(I::AlgAssAbsOrdIdl, J::AlgAssAbsOrdIdl; check::Bool=true) -> Bool, AbstractAssociativeAlgebraElem
+    is_isomorphic(I::AbsNumFieldOrderIdeal, J::AbsNumFieldOrderIdeal) -> Bool, AbsSimpleNumFieldElem
+    is_isomorphic(I::NfFracOrdIdl, J::NfFracOrdIdl) -> Bool, AbsSimpleNumFieldElem
+    is_isomorphic(I::AlgAssAbsOrdIdl, J::AlgAssAbsOrdIdl) -> Bool, AbstractAssociativeAlgebraElem
 
 Given two (fractional) ideals $I$ and $J$ of an order $R$ of an $Q$-étale
 algebra $A$, this function returns `true` if an element $a \in A$ exists such that
 $I = aJ$ and `false` otherwise.
 """
-function is_isomorphic(I::T, J::T; check::Bool=true) where {T <: Union{AbsNumFieldOrderIdeal, AbsSimpleNumFieldOrderFractionalIdeal, AlgAssAbsOrdIdl}}
-  return is_isomorphic_with_map(I, J; check=check)[1]
+function is_isomorphic(I::T, J::T) where {T <: Union{AbsNumFieldOrderIdeal, AbsSimpleNumFieldOrderFractionalIdeal, AlgAssAbsOrdIdl}}
+  return is_isomorphic_with_map(I, J)[1]
 end
 
 function ring_of_multipliers(I::AbsSimpleNumFieldOrderFractionalIdeal)

--- a/src/AlgAssAbsOrd/ICM.jl
+++ b/src/AlgAssAbsOrd/ICM.jl
@@ -6,17 +6,19 @@
 
 # Stefano Marseglia "Computing the ideal class monoid of an order"
 @doc raw"""
-    ideal_class_monoid(R::AbsNumFieldOrder)
+    ideal_class_monoid(R::AbsNumFieldOrder; check::Bool=true)
       -> Vector{FacElem{AbsSimpleNumFieldOrderFractionalIdeal, AbsNumFieldOrderFractionalIdealSet{AbsSimpleNumField, AbsSimpleNumFieldElem}}}
-    ideal_class_monoid(R::AlgAssAbsOrd)
+    ideal_class_monoid(R::AlgAssAbsOrd; check::Bool=true)
       -> Vector{FacElem{AlgAssAbsOrdIdl, AlgAssAbsOrdIdlSet}}
 
 Given an order $R$ in a number field or a finite product of number fields, this
 function returns representatives of the isomorphism classes of fractional
 ideals in $R$.
 """
-function ideal_class_monoid(R::T) where { T <: Union{ AbsNumFieldOrder, AlgAssAbsOrd } }
-  @assert is_commutative(R)
+function ideal_class_monoid(R::T; check::Bool=true) where {T <: Union{AbsNumFieldOrder, AlgAssAbsOrd}}
+  if check
+    @assert is_commutative(R)
+  end
   orders = overorders(R)
   result = Vector{FacElem{fractional_ideal_type(R)}}()
   for S in orders
@@ -27,15 +29,18 @@ end
 
 # Stefano Marseglia "Computing the ideal class monoid of an order", Prop. 4.1
 @doc raw"""
-    is_locally_isomorphic(I::AbsNumFieldOrderIdeal, J::AbsNumFieldOrderIdeal) -> Bool
-    is_locally_isomorphic(I::NfFracOrdIdl, J::NfFracOrdIdl) -> Bool
-    is_locally_isomorphic(I::AlgAssAbsOrdIdl, J::AlgAssAbsOrdIdl) -> Bool
+    is_locally_isomorphic(I::AbsNumFieldOrderIdeal, J::AbsNumFieldOrderIdeal; check::Bool=true) -> Bool
+    is_locally_isomorphic(I::NfFracOrdIdl, J::NfFracOrdIdl; check::Bool=true) -> Bool
+    is_locally_isomorphic(I::AlgAssAbsOrdIdl, J::AlgAssAbsOrdIdl; check::Bool=true) -> Bool
 
 Given two (fractional) ideals $I$ and $J$ of an order $R$ of an $Q$-étale
 algebra, this function returns `true` if $I_p$ and $J_p$ are isomorphic for
 all primes $p$ of $R$ and `false` otherwise.
 """
-function is_locally_isomorphic(I::T, J::T) where { T <: Union{ AbsNumFieldOrderIdeal, AbsSimpleNumFieldOrderFractionalIdeal, AlgAssAbsOrdIdl } }
+function is_locally_isomorphic(I::T, J::T; check::Bool=true) where {T <: Union{AbsNumFieldOrderIdeal, AbsSimpleNumFieldOrderFractionalIdeal, AlgAssAbsOrdIdl}}
+  if check
+    @assert is_commutative(order(I))
+  end
   IJ = colon(I, J)
   JI = colon(J, I)
   return one(_algebra(order(I))) in IJ*JI
@@ -43,15 +48,18 @@ end
 
 # Stefano Marseglia "Computing the ideal class monoid of an order", Cor. 4.5
 @doc raw"""
-    is_isomorphic_with_map(I::AbsNumFieldOrderIdeal, J::AbsNumFieldOrderIdeal) -> Bool, AbsSimpleNumFieldElem
-    is_isomorphic_with_map(I::NfFracOrdIdl, J::NfFracOrdIdl) -> Bool, AbsSimpleNumFieldElem
-    is_isomorphic_with_map(I::AlgAssAbsOrdIdl, J::AlgAssAbsOrdIdl) -> Bool, AbstractAssociativeAlgebraElem
+    is_isomorphic_with_map(I::AbsNumFieldOrderIdeal, J::AbsNumFieldOrderIdeal; check::Bool=true) -> Bool, AbsSimpleNumFieldElem
+    is_isomorphic_with_map(I::NfFracOrdIdl, J::NfFracOrdIdl; check::Bool=true) -> Bool, AbsSimpleNumFieldElem
+    is_isomorphic_with_map(I::AlgAssAbsOrdIdl, J::AlgAssAbsOrdIdl; check::Bool=true) -> Bool, AbstractAssociativeAlgebraElem
 
 Given two (fractional) ideals $I$ and $J$ of an order $R$ of an $Q$-étale
 algebra $A$, this function returns `true` and an element $a \in A$ such that
 $I = aJ$ if such an element exists and `false` and $0$ otherwise.
 """
-function is_isomorphic_with_map(I::T, J::T) where { T <: Union{ AbsNumFieldOrderIdeal, AbsSimpleNumFieldOrderFractionalIdeal, AlgAssAbsOrdIdl}}
+function is_isomorphic_with_map(I::T, J::T; check::Bool=true) where {T <: Union{AbsNumFieldOrderIdeal, AbsSimpleNumFieldOrderFractionalIdeal, AlgAssAbsOrdIdl}}
+  if check
+    @assert is_commutative(order(I))
+  end
   A = _algebra(order(I))
   if !is_locally_isomorphic(I, J)
     return false, zero(A)
@@ -71,16 +79,16 @@ function is_isomorphic_with_map(I::T, J::T) where { T <: Union{ AbsNumFieldOrder
 end
 
 @doc raw"""
-    is_isomorphic(I::AbsNumFieldOrderIdeal, J::AbsNumFieldOrderIdeal) -> Bool, AbsSimpleNumFieldElem
-    is_isomorphic(I::NfFracOrdIdl, J::NfFracOrdIdl) -> Bool, AbsSimpleNumFieldElem
-    is_isomorphic(I::AlgAssAbsOrdIdl, J::AlgAssAbsOrdIdl) -> Bool, AbstractAssociativeAlgebraElem
+    is_isomorphic(I::AbsNumFieldOrderIdeal, J::AbsNumFieldOrderIdeal; check::Bool=true) -> Bool, AbsSimpleNumFieldElem
+    is_isomorphic(I::NfFracOrdIdl, J::NfFracOrdIdl; check::Bool=true) -> Bool, AbsSimpleNumFieldElem
+    is_isomorphic(I::AlgAssAbsOrdIdl, J::AlgAssAbsOrdIdl; check::Bool=true) -> Bool, AbstractAssociativeAlgebraElem
 
 Given two (fractional) ideals $I$ and $J$ of an order $R$ of an $Q$-étale
 algebra $A$, this function returns `true` if an element $a \in A$ exists such that
 $I = aJ$ and `false` otherwise.
 """
-function is_isomorphic(I::T, J::T) where { T <: Union{ AbsNumFieldOrderIdeal, AbsSimpleNumFieldOrderFractionalIdeal, AlgAssAbsOrdIdl}}
-  return is_isomorphic_with_map(I, J)[1]
+function is_isomorphic(I::T, J::T; check::Bool=true) where {T <: Union{AbsNumFieldOrderIdeal, AbsSimpleNumFieldOrderFractionalIdeal, AlgAssAbsOrdIdl}}
+  return is_isomorphic_with_map(I, J; check=check)[1]
 end
 
 function ring_of_multipliers(I::AbsSimpleNumFieldOrderFractionalIdeal)


### PR DESCRIPTION
Since the isomorphism test currently terminates with a wrong answer for fractional ideals in noncommutative algebras, check the needed assumptions.