### PR TITLE
fix: handle nonmonic norm factors in Trager factorization

### DIFF
--- a/src/FunField/Factor.jl
+++ b/src/FunField/Factor.jl
@@ -190,6 +190,7 @@ end
 
 #plain vanilla Trager, possibly doomed in pos. small char.
 function _factor_assume_squarefree_and_separable(f::Generic.Poly{<:Generic.AbsSimpleFunctionFieldElem})
+  @assert is_monic(f)
   i = 0
   local N
   g = f
@@ -211,7 +212,7 @@ function _factor_assume_squarefree_and_separable(f::Generic.Poly{<:Generic.AbsSi
   end
 
   fN = factor(N)
-  @assert isone(fN.unit)
+  # We are reconstructing the monic polynomial g and the gcds below are monic.
   D = Fac(one(parent(f)), Dict((gcd(map_coefficients(base_ring(f), p, parent = parent(f)), g)(t+i*a), k) for (p,k) = fN.fac))
   return D
 end

--- a/test/FunField/Factor.jl
+++ b/test/FunField/Factor.jl
@@ -12,6 +12,16 @@
   @test unit(fac) * prod(p^e for (p, e) in fac) == f
   @test all(isone(degree(p)) for (p, _) in fac)
 
+  # The factors of the norm need not be monic over a rational function field.
+  Qt, = rational_function_field(QQ, :t)
+  Qtx, x = Qt[:x]
+  K, a = function_field(x^2 + 1//2*x + 1, :a)
+  Ky, y = K[:y]
+  f = y - a
+  fac = factor(f)
+  @test evaluate(fac) == f
+  @test all(isone(degree(p)) for (p, _) in fac)
+
   # inseparable extension
   let
     k, o = finite_field(9)


### PR DESCRIPTION
The assertion was too strong. We reconstruct the factorization of a monic polynomial, so we don't care what the unit of the factorization of the norm is.

Assert that the helper receives a monic polynomial and add a regression test covering a nontrivial norm factorization unit.

Fixes #2247
