### PR TITLE
feat: add `multiplicative_generator` for finite fields

### DIFF
--- a/src/Misc/FiniteField.jl
+++ b/src/Misc/FiniteField.jl
@@ -125,7 +125,7 @@ end
 #
 ################################################################################
 
-function primitive_element(F::T; n_quo::Int = -1) where T <: Union{FqPolyRepField, fqPolyRepField, fpField, Nemo.FpField, FqField}
+function _primitive_element(F::T, n_quo::Int) where T <: Union{FqPolyRepField, fqPolyRepField, fpField, Nemo.FpField, FqField}
   n = order(F)-1
   k = ZZRingElem(1)
   if n_quo != -1
@@ -157,6 +157,26 @@ function primitive_element(F::T; n_quo::Int = -1) where T <: Union{FqPolyRepFiel
     end
   end
   return x
+end
+
+@doc raw"""
+    multiplicative_generator(F::FinField) -> FinFieldElem
+
+Return a generator of the multiplicative group of the finite field $F$.
+
+The result is cached on the finite field, so repeated calls return the same
+element.
+"""
+@attr elem_type(F) function multiplicative_generator(F::T) where T <: Union{FqPolyRepField, fqPolyRepField, fpField, Nemo.FpField, FqField}
+  return _primitive_element(F, -1)
+end
+
+function primitive_element(F::T; n_quo::Int = -1) where T <: Union{FqPolyRepField, fqPolyRepField, fpField, Nemo.FpField, FqField}
+  if n_quo == -1
+    # to exploit caching
+    return multiplicative_generator(F)
+  end
+  return _primitive_element(F, n_quo)
 end
 
 
@@ -355,4 +375,3 @@ function disc_log(b::T, x::T) where {T <: FinFieldElem}
   @assert parent(b) === parent(x)
   return Hecke.disc_log_bs_gs(b, x, order(parent(b)))
 end
-

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -713,6 +713,7 @@ export mul_sparse
 export multiples
 export multiplication_by_m_map
 export multiplication_table
+export multiplicative_generator
 export multiplicative_group
 export multiplicative_group_generators
 export multiplicative_order

--- a/test/Misc/FiniteField.jl
+++ b/test/Misc/FiniteField.jl
@@ -1,3 +1,18 @@
+@testset "Multiplicative generator" begin
+  fields = FinField[
+    GF(31),
+    GF(ZZRingElem(31)),
+    GF(ZZRingElem(31), 2, :a),
+  ]
+
+  for F in fields
+    g = multiplicative_generator(F)
+    n = order(F) - 1
+    @test all(l -> !isone(g^div(n, l)), prime_divisors(n))
+    @test multiplicative_generator(F) === g
+  end
+end
+
 @testset "fpField" begin
 
   for p in [31, 11, 101]
@@ -250,4 +265,3 @@ let # #2237
   U, mU = unit_group(L)
   @test order(U) == ZZ(37)^14 - 1
 end
-


### PR DESCRIPTION
This adds `multiplicative_generator(::FinField)`, which promises to cache the result.