### PR TITLE
fix: resolve unbound type parameters flagged by Aqua on Julia nightly

### DIFF
--- a/src/AlgAss/AbsAlgAss.jl
+++ b/src/AlgAss/AbsAlgAss.jl
@@ -107,7 +107,7 @@ center(A::AbstractAssociativeAlgebra)
 #
 ################################################################################
 
-morphism_type(::Type{T}, ::Type{S}) where {R, T <: AbstractAssociativeAlgebra{R}, S <: AbstractAssociativeAlgebra{R}} = AbsAlgAssMor{T, S, Generic.MatSpaceElem{R}}
+morphism_type(::Type{T}, ::Type{S}) where {T <: AbstractAssociativeAlgebra, S <: AbstractAssociativeAlgebra} = AbsAlgAssMor{T, S, Generic.MatSpaceElem{elem_type(base_ring_type(T))}}
 
 morphism_type(::Type{T}, ::Type{S}) where {T <: AbstractAssociativeAlgebra{QQFieldElem}, S <: AbstractAssociativeAlgebra{QQFieldElem}} = AbsAlgAssMor{T, S, QQMatrix}
 

--- a/src/AlgAss/AlgCyc.jl
+++ b/src/AlgAss/AlgCyc.jl
@@ -61,6 +61,8 @@ function base_ring(
   return base_ring(c.sca)::parent_type(T)
 end
 
+base_ring_type(::Type{CyclicAlgebra{T, S}}) where {T, S} = parent_type(T)
+
 """Return the cyclic algebra as a structure constant algebra."""
 function structure_constant_algebra(
   c::CyclicAlgebra{T, S},

--- a/src/AlgAss/Elem.jl
+++ b/src/AlgAss/Elem.jl
@@ -8,7 +8,8 @@ _is_sparse(a::AbstractAssociativeAlgebraElem) = _is_sparse(parent(a))
 
 _is_dense(a::AbstractAssociativeAlgebraElem) = _is_dense(parent(a))
 
-function AbstractAlgebra.promote_rule(U::Type{<:AbstractAssociativeAlgebraElem{T}}, ::Type{S}) where {T, S}
+function AbstractAlgebra.promote_rule(U::Type{<:AbstractAssociativeAlgebraElem}, ::Type{S}) where {S}
+  T = elem_type(base_ring_type(parent_type(U)))
   if AbstractAlgebra.promote_rule(T, S) === T
     return U
   else

--- a/src/AlgAssAbsOrd/Order.jl
+++ b/src/AlgAssAbsOrd/Order.jl
@@ -10,7 +10,10 @@ algebra_type(::Type{AlgAssAbsOrd{T, S}}) where {S, T} = T
 
 order_type(::Type{T}) where {T <: AbstractAssociativeAlgebra{QQFieldElem}} = AlgAssAbsOrd{T, ZZRing}
 
-order_type(::Type{T}) where {S <: NumFieldElem, T <: AbstractAssociativeAlgebra{S}} = AlgAssRelOrd{S, fractional_ideal_type(order_type(parent_type(S))), T}
+function order_type(::Type{T}) where {T <: AbstractAssociativeAlgebra}
+  S = elem_type(base_ring_type(T))
+  return AlgAssRelOrd{S, fractional_ideal_type(order_type(parent_type(S))), T}
+end
 
 order_type(::Type{T}, ::Type{ZZRing}) where {T <: AbstractAssociativeAlgebra{QQFieldElem}} = AlgAssAbsOrd{T, ZZRing}
 

--- a/src/GrpAb/ChainComplex.jl
+++ b/src/GrpAb/ChainComplex.jl
@@ -107,7 +107,8 @@ at the end, the last object is the codomain of the last map...
   complete  ::Bool
   fill     #::Function: fill(C, i) creates the i-th map
 
-  function ComplexOfMorphisms(A::S; check::Bool = true, typ:: Symbol = :chain, seed::Int = 0) where {S <:Vector{<:Map{<:T, <:T}}} where {T}
+  function ComplexOfMorphisms(A::S; check::Bool = true, typ:: Symbol = :chain, seed::Int = 0) where {S <: Vector{<:Map}}
+    T = mapreduce(m -> typejoin(typeof(domain(m)), typeof(codomain(m))), typejoin, A)
     return ComplexOfMorphisms(T, A, check = check, typ = typ, seed = seed)
   end
 

--- a/src/Misc/nmod_poly.jl
+++ b/src/Misc/nmod_poly.jl
@@ -4,18 +4,19 @@
 #
 ################################################################################
 @doc raw"""
-    resultant_ideal(f::PolyRingElem{T}, g::PolyRingElem{T}) where T <: ResElem{S} where S <: IntegerUnion -> T
+    resultant_ideal(f::PolyRingElem{T}, g::PolyRingElem{T}) where T <: ResElem{<:IntegerUnion} -> T
 
 A generator for the ideal of the resultant of $f$ and $g$ using a quadratic-time algorithm.
 One of the two polynomials must be monic.
 """
-function resultant_ideal(f::PolyRingElem{T}, g::PolyRingElem{T}) where T <: ResElem{S} where S <: IntegerUnion
+function resultant_ideal(f::PolyRingElem{T}, g::PolyRingElem{T}) where T <: ResElem{<:IntegerUnion}
   #The algorithm is the same as the resultant. We assume that one fo the 2 polynomials is monic. Under this assumption, at every
   #step the same is true and we can discard the unit obtained from the fun_factor function
   Nemo.check_parent(f, g)
   @assert typeof(f) == typeof(g)
   Rt = parent(f)
   R = base_ring(Rt)
+  S = typeof(modulus(R))
   m = ZZRingElem(modulus(R))
 
   #easy = is_prime_power(m)
@@ -132,13 +133,14 @@ function resultant_ideal(f::PolyRingElem{T}, g::PolyRingElem{T}) where T <: ResE
 end
 
 
-function resultant_ideal_pp(f::PolyRingElem{T}, g::PolyRingElem{T}) where T <: ResElem{S} where S <: IntegerUnion
+function resultant_ideal_pp(f::PolyRingElem{T}, g::PolyRingElem{T}) where T <: ResElem{<:IntegerUnion}
   #The algorithm is the same as the resultant. We assume that one fo the 2 polynomials is monic. Under this assumption, at every
   #step the same is true and we can discard the unit obtained from the fun_factor function
   Nemo.check_parent(f, g)
   @assert typeof(f) == typeof(g)
   Rt = parent(f)
   R = base_ring(Rt)
+  S = typeof(modulus(R))
   #pn = ZZRingElem(modulus(R))
   pn = modulus(R)
 
@@ -379,11 +381,12 @@ end
 # rres(f, g) = rres(g, f)
 # rres(uf, g) = rres(f, g)
 # rres(pf, g) mod p^n = p*(rres(f, g) mod p^(n-1)) (under right hypotheses)
-function rres_sircana(f1::PolyRingElem{T}, g1::PolyRingElem{T}) where T <: ResElem{S} where S <: IntegerUnion
+function rres_sircana(f1::PolyRingElem{T}, g1::PolyRingElem{T}) where T <: ResElem{<:IntegerUnion}
   Nemo.check_parent(f1, g1)
   @assert typeof(f1) == typeof(g1)
   Rt = parent(f1)
   R = base_ring(Rt)
+  S = typeof(modulus(R))
   m = ZZRingElem(modulus(R))
   #easy = is_prime_power(m)
   #if easy
@@ -552,11 +555,12 @@ function rresx_sircana_pp(f::PolyRingElem{T}, g::PolyRingElem{T}) where T <: Res
 end
 
 
-function _rresx_sircana(f::PolyRingElem{T}, g::PolyRingElem{T}) where T <: ResElem{S} where S <: IntegerUnion
+function _rresx_sircana(f::PolyRingElem{T}, g::PolyRingElem{T}) where T <: ResElem{<:IntegerUnion}
   Nemo.check_parent(f, g)
 
   Rt = parent(f)
   R = base_ring(Rt)
+  S = typeof(modulus(R))
   Zx = polynomial_ring(ZZ, "x", cached = false)[1]
   m = ZZRingElem(modulus(R))
   #easy = is_prime_power(m)
@@ -872,15 +876,16 @@ end
 ################################################################################
 
 @doc raw"""
-    resultant_sircana(f::PolyRingElem{T}, g::PolyRingElem{T}) where T <: ResElem{S} where S <: IntegerUnion -> T
+    resultant_sircana(f::PolyRingElem{T}, g::PolyRingElem{T}) where T <: ResElem{<:IntegerUnion} -> T
 
 The resultant of $f$ and $g$ using a quadratic-time algorithm.
 """
-function resultant_sircana(f::PolyRingElem{T}, g::PolyRingElem{T}) where T <: ResElem{S} where S <: IntegerUnion
+function resultant_sircana(f::PolyRingElem{T}, g::PolyRingElem{T}) where T <: ResElem{<:IntegerUnion}
   Nemo.check_parent(f, g)
   @assert typeof(f) == typeof(g)
   Rt = parent(f)
   R = base_ring(Rt)
+  S = typeof(modulus(R))
   m = ZZRingElem(modulus(R))
   e, p = is_perfect_power_with_data(m)
   easy = is_prime(p)

--- a/src/NumFieldOrd/NfRelOrd/NfRelOrd.jl
+++ b/src/NumFieldOrd/NfRelOrd/NfRelOrd.jl
@@ -462,7 +462,8 @@ function order(L::RelNonSimpleNumField{AbsSimpleNumFieldElem}, M::Generic.Mat{Ab
 end
 
 
-function order(L::NumField{S}, M::Generic.Mat{S}) where S <: NumFieldElem{T} where T
+function order(L::NumField{S}, M::Generic.Mat{S}) where {S <: NumFieldElem}
+  T = elem_type(base_field(L))
   return RelNumFieldOrder{S, RelNumFieldOrderFractionalIdeal{T}, elem_type(L)}(L, deepcopy(M))
 end
 

--- a/src/QuadForm/Enumeration.jl
+++ b/src/QuadForm/Enumeration.jl
@@ -36,10 +36,11 @@ function _pseudo_cholesky(G::ZZMatrix, ::Type{Matrix{QQFieldElem}})
   return __pseudo_cholesky!(C, G)
 end
 
-function _pseudo_cholesky(G::ZZMatrix, ::Type{Matrix{S}}) where {T, S <: Union{Rational{T}, UnsafeRational{T}}}
+function _pseudo_cholesky(G::ZZMatrix, ::Type{Matrix{S}}) where {S <: Union{Rational, UnsafeRational}}
   n = ncols(G)
   z = Matrix{S}(undef, n, n)
   C = _pseudo_cholesky(G, Matrix{QQFieldElem})
+  T = fieldtype(S, 1)
   for i in 1:n
     for j in 1:n
       z[i, j] = S(T(numerator(C[i, j])), T(denominator(C[i, j])))


### PR DESCRIPTION
## Summary

- remove type parameters that occur only in the upper bound of another `where` parameter and are read in the method body
- recover the required types at runtime instead: `S = typeof(modulus(R))` in `src/Misc/nmod_poly.jl`, `T = fieldtype(S, 1)` in `_pseudo_cholesky`, `elem_type(base_ring_type(...))` in `morphism_type`/`order_type`/`promote_rule`, `typejoin` over domain/codomain types in `ComplexOfMorphisms`, and `elem_type(base_field(L))` in `order(L, M)`
- add the missing `base_ring_type` method for `CyclicAlgebra`
- update the two docstrings in `nmod_poly.jl` that showed the old signatures

## Rationale

Julia 1.14 (current nightly) ships a rewritten, more precise `Test.detect_unbound_args`, which Aqua's `test_unbound_args` uses: it now reports methods where some matching call cannot pin a static parameter to a definite value and the parameter is read in the body. This flags 11 methods on master and currently fails the `test (nightly, ubuntu-latest, false)` CI job for every PR:

```
rres_sircana, resultant_sircana, _rresx_sircana, resultant_ideal,
resultant_ideal_pp (src/Misc/nmod_poly.jl)
_pseudo_cholesky (src/QuadForm/Enumeration.jl)
morphism_type (src/AlgAss/AbsAlgAss.jl)
promote_rule (src/AlgAss/Elem.jl)
order_type (src/AlgAssAbsOrd/Order.jl)
ComplexOfMorphisms (src/GrpAb/ChainComplex.jl)
order (src/NumFieldOrd/NfRelOrd/NfRelOrd.jl)
```

Dispatch semantics are unchanged: the removed parameters did not constrain dispatch beyond what the argument types already express.

## Testing

On Julia nightly (`1.14.0-DEV`):

```
# master
Test.detect_unbound_args(Hecke, recursive=true)  # 11 methods
# this PR
Test.detect_unbound_args(Hecke, recursive=true)  # 0 methods
```

The changed code paths were also exercised functionally under Julia 1.12.7 (resultants over `ZZ/nZ`, `_pseudo_cholesky` with `Rational{Int128}`/`UnsafeRational{Int128}`, chain complexes of abelian groups, relative orders, `promote_rule` on algebra element types, `morphism_type`/`order_type`), with results identical to master.
