### PR TITLE
fix: preserve integral ideal images under automorphisms

### DIFF
--- a/src/Map/NumberField.jl
+++ b/src/Map/NumberField.jl
@@ -310,7 +310,10 @@ function induce_image(f::NumFieldHom{AbsSimpleNumField, AbsSimpleNumField}, x::A
   I = ideal(OK)
   if isdefined(x, :gen_two)
     new_gen_two = f(K(x.gen_two))
-    if has_minimum(x)
+    # Coefficientwise reduction is integral only when the power basis is
+    # integral and contained in the target order.
+    if has_minimum(x) && is_defining_polynomial_nice(K) &&
+        contains_equation_order(OK)
       new_gen_two = mod(new_gen_two, minimum(x, copy = false)^2)
     end
     if is_maximal_known(OK) && is_maximal(OK)

--- a/test/Map/NumberField.jl
+++ b/test/Map/NumberField.jl
@@ -27,6 +27,30 @@ end
   I = ideal(E, E(a))
   @test_throws ErrorException Hecke.induce_image(f, I)
 
+  @testset "Non-integral defining generator" begin
+    K, a = number_field(
+      x^4 + 4//9*x^2 + 4//9, "a"; cached = false)
+    @test !is_defining_polynomial_nice(K)
+    OK = maximal_order(K)
+    primes = prime_decomposition(OK, 2)
+    @test length(primes) == 1
+    P = only(primes)[1]
+    automorphisms = automorphism_list(K)
+    @test length(automorphisms) == 4
+
+    images = [Hecke.induce_image(sigma, P) for sigma in automorphisms]
+    exact_images = [
+      ideal(OK, [OK(sigma(K(element))) for element in basis(P)])
+      for sigma in automorphisms
+    ]
+    @test all(
+      Hecke.elem_in_nf(image.gen_two) in OK for image in images)
+    @test [basis_matrix(image) for image in images] ==
+          [basis_matrix(image) for image in exact_images]
+    @test count(==(P), images) ==
+          ramification_index(P)*degree(P) == length(automorphisms)
+  end
+
 end
 
 
@@ -135,4 +159,3 @@ let
   f = hom(K, K, -a)
   @test Hecke.is_involution(f)
 end
-


### PR DESCRIPTION
## Summary

- apply coefficientwise reduction to an ideal generator only when the defining power basis is integral and contained in the target order
- retain the existing maximal-order unchecked-coercion fast path
- compare automorphic ideal images with basis-wise exact images for a field with a non-integral defining generator

An automorphism preserves integrality, but coefficientwise reduction in a non-integral power basis need not. The previous optimization could therefore replace a valid integral image by an element outside the maximal order.

## Test

`julia --project=. -e 'using Hecke, Test; include("test/Map/NumberField.jl")'`

Result: all focused testsets passed; the `Induce image` testset passed 9/9 checks.