### PR TITLE
fix: reuse known containment in compositum

### DIFF
--- a/src/NumField/NfAbs/NfAbs.jl
+++ b/src/NumField/NfAbs/NfAbs.jl
@@ -568,6 +568,14 @@ Assuming $L$ is normal (which is not checked), compute the compositum $C$ of the
 2 fields together with the embedding of $K \to C$ and $L \to C$.
 """
 function compositum(K::AbsSimpleNumField, L::AbsSimpleNumField)
+  if K === L
+    identity = id_hom(K)
+    return K, identity, identity
+  end
+  if has_embedding(L, K)
+    mL = hom(L, K, force_coerce(K, gen(L)); check = false)
+    return K, id_hom(K), mL
+  end
   lf = factor(L, K.pol)
   d = degree(first(lf.fac)[1])
   if any(x->degree(x) != d, keys(lf.fac))

--- a/test/NumField/NfAbs/NfAbs.jl
+++ b/test/NumField/NfAbs/NfAbs.jl
@@ -158,5 +158,18 @@ end
 
   @test !Hecke.has_embedding(C, K)
   @test !Hecke.has_embedding(K, L)
-end
 
+  D, mC, mL_again = compositum(C, L)
+  @test D === C
+  @test domain(mC) === C
+  @test codomain(mC) === C
+  @test mC(gen(C)) == gen(C)
+  @test domain(mL_again) === L
+  @test codomain(mL_again) === C
+  @test mL_again(b) == mL(b)
+
+  D, mC1, mC2 = compositum(C, C)
+  @test D === C
+  @test mC1(gen(C)) == gen(C)
+  @test mC2(gen(C)) == gen(C)
+end


### PR DESCRIPTION
## Summary

- return the input field and identity maps when both operands are the same object
- reuse a registered embedding when the normal second field is already contained in the first
- preserve the exact known embedding instead of constructing an isomorphic compositum again

This avoids a factorization and a new absolute-field construction when the field lattice already contains the answer.

## Test

`julia --project=. -e 'using Hecke, Test; include("test/NumField/NfAbs/NfAbs.jl")'`

Result: the complete focused file passed, including 16/16 compositum checks.