### PR TITLE
fix: Fix isomorphism tests and calculations for modules over algebras

### DIFF
--- a/src/ModAlgAss/Lattices/Morphisms.jl
+++ b/src/ModAlgAss/Lattices/Morphisms.jl
@@ -37,7 +37,6 @@ function endomorphism_ring(f::EndAlgMap, L::ModAlgAssLat)
   n = nrows(BELint[1])
   r = length(BELint)
   Z = zero_matrix(ZZ, r, n^2)
-  cartesiantolinear = LinearIndices((n, n))
   lineartocartesian = CartesianIndices((n, n))
   for i in 1:r
     for j in 1:n^2
@@ -112,7 +111,6 @@ function _hom_space_as_ideal(L::ModAlgAssLat, M::ModAlgAssLat)
   n = nrows(Bint[1])
   r = length(Bint)
   Z = zero_matrix(ZZ, r, n^2)
-  cartesiantolinear = LinearIndices((n, n))
   lineartocartesian = CartesianIndices((n, n))
   for i in 1:r
     for j in 1:n^2
@@ -273,7 +271,7 @@ end
 
 function _is_isomorphic_with_isomorphism_same_ambient_module(L::ModAlgAssLat, M::ModAlgAssLat, ::Val{with_iso} = Val(true)) where {with_iso}
   @vprintln :PIP 1 "is_isomorphic: computing hom space as ideal"
-  E, f, O, I = _hom_space_as_ideal(L, M)
+  _, f, O, I = _hom_space_as_ideal(L, M)
   # This is BHJ, 2022, Prop. 3.3
   # Need to check that L and M are locally isomorphic
   @vprintln :PIP 1 "is_isomorphic: checking local isomorphism"
@@ -388,7 +386,6 @@ function is_free_with_basis(L::ModAlgAssLat)
   @assert d != -1
   @assert d == 1
   O = L.base_ring
-  A = algebra(O)
   M = free_lattice(O, d)
   V = M.V
   fl, iso = is_isomorphic_with_isomorphism(L, M)

--- a/src/ModAlgAss/Lattices/Morphisms.jl
+++ b/src/ModAlgAss/Lattices/Morphisms.jl
@@ -215,7 +215,7 @@ function _is_loc_iso_gen(L::ModAlgAssLat,
   fl, alpha = is_locally_free(I, p, side = :right)
   imal = image(f, alpha)
   if !fl
-    if with_iso === Val{true}
+    if with_iso
       return fl, imal
     else
       return fl

--- a/src/ModAlgAss/ModAlgAss.jl
+++ b/src/ModAlgAss/ModAlgAss.jl
@@ -649,9 +649,13 @@ end
 #end
 
 function is_isomorphic_with_isomorphism(V::ModAlgAss, W::ModAlgAss)
+  br = W.base_ring
+  if V == W
+    return true, hom(V, W, identity_matrix(br, dim(W)); check=false)
+  end
   B = _basis_of_hom(W, V)
   if length(B) == 0
-    return false, hom(V, W, basis(W))
+    return false, hom(V, W, zero_matrix(br, dim(W)); check=false)
   end
   l = length(B)
   for i in 1:50
@@ -660,7 +664,7 @@ function is_isomorphic_with_isomorphism(V::ModAlgAss, W::ModAlgAss)
       return true, hom(V, W, c)
     end
   end
-  return false, hom(V, W, basis(W))
+  throw("Maximal number of tries exhausted while finding isomorphism")
 end
 
 function is_free(V::ModAlgAss)

--- a/src/ModAlgAss/ModAlgAss.jl
+++ b/src/ModAlgAss/ModAlgAss.jl
@@ -447,8 +447,6 @@ function trivial_module(A::AbstractAssociativeAlgebra)
 end
 
 function regular_module(A::AbstractAssociativeAlgebra)
-  K = base_ring(A)
-  n = dim(A)
   B = basis(A)
   action_of_basis = [representation_matrix(b, :right) for b in B]
   M = Amodule(A, action_of_basis)
@@ -458,7 +456,6 @@ function regular_module(A::AbstractAssociativeAlgebra)
 end
 
 function regular_module(A::AbstractAssociativeAlgebra, p)#::AbsAlgAssMor)
-  K = base_ring(A)
   action_of_basis = [representation_matrix(p(b), :right) for b in basis(A)]
   M = Amodule(A, action_of_basis)
   # We do some more, because we know the endomorphism algbera
@@ -487,7 +484,6 @@ end
 
 function free_module(A::AbstractAssociativeAlgebra, r::Int)
   K = base_ring(A)
-  n = dim(A)
   B = basis(A)
   action_of_basis = Vector{dense_matrix_type(K)}()
   for b in B
@@ -668,6 +664,9 @@ function is_isomorphic_with_isomorphism(V::ModAlgAss, W::ModAlgAss)
 end
 
 function is_free(V::ModAlgAss)
+  if V.isfree == 1
+    return true
+  end
   dV = dim(V)
   A = algebra(V)
   dA = dim(A)
@@ -675,7 +674,7 @@ function is_free(V::ModAlgAss)
     return false
   end
   d = div(dV, dA)
-  fl = is_isomorphic_with_isomorphism(V, free_module(algebra(V), d))[1]
+  fl, _ = is_isomorphic_with_isomorphism(V, free_module(algebra(V), d))
   if !fl
     return false
   end
@@ -714,7 +713,7 @@ function _twist(V::ModAlgAss, a::Map)
     @assert A(g) == B[i]
     push!(rep2, action(V, A(a(g))))
   end
-  W = Amodule(A, rep2)
+  return Amodule(A, rep2)
 end
 
 function _change_group(V::ModAlgAss, a::Map; algebra = nothing)
@@ -731,6 +730,5 @@ function _change_group(V::ModAlgAss, a::Map; algebra = nothing)
     g = A.base_to_group[i]
     push!(rep2, action(V, A(a(g))))
   end
-  W = Amodule(QH, rep2)
-  return W
+  return Amodule(QH, rep2)
 end


### PR DESCRIPTION
Add some minor repairs; fix branches that were crashing because of non-implemented methods, and fix a branch condition that was always evaluating to false, resulting in type instability. While there, remove some unused variables in function bodies.