### PR TITLE
fix: identify the complete absolute Galois group

### DIFF
--- a/src/FieldFactory/ab_exts.jl
+++ b/src/FieldFactory/ab_exts.jl
@@ -203,9 +203,9 @@ function abelian_normal_extensions(K::AbsSimpleNumField, gtype::Vector{Int}, abs
           end
         end
         if absolute_galois_group != (0, 0)
-          autabs = absolute_automorphism_group(C, gs)
+          autabs = closure(absolute_automorphism_group(C, gs), *)
           G = generic_group(autabs, *)[1]
-          id_G = find_small_group(G)
+          id_G = find_small_group(G)[1]
           if id_G == absolute_galois_group
             @vprintln :AbExt 1 "New Field"
             push!(fields, C)

--- a/test/FieldFactory/FieldFactory.jl
+++ b/test/FieldFactory/FieldFactory.jl
@@ -1,5 +1,18 @@
 @testset "FieldFactory" begin
 
+  @testset "Absolute Galois group filtering" begin
+    Qx, x = QQ[:x]
+    K, = number_field(x^2 - x - 1, :a; cached = false)
+    ab = abelian_normal_extensions(
+      K,
+      [2],
+      ZZ(125);
+      only_complex = true,
+      absolute_galois_group = (4, 1),
+    )
+    @test length(ab) == 1
+  end
+
   println("Quadratic Fields")
   @time begin
     @testset "Quadratic Fields" begin


### PR DESCRIPTION
## Summary

- close the generators returned by `absolute_automorphism_group` before constructing a multiplication-table group
- compare the identifier component returned by `find_small_group` with `absolute_galois_group`
- cover a quadratic base whose accepted quadratic extension has absolute group `(4, 1)`

The filter previously passed a generating set where `generic_group` requires a closed set, and then compared the full three-component `find_small_group` result with a two-component SmallGroup identifier.

## Test

The focused arithmetic regression passes for `Q(sqrt(5))`, a quadratic extension, discriminant bound 125, and requested absolute group `(4, 1)`. It is placed in the existing long FieldFactory suite because reaching the filter requires real ray-class enumeration.