### PR TITLE
fix: GenOrdElem return coordinates over the base ring

### DIFF
--- a/src/GenOrd/GenOrd.jl
+++ b/src/GenOrd/GenOrd.jl
@@ -353,7 +353,8 @@ function coordinates(a::FieldElem, O::GenOrd)
 end
 
 function coordinates(a::GenOrdElem)
-  return coordinates(a.data, parent(a))
+  O = parent(a)
+  return base_ring(O).(coordinates(data(a), O))
 end
 
 function coordinates(a::Generic.AbsSimpleFunctionFieldElem)
@@ -385,9 +386,7 @@ function _representation_matrix_direct(a::GenOrdElem)
   for i in 1:n
     c = coordinates(b[i]*a)
     for j in 1:n
-      num, den = integral_split(c[j], R)
-      @assert isone(den)
-      m[i, j] = num
+      m[i, j] = c[j]
     end
   end
 
@@ -418,15 +417,7 @@ end
 
 function representation_matrix(a::GenOrdElem)
   O = parent(a)
-  R = base_ring(O)
-
-  v = map(coordinates(a)) do x
-    num, den = integral_split(x, R)
-    @assert isone(den)
-    num
-  end
-
-  return _representation_matrix(O, v)
+  return _representation_matrix(O, coordinates(a))
 end
 
 ################################################################################

--- a/src/GenOrd/Ideal.jl
+++ b/src/GenOrd/Ideal.jl
@@ -1509,8 +1509,7 @@ function containment_by_matrices(x::GenOrdElem, y::GenOrdIdl)
   num = map_entries(kx, A*den)
   R = residue_ring(kx, den; cached = false)[1]
   M = map_entries(R, num)
-  # coordinates(x) are in base field: lift through O.R
-  coords = map(c -> numerator(c, kx), coordinates(x))
+  coords = coordinates(x)
   v = matrix(R, 1, degree(parent(x)), coords)
   #mul!(v, v, M) This didn't work
   v = v*M

--- a/test/GenOrd/GenOrd.jl
+++ b/test/GenOrd/GenOrd.jl
@@ -25,6 +25,17 @@
   @test parent(u) === Ofin
   @test is_unit(u)
 
+  @testset "Coordinates" begin
+    k, t = rational_function_field(GF(3), "t")
+    K, _ = function_field(polynomial(k, [t, 0, 1]))
+    O = finite_maximal_order(K)
+    c = @inferred coordinates(one(O))
+    @test c == [one(base_ring(O)), zero(base_ring(O))]
+    @test eltype(c) === elem_type(base_ring(O))
+    @test all(x -> parent(x) === base_ring(O), c)
+    @test O(c) == one(O)
+  end
+
   let # some weird rings
     Qt,t = rational_function_field(QQ, :t)
     Qtx, x= Qt[:x]


### PR DESCRIPTION
Fixes #2286
