### PR TITLE
fix: repair transitive field extraction in GAPExt

### DIFF
--- a/ext/GAPExt/GAPExt.jl
+++ b/ext/GAPExt/GAPExt.jl
@@ -22,6 +22,8 @@ import Hecke:
   is_automorphisms_known,
   is_fixed_point_free,
   IdGroup,
+  morphism_type,
+  automorphism_list,
   number_field,
   AbsSimpleNumFieldEmbedding,
   permutation_group1,

--- a/ext/GAPExt/non_normal.jl
+++ b/ext/GAPExt/non_normal.jl
@@ -1,21 +1,34 @@
-function to_non_normal(l::Vector{FieldsTower}, G::GAP.GapObj, deg::Int)
+function _transitive_subgroup_class(
+  G::GAP.GapObj,
+  deg::Int,
+  tid::Union{Nothing, Int} = nothing,
+)
+  for class in GAP.Globals.ConjugacyClassesSubgroups(G)
+    H = GAP.Globals.Representative(class)
+    GAP.Globals.Index(G, H) == deg || continue
+    GAP.Globals.Size(GAP.Globals.Core(G, H)) == 1 || continue
+    if tid !== nothing
+      action = GAP.Globals.FactorCosetAction(G, H)
+      GAP.Globals.TransitiveIdentification(GAP.Globals.Image(action)) == tid ||
+        continue
+    end
+    return class
+  end
+  error("Representation not possible")
+end
+
+function to_non_normal(
+  l::Vector{FieldsTower},
+  G::GAP.GapObj,
+  deg::Int;
+  tid::Union{Nothing, Int} = nothing,
+)
   for x in l
     assure_automorphisms(x)
     assure_isomorphism(x, G)
   end
-  lC = GAP.Globals.ConjugacyClassesSubgroups(G)
-  ind = 0
-  for i = 1:length(lC)
-    r = GAP.Globals.Representative(lC[i])
-    if GAP.Globals.Size(r) == divexact(degree(l[1].field), deg) && GAP.Globals.Size(GAP.Globals.Core(G, r)) == 1
-      ind = i
-      break
-    end
-  end
-  if iszero(ind)
-    error("Representation not possible")
-  end
-  rep = GAP.Globals.Representative(lC[ind])
+  class = _transitive_subgroup_class(G, deg, tid)
+  rep = GAP.Globals.Representative(class)
   ffields = Vector{AbsSimpleNumField}(undef, length(l))
   for i = 1:length(ffields)
     ffields[i] = fixed_field(l[i], rep)
@@ -107,7 +120,7 @@ function fields_transitive_group(n::Int, i::Int, disc::ZZRingElem)
   disc_NC = _find_discriminant_bound(n, i, disc)
   @vprintln :Fields 1 "Normal-closure discriminant bound: $disc_NC"
   lf = Hecke.fields(id[1], id[2], disc_NC)
-  ln = to_non_normal(lf, G1, n)
+  ln = to_non_normal(lf, G1, n; tid = i)
   indices = Int[]
   for i = 1:length(ln)
     if abs(discriminant(maximal_order(ln[i]))) <= disc

--- a/ext/GAPExt/non_normal.jl
+++ b/ext/GAPExt/non_normal.jl
@@ -60,7 +60,7 @@ function _find_discriminant_bound(n, i, disc)
     mp = GAP.Globals.FactorCosetAction(G1, H)
     idT = GAP.Globals.TransitiveIdentification(GAP.Globals.Image(mp))
     if idT == i
-      ind = i
+      ind = k
       break
     end
   end
@@ -81,11 +81,11 @@ function _find_discriminant_bound(n, i, disc)
     end
   end
   if isfrobenius
-    @show "Frobenius!"
+    @vprintln :Fields 1 "Frobenius group: tighter closure bound"
     #In this case, we can find a better bound for the closure!
     m = divexact(id[1], n)
     bdisc = disc^(2*m*n-m)
-    return root(bdisc, n-1)
+    return iroot(bdisc, n-1)
   end
   j = 1
   for i = 2:length(conjs)
@@ -104,8 +104,9 @@ function fields_transitive_group(n::Int, i::Int, disc::ZZRingElem)
   @assert GAP.Globals.IsSolvable(Gt)
   id = GAP.Globals.IdGroup(Gt)
   G1 = GAP.Globals.SmallGroup(id)
-  @show disc_NC = _find_discriminant_bound(n, i, disc)
-  lf = fields(id[1], id[2], disc_NC)
+  disc_NC = _find_discriminant_bound(n, i, disc)
+  @vprintln :Fields 1 "Normal-closure discriminant bound: $disc_NC"
+  lf = Hecke.fields(id[1], id[2], disc_NC)
   ln = to_non_normal(lf, G1, n)
   indices = Int[]
   for i = 1:length(ln)

--- a/test/FieldFactory/FieldFactory.jl
+++ b/test/FieldFactory/FieldFactory.jl
@@ -4,6 +4,15 @@
     GAPExt = Base.get_extension(Hecke, :GAPExt)
     @test GAPExt._find_discriminant_bound(3, 1, ZZ(2)) == 5
     @test GAPExt._find_discriminant_bound(4, 2, ZZ(2)) == 5
+
+    G = GAP.Globals.SmallGroup(24, 12)
+    for tid in (7, 8)
+      class = GAPExt._transitive_subgroup_class(G, 6, tid)
+      H = GAP.Globals.Representative(class)
+      action = GAP.Globals.FactorCosetAction(G, H)
+      @test GAP.Globals.TransitiveIdentification(
+        GAP.Globals.Image(action)) == tid
+    end
   end
 
   println("Quadratic Fields")

--- a/test/FieldFactory/FieldFactory.jl
+++ b/test/FieldFactory/FieldFactory.jl
@@ -1,5 +1,11 @@
 @testset "FieldFactory" begin
 
+  @testset "Transitive group fields" begin
+    GAPExt = Base.get_extension(Hecke, :GAPExt)
+    @test GAPExt._find_discriminant_bound(3, 1, ZZ(2)) == 5
+    @test GAPExt._find_discriminant_bound(4, 2, ZZ(2)) == 5
+  end
+
   println("Quadratic Fields")
   @time begin
     @testset "Quadratic Fields" begin


### PR DESCRIPTION
## Summary

- import the number-field helpers used by fixed-field extraction
- select the actual subgroup-conjugacy-class position when deriving a discriminant bound
- use a floor integer root because the value is a bound, not necessarily an exact power
- qualify the Hecke field enumerator and replace unconditional debug output with verbosity
- select a core-free subgroup class by the exact transitive coset-action label before extracting a stem

The same abstract group can have several core-free subgroup classes of the requested index with different transitive labels. Taking the first class can therefore return the wrong stem. `SmallGroup(24, 12)` already exhibits this with its degree-six actions `6T7` and `6T8`.

The application-specific bounded discovery entrypoint from the local fork is deliberately not included.

## Test

Focused GAP extension checks cover:

- the non-exact regular `3T1` Frobenius bound
- `4T2`, whose matching subgroup-class position differs from its transitive label
- exact selection of both `6T7` and `6T8`

The checks pass in a dedicated Hecke+GAP environment and are placed in the existing long FieldFactory suite.