### PR TITLE
fix: omit unit factors from factor_easy

### DIFF
--- a/src/NumFieldOrd/NfOrd/Ideal/Prime.jl
+++ b/src/NumFieldOrd/NfOrd/Ideal/Prime.jl
@@ -841,12 +841,15 @@ function factor_easy(I::AbsNumFieldOrderIdeal{AbsSimpleNumField, AbsSimpleNumFie
     r = is_perfect_power_with_data(r)[2]
     if !isone(r)
       r = ppio(minimum(I), r)[1]
+      isone(r) && continue
       J = gcd(I, r)
+      @assert !isone(J)
       ideals[J] = 1
     end
   end
   @hassert :AbsNumFieldOrder 1 prod(x^y for (x, y) in ideals; init = 1 * OK) == I
   @hassert :AbsNumFieldOrder 1 all(!iszero, values(ideals))
+  @hassert :AbsNumFieldOrder 1 all(!isone, keys(ideals))
   @hassert :AbsNumFieldOrder 1 is_pairwise_coprime(collect(keys(ideals)))
   return ideals
 end

--- a/test/NfOrd/Ideal/Prime.jl
+++ b/test/NfOrd/Ideal/Prime.jl
@@ -219,6 +219,18 @@ lf = Hecke.factor_easy(A)
 @test prod(x^y for (x, y) in lf) == A
 @test Hecke.is_pairwise_coprime([x^y for (x, y) in lf])
 
+@testset "factor_easy omits unit residuals" begin
+  K, _ = quadratic_field(2, cached = false)
+  O = maximal_order(K)
+  p = next_prime(ZZ(10)^10)
+  q = next_prime(p)
+  I = ideal(O, p*q, O(1))
+  lf = Hecke.factor_easy(I)
+  @test isone(I)
+  @test isempty(lf)
+  @test prod(x^y for (x, y) in lf; init = 1*O) == I
+end
+
 # primary decomposition
 K, a = quadratic_field(5)
 O = equation_order(K)


### PR DESCRIPTION
## Summary

- recheck the residual after perfect-power cleanup and `ppio`
- skip it when that cleanup removes the complete residual
- assert the internal nonunit-factor invariant
- add a compact regression whose composite residual survives trial division

Previously, `ppio` could turn a nontrivial residual into one, after which `gcd(I, 1)` inserted the unit ideal into the returned factorization. Consumers of `factor_easy` expect nonunit, pairwise-coprime factors whose powered product reconstructs the input.

## Test

`julia --project=. -e 'using Hecke, Test; include("test/NfOrd/Ideal/Prime.jl")'`

Result: the complete focused test file passed; the new regression takes about 0.1 seconds.