### PR TITLE
RFC implementation: expose quadratic Kummer generators

### DIFF
--- a/src/RCF/rcf.jl
+++ b/src/RCF/rcf.jl
@@ -104,6 +104,35 @@ function ray_class_field_cyclic_pp(CFpp::ClassField_pp; using_stark_units::Bool 
   return CFpp
 end
 
+@doc raw"""
+    quadratic_kummer_generator(C::ClassField) -> FacElem
+
+Return a factored Kummer generator for the formal quadratic class field `C`,
+reduced modulo squares. This does not materialize the relative class field.
+"""
+function quadratic_kummer_generator(CF::ClassField{S, T}) where {S, T}
+  degree(CF) == 2 || throw(ArgumentError(
+    "Kummer generator extraction requires a quadratic class field"))
+
+  CFpp = ClassField_pp{S, T}()
+  CFpp.rayclassgroupmap = CF.rayclassgroupmap
+  CFpp.quotientmap = CF.quotientmap
+  _rcf_S_units(CFpp)
+  _rcf_find_kummer(CFpp)
+
+  isdefined(CFpp, :o) && CFpp.o == 2 || error(
+    "failed to find a quadratic Kummer generator")
+  isdefined(CFpp, :defect) && isone(CFpp.defect) || error(
+    "quadratic Kummer generator has a descent defect")
+  isdefined(CFpp, :sup_known) && CFpp.sup_known || error(
+    "support of the quadratic Kummer generator is not known")
+
+  a = reduce_mod_powers(CFpp.a, 2, CFpp.sup)
+  base_ring(a) === base_field(CF) || error(
+    "quadratic Kummer generator is not defined over the class field base")
+  return a
+end
+
 ################################################################################
 #
 #  Using norm relations to get the S-units

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -809,6 +809,7 @@ export push!
 export push_through_isogeny
 export quadratic_defect
 export quadratic_field
+export quadratic_kummer_generator
 export quadratic_lattice
 export quadratic_product
 export quadratic_space

--- a/test/RCF/rcf.jl
+++ b/test/RCF/rcf.jl
@@ -3,6 +3,30 @@
   k, a = number_field(x - 1, "a")
   Z = maximal_order(k)
 
+  @testset "quadratic Kummer generator" begin
+    R, mR = ray_class_group(5 * Z, real_places(k), n_quo = 2)
+    quotients = collect(index_p_subgroups(
+      R, ZZRingElem(2), (A, H) -> quo(A, H)[2]))
+    C = ray_class_field(mR, only(quotients))
+
+    @test !isdefined(C, :A)
+    @test !isdefined(C, :cyc)
+    generator = quadratic_kummer_generator(C)
+    @test base_ring(generator) === k
+    @test !is_square(evaluate(generator))
+    @test !isdefined(C, :A)
+    @test !isdefined(C, :cyc)
+
+    extension = kummer_extension(2, [generator])
+    for q in (3, 7, 11, 13, 17, 19)
+      P = first(prime_decomposition(Z, q))[1]
+      artin_image = C.quotientmap(preimage(C.rayclassgroupmap, P))
+      expected = mod(Int(artin_image[1]), 2)
+      observed = mod(Int(Hecke.canonical_frobenius(P, extension)[1]), 2)
+      @test observed == expected
+    end
+  end
+
   function doit(u::AbstractUnitRange, p::Int = 3)
     cnt = 0
     for i in u


### PR DESCRIPTION
## Design status

Draft implementation for #2340. The issue is the API/design discussion; this PR is intentionally draft until the public name, return shape, and caching policy are agreed.

## Summary

- add `quadratic_kummer_generator(C::ClassField) -> FacElem`
- reuse the existing S-unit and inverse-Kummer computations
- reduce the result modulo squares and stop before `radical_extension` and descent
- keep the formal `ClassField` unmaterialized
- verify the returned Kummer character against the defining Artin quotient

The implementation does not introduce a result wrapper, duplicate the ray class maps, or add a second Frobenius API.

## Mathematical contract

For a formal degree-two class field `C` over `K`, the returned factored element `a` lies in `K` and `K(sqrt(a))/K` realizes the Artin quotient encoded by `C`.

The test compares

```julia
C.quotientmap(preimage(C.rayclassgroupmap, P))
```

with `canonical_frobenius(P, kummer_extension(2, [a]))` at six admissible primes.

## Local verification

The focused quadratic Kummer testset passes 12/12 under Julia 1.12.7. It checks that `C.A` and `C.cyc` remain undefined before and after extraction, that the returned element is a nonsquare over the base field, and that all six Frobenius comparisons agree.

Closes #2340
