### PR TITLE
fix: return the structure constant algebra of a cyclic algebra

### DIFF
--- a/src/AlgAss/AlgCyc.jl
+++ b/src/AlgAss/AlgCyc.jl
@@ -65,7 +65,7 @@ end
 function structure_constant_algebra(
   c::CyclicAlgebra{T, S},
 ) where {T, S}
-  return StructureConstantAlgebra(c.sca)::StructureConstantAlgebra{T}
+  return c.sca::StructureConstantAlgebra{T}
 end
 
 """

--- a/test/AlgAss/AlgCyc.jl
+++ b/test/AlgAss/AlgCyc.jl
@@ -7,6 +7,7 @@
   @test !is_split(cyclic_algebra(k1, sigma1, QQ(3)))
 
   c = cyclic_algebra(k1, sigma1, QQ(4))
+  @test structure_constant_algebra(c) === parent(Hecke.generating_element(c))
   splits, iso = is_split_with_map(c)
   @test splits
   @test iso(domain(iso)(1)) == codomain(iso)(1)


### PR DESCRIPTION
## Summary

- return the structure constant algebra already stored by `CyclicAlgebra`
- cover the public accessor with a regression

`StructureConstantAlgebra(c.sca)` invokes a conversion that returns an algebra-map pair. The accessor asserts a structure-constant-algebra return type, so calling it currently raises a type error. Returning `c.sca` directly matches both the documented contract and the existing cyclic-algebra representation.

## Test

`julia --project=. -e 'using Hecke, Test; include("test/AlgAss/AlgCyc.jl")'`

Result: 22/22 tests passed.