### PR TITLE
fix: retry automorphism reduction at a good prime

### DIFF
--- a/src/Map/NumberField.jl
+++ b/src/Map/NumberField.jl
@@ -576,18 +576,38 @@ function small_generating_set(G::Vector{<: NumFieldHom{AbsSimpleNumField, AbsSim
   end
 end
 
-function _order(G::Vector{<: NumFieldHom{AbsSimpleNumField, AbsSimpleNumField}})
+function _automorphism_reduction(
+  G::Vector{<:NumFieldHom{AbsSimpleNumField, AbsSimpleNumField}},
+  p::Int,
+)
   K = domain(G[1])
-	p = 2
-  R = Native.GF(p, cached = false)
-	Rx = polynomial_ring(R, "x", cached = false)[1]
-  while iszero(discriminant(change_base_ring(R, defining_polynomial(K); parent = Rx)))
-		p = next_prime(p)
-	  R = Native.GF(p, cached = false)
-		Rx = polynomial_ring(R, "x", cached = false)[1]
-	end
-  given_gens = fpPolyRingElem[Rx(image_primitive_element(x)) for x in G]
-  return length(closure(given_gens, (x, y) -> Hecke.compose_mod(x, y, change_base_ring(R, defining_polynomial(K); parent = Rx)), gen(Rx)))
+  d = numerator(discriminant(defining_polynomial(K)))
+  while true
+    while mod(d, p) == 0
+      p = next_prime(p)
+    end
+    try
+      R = Native.GF(p, cached = false)
+      Rx, x = polynomial_ring(R, "x", cached = false)
+      fmod = change_base_ring(R, defining_polynomial(K); parent = Rx)
+      pols = fpPolyRingElem[Rx(image_primitive_element(g)) for g in G]
+      return x, fmod, pols
+    catch e
+      if isa(e, Nemo.FlintException) && e.type == Nemo.FLINT_IMPINV
+        # A generator image can have a denominator divisible by p even when
+        # the defining polynomial has good reduction.
+        p = next_prime(p)
+        continue
+      end
+      rethrow(e)
+    end
+  end
+end
+
+function _order(G::Vector{<: NumFieldHom{AbsSimpleNumField, AbsSimpleNumField}})
+  x, fmod, given_gens = _automorphism_reduction(G, 2)
+  return length(closure(
+    given_gens, (x, y) -> Hecke.compose_mod(x, y, fmod), x))
 end
 
 ################################################################################

--- a/src/Map/automorphisms.jl
+++ b/src/Map/automorphisms.jl
@@ -207,29 +207,7 @@ end
 function _automorphism_group_generic(K::AbsSimpleNumField)
   aut = automorphism_list(K)
   n = degree(K)
-  #First, find a good prime
-  p = 11
-  d = numerator(discriminant(K.pol))
-  while mod(d, p) == 0
-    p = next_prime(p)
-  end
-  local pols
-  local fmod
-  while true
-    try
-      R = Native.GF(p, cached = false)
-      Rx, x = polynomial_ring(R, "x", cached = false)
-      fmod = change_base_ring(R, defining_polynomial(K); parent = Rx)
-      pols = fpPolyRingElem[Rx(image_primitive_element(g)) for g in aut]
-      break
-    catch e
-      if isa(e, Nemo.FlintException) && e.type == Nemo.FLINT_IMPINV
-        p = next_prime(p)
-        continue
-      end
-      rethrow(e)
-    end
-  end
+  _, fmod, pols = _automorphism_reduction(aut, 11)
 
   Dcreation = Vector{Tuple{fpPolyRingElem, Int}}(undef, length(pols))
   for i = 1:length(pols)
@@ -305,20 +283,13 @@ automorphism_group(L::NumField, ::QQField) = absolute_automorphism_group(L)
 function closure(S::Vector{<:NumFieldHom{AbsSimpleNumField, AbsSimpleNumField}}, final_order::Int = -1)
 
   K = domain(S[1])
-  d = numerator(discriminant(K.pol))
-  p = 11
-  while mod(d, p) == 0
-    p = next_prime(p)
-  end
-  R = Native.GF(p, cached = false)
-  Rx, x = polynomial_ring(R, "x", cached = false)
-  fmod = change_base_ring(R, defining_polynomial(K); parent = Rx)
+  x, fmod, reduced_generators = _automorphism_reduction(S, 11)
 
   t = length(S)
   order = 1
   elements = automorphism_type(K)[id_hom(K)]
   pols = fpPolyRingElem[x]
-  gpol = Rx(image_primitive_element(S[1]))
+  gpol = reduced_generators[1]
   if gpol != x
     push!(pols, gpol)
     push!(elements, S[1])
@@ -340,11 +311,11 @@ function closure(S::Vector{<:NumFieldHom{AbsSimpleNumField, AbsSimpleNumField}},
 
   for i in 2:t
     if !(S[i] in elements)
-      pi = Rx(image_primitive_element(S[i]))
+      pi = reduced_generators[i]
       previous_order = order
       order = order + 1
       push!(elements, S[i])
-      push!(pols, Rx(image_primitive_element(S[i])))
+      push!(pols, pi)
       for j in 2:previous_order
         order = order + 1
         push!(pols, compose_mod(pols[j], pi, fmod))
@@ -357,7 +328,7 @@ function closure(S::Vector{<:NumFieldHom{AbsSimpleNumField, AbsSimpleNumField}},
       while rep_pos <= order
         for k in 1:i
           s = S[k]
-          po = Rx(image_primitive_element(s))
+          po = reduced_generators[k]
           att = compose_mod(pols[rep_pos], po, fmod)
           if !(att in pols)
             elt = elements[rep_pos]*s
@@ -382,18 +353,8 @@ function closure(S::Vector{<:NumFieldHom{AbsSimpleNumField, AbsSimpleNumField}},
 end
 
 function generic_group(G::Vector{<:NumFieldHom{AbsSimpleNumField, AbsSimpleNumField}}, ::typeof(*), full::Bool = true)
-  K = domain(G[1])
   n = length(G)
-  #First, find a good prime
-  p = 11
-  d = numerator(discriminant(K.pol))
-  while mod(d, p) == 0
-    p = next_prime(p)
-  end
-  R = Native.GF(p, cached = false)
-  Rx, x = polynomial_ring(R, "x", cached = false)
-  fmod = change_base_ring(R, defining_polynomial(K); parent = Rx)
-  pols = fpPolyRingElem[Rx(image_primitive_element(g)) for g in G]
+  _, fmod, pols = _automorphism_reduction(G, 11)
   Dcreation = Vector{Tuple{fpPolyRingElem, Int}}(undef, length(pols))
   for i = 1:length(pols)
     Dcreation[i] = (pols[i], i)

--- a/test/Map/NumberField.jl
+++ b/test/Map/NumberField.jl
@@ -32,6 +32,21 @@ end
 
 @testset "Automorphisms" begin
   Qx, x = QQ["x"]
+
+  @testset "Presentation-bad reduction primes" begin
+    K2, a2 = number_field(
+      x^2 - 1//2*x - 2, "a"; cached = false)
+    sigma2 = hom(K2, K2, 1//2 - a2; check = true)
+    @test Hecke._order([sigma2]) == 2
+
+    K11, a11 = number_field(
+      x^2 - 1//11*x - 2, "a"; cached = false)
+    sigma11 = hom(K11, K11, 1//11 - a11; check = true)
+    automorphisms = [id_hom(K11), sigma11]
+    @test length(Hecke.closure([sigma11], 2)) == 2
+    @test order(first(Hecke.generic_group(automorphisms, *))) == 2
+  end
+
   f = x^32 - 217*x^28 + 42321*x^24 - 999502*x^20 + 18913054*x^16 - 80959662*x^12 + 277668081*x^8 - 115322697*x^4 + 43046721
   K, a = number_field(f, cached = false, check = false)
   auts = Hecke._automorphisms(K, is_abelian = true)
@@ -135,4 +150,3 @@ let
   f = hom(K, K, -a)
   @test Hecke.is_involution(f)
 end
-


### PR DESCRIPTION
## Summary

- centralize modular reduction of absolute number-field automorphisms
- skip primes dividing the defining-polynomial discriminant
- retry only `FLINT_IMPINV` when a generator image has a denominator divisible by the chosen prime
- use the same reduction contract in automorphism-group construction, `closure`, `generic_group`, and `_order`
- cover presentation-bad primes 2 and 11

A prime can be arithmetically good for the defining polynomial while still being bad for the chosen presentation of an automorphism image. Such a prime should not make the abstract automorphism group computation fail.

## Test

`julia --project=. -e 'using Hecke, Test; include("test/Map/NumberField.jl")'`

Result: all focused testsets passed, including 72 composition-order and 9 automorphism checks.