### PR TITLE
fix: clear rational local norm denominators correctly

### DIFF
--- a/src/LocalField/neq.jl
+++ b/src/LocalField/neq.jl
@@ -1479,7 +1479,7 @@ function is_local_norm(k::Hecke.AbsSimpleNumField, a::Integer)
 end
 
 function is_local_norm(k::Hecke.AbsSimpleNumField, a::QQFieldElem)
-  return is_local_norm(k, numerator(a)*denominator(a)^degree(k))
+  return is_local_norm(k, numerator(a)*denominator(a)^(degree(k) - 1))
 end
 
 function is_local_norm(k::Hecke.AbsSimpleNumField, a::Rational)

--- a/test/LocalField/neq.jl
+++ b/test/LocalField/neq.jl
@@ -152,5 +152,13 @@ end
 
   K, b = radical_extension(2, a+1)
   @test is_local_norm(K, norm(b+a)) == true
+
+  gaussian, _ = quadratic_field(-1)
+  @test !is_local_norm(gaussian, QQ(1//3))
+  @test is_local_norm(gaussian, QQ(1//9))
+
+  cyclotomic_quartic, _ = cyclotomic_field(5)
+  @test !is_local_norm(cyclotomic_quartic, QQ(1//3))
+  @test is_local_norm(cyclotomic_quartic, QQ(1//81))
 end
 


### PR DESCRIPTION
## Summary

- clear the denominator of a rational local-norm query by multiplying by the norm of the denominator
- add quadratic and quartic regression tests for rational norms and non-norms

## Rationale

For `a = n/d` and `[K : QQ] = m`, multiplication by the norm of the embedded rational scalar `d` preserves the norm class:

```
a * N_{K/QQ}(d) = (n/d) * d^m = n * d^(m - 1).
```

The previous exponent `m` therefore changed the queried norm class instead of merely clearing the denominator.

## Testing

```
julia --startup-file=no --project=. -e 'using Test, Hecke; include("test/setup.jl"); include("test/LocalField/neq.jl")'\n```\n\nAll LocalField tests passed; the `LocalNorm` testset passed 6/6.