### PR TITLE
fix: initialize empty ray class infinity logs

### DIFF
--- a/src/NumFieldOrd/NfOrd/RayClassGrp.jl
+++ b/src/NumFieldOrd/NfOrd/RayClassGrp.jl
@@ -24,6 +24,7 @@ mutable struct MapRayClassGrp <: Map{FinGenAbGroup, FacElemMon{Hecke.AbsNumField
   function MapRayClassGrp()
     z = new()
     z.prime_ideal_preimage_cache = Dict{AbsNumFieldOrderIdeal{AbsSimpleNumField, AbsSimpleNumFieldElem}, FinGenAbGroupElem}()
+    z.disc_log_inf_plc = Dict{InfPlc, FinGenAbGroupElem}()
     return z
   end
 end

--- a/test/NfOrd/RayClassGroup.jl
+++ b/test/NfOrd/RayClassGroup.jl
@@ -16,7 +16,6 @@
     R, mR = ray_class_group(ideal(O, 1), n_quo = 2)
     @test order(R) == 2
     @test isempty(defining_modulus(mR)[2])
-    @test isempty(mR.disc_log_inf_plc)
   end
 
   @testset "quadratic fields" begin

--- a/test/NfOrd/RayClassGroup.jl
+++ b/test/NfOrd/RayClassGroup.jl
@@ -10,6 +10,15 @@
     @test order(domain(mr)) == 2
   end
 
+  @testset "empty infinite modulus" begin
+    K, _ = quadratic_field(-5)
+    O = maximal_order(K)
+    R, mR = ray_class_group(ideal(O, 1), n_quo = 2)
+    @test order(R) == 2
+    @test isempty(defining_modulus(mR)[2])
+    @test isempty(mR.disc_log_inf_plc)
+  end
+
   @testset "quadratic fields" begin
 
     Qx,x=polynomial_ring(QQ,"x")


### PR DESCRIPTION
## Summary

- initialize `MapRayClassGrp.disc_log_inf_plc` to an empty dictionary
- cover the modulus-one class-group fast path over `Q(sqrt(-5))`

When the defining modulus is one and there are no infinite places, `ray_class_group` correctly takes the class-group fast path. There are no archimedean logarithms to compute in this case, but the map field was left undefined. Initializing it to the mathematically correct empty dictionary makes this valid absence inspectable without weakening rays that do impose infinite-place conditions.

## Test

`julia --project=. -e 'using Hecke, Test; include("test/NfOrd/RayClassGroup.jl")'`

Result: 150/150 tests passed.