### PR TITLE
fix: allow T2 precision to follow element height

### DIFF
--- a/src/NumField/NfAbs/Conjugates.jl
+++ b/src/NumField/NfAbs/Conjugates.jl
@@ -374,10 +374,6 @@ function _minkowski_map_and_apply(a, abs_tol, G, work_tol::Int = abs_tol)
     end
   end
 
-  if work_tol > 2^18 || abs_tol > 2^18
-    error("asdsd")
-  end
-
   #R = ArbField(precision(parent(c[1])), false)
   R = ArbField(2 * work_tol, cached = false)
   sqrt2 = sqrt(R(2))

--- a/test/NfAbs/Conjugates.jl
+++ b/test/NfAbs/Conjugates.jl
@@ -80,6 +80,14 @@ end
 
   k, z = cyclotomic_field(1)
   @test isone(t2(z))
+
+  # Working precision is determined by the element height. This example
+  # requires the first precision doubling beyond 2^18 bits.
+  k, z = quadratic_field(-1)
+  height = 262_200
+  high = t2(k(ZZ(2)^height) * z)
+  @test contains(high, ZZ(2)^(2 * height + 1))
+  @test Hecke.radiuslttwopower(high, -32)
 end
 
 @testset "signs" begin


### PR DESCRIPTION
## Summary

- remove the arbitrary `2^18`-bit rejection from exact Minkowski interval refinement
- add a high-height imaginary quadratic regression that crosses the former limit
- verify both exact containment and the requested radius

The required working precision depends on the input height. The refinement already increases precision until its certified radius is small enough, so this fixed ceiling rejected otherwise valid computations without providing a correctness safeguard.

## Test

`julia --project=. -e 'using Hecke, Test; include("test/NfAbs/Conjugates.jl")'`

Result: 68/68 tests passed.