### PR TITLE
fix: preserve Selmer exponent and inverse coordinates

### DIFF
--- a/src/NumField/Selmer.jl
+++ b/src/NumField/Selmer.jl
@@ -1,17 +1,6 @@
 module SelmerModule
 using Hecke
 
-"""
-Adds an element to the group. For this to work, C needs to be a subgroup of the parent of a.
-Should move to GrpAb
-"""
-function Base.push!(C::FinGenAbGroup, a::FinGenAbGroupElem)
-  g = gens(C)
-  push!(g, a)
-  #TODO: find common overgroup? Assuming for now that parent(a) is it.
-  return sub(parent(a), g)
-end
-
 #TODO: should be exported, but at this point, index is not yet a symbol, so it can't be extended.
 #Should move to GrpAb
 function index(G::FinGenAbGroup, U::FinGenAbGroup; check::Bool = true)
@@ -73,11 +62,11 @@ function pselmer_group_fac_elem(p::Int, S::Vector{<:AbsNumFieldOrderIdeal{AbsSim
     for (pi, ei) = lp
       (norm(pi) < 1000 || degree(pi) == 1) || continue
       c = preimage(mC, pi)
-      c in s && continue
-      s, ms = push!(s, c)
+      has_preimage_with_preimage(ms, c)[1] && continue
+      s, ms = sub(C, vcat([ms(g) for g in gens(s)], [c]))
       push!(D, pi)
     end
-    p, pos = iterate(P, pos)
+    pr, pos = iterate(P, pos)
   end
 
   if length(D) + length(S) == 0
@@ -171,7 +160,7 @@ function pselmer_group_fac_elem(p::Int, S::Vector{<:AbsNumFieldOrderIdeal{AbsSim
         mF = Hecke.extend_easy(mF, K)
         va = try [preimage(mu, mF(toK(g)))[1] for g = gens(Sel)]
              catch e
-               isa(e, BadPrime) || rethrow(e)
+               isa(e, Hecke.BadPrime) || rethrow(e)
                nothing
              end
         va === nothing && continue
@@ -189,7 +178,7 @@ function pselmer_group_fac_elem(p::Int, S::Vector{<:AbsNumFieldOrderIdeal{AbsSim
     end
     fl, sol = can_solve_with_solution(dl, dx; side = :right)
     @assert fl
-    return Sel(map(lift, vec(collect(sol))))
+    return Sel(map(x -> lift(ZZ, x), vec(collect(sol))))
   end
 
   return Sel, MapFromFunc(Sel, codomain(mU), toK, toSel)

--- a/test/NumField/Selmer.jl
+++ b/test/NumField/Selmer.jl
@@ -11,4 +11,19 @@
   sel, mmap = pselmer_group_fac_elem(2, [-1, 2, 3]);
   h = hom(Sel, sel, [preimage(mmap, Hecke.factored_norm(map(g), parent = codomain(mmap))) for g = gens(Sel)]);
   k, mk = kernel(h);
+
+  # The auxiliary class-group prime cursor must not overwrite the requested
+  # Selmer exponent. Over Q(sqrt(-14)), the primes above 2 leave an even
+  # class-group index, so this executes that cursor before forming the
+  # 2-Selmer quotient.
+  Qx, x = QQ["x"]
+  L, _ = number_field(x^2 + 14, "b")
+  OL = maximal_order(L)
+  S2 = first.(prime_decomposition(OL, 2))
+  Sel2, mSel2 = pselmer_group_fac_elem(2, S2)
+  @test order(Sel2) == 8
+  for value in (L(-1), L(2))
+    coordinate = preimage(mSel2, codomain(mSel2)(value))
+    @test is_square(evaluate(mSel2(coordinate)) / value)
+  end
 end


### PR DESCRIPTION
## Summary

- keep the auxiliary class-group prime cursor separate from the requested Selmer exponent
- extend the current class subgroup through its inclusion map instead of defining `Base.push!` for finite abelian groups
- qualify `BadPrime` inside `SelmerModule`
- lift inverse-map coordinates explicitly to `ZZ`
- cover the expected 2-Selmer order and inverse representatives over `Q(sqrt(-14))`

The loop cursor previously overwrote `p`, so every later quotient and local computation could use an auxiliary rational prime instead of the requested Selmer exponent. The inverse map also relied on an ambiguous one-argument `lift`.

## Test

`julia --project=. -e 'using Hecke, Test; include("test/NumField/Selmer.jl")'`

Result: 4/4 tests passed.