### PR TITLE
fix: reject virtual classes with negative signature in `_is_valid`

### DIFF
--- a/src/QuadForm/Quad/Spaces.jl
+++ b/src/QuadForm/Quad/Spaces.jl
@@ -2457,6 +2457,11 @@ end
 function _is_valid(q::QuadSpaceCls{K}) where {K}
   q.dim >= q.dim_rad >= 0 || return false
 
+  # Subtraction of classes produces virtual classes, whose signature tuples may
+  # have negative entries. No quadratic space has a negative number of positive
+  # (resp. negative) squares at a real place, so such a class is not valid.
+  all(all(>=(0), s) for s in values(q.signature_tuples)) || return false
+
   @hassert :Lattice 1 !iszero(q.det)
   dim = q.dim - q.dim_rad
   neg_hasse = [p for p in keys(q.LGS) if hasse_invariant(q.LGS[p])==-1]

--- a/test/QuadForm/Quad/Spaces.jl
+++ b/test/QuadForm/Quad/Spaces.jl
@@ -511,6 +511,24 @@
     @test represents(q, 0)
     @test !is_isotropic(q)
 
+    # A definite space is anisotropic and represents only values of the sign of
+    # its own definiteness. Subtracting a hyperbolic plane (resp. a square class)
+    # from a definite class yields a virtual class with a negative entry in its
+    # signature tuple, which must not be mistaken for the class of a space.
+    for n in 1:8
+      qpos = quadratic_space(QQ, identity_matrix(QQ, n))
+      qneg = quadratic_space(QQ, -identity_matrix(QQ, n))
+      @test !is_isotropic(qpos)
+      @test !is_isotropic(qneg)
+      @test represents(qpos, 1)
+      @test !represents(qpos, -1)
+      @test represents(qneg, -1)
+      @test !represents(qneg, 1)
+    end
+    q = quadratic_space(QQ, diagonal_matrix(QQFieldElem[-5, -3, -2, -5]))
+    @test !is_isotropic(q)
+    @test !represents(q, 1)
+
     for i in 1:100
       for r in 1:4
         I = [i for i in -20:20 if i!=0]


### PR DESCRIPTION
`is_isotropic(q::QuadSpace)` decides isotropy by asking whether the isometry class of `q` represents a hyperbolic plane, and `represents` tests `_is_valid(g1 - g2)`. Subtraction of isometry classes deliberately produces *virtual* classes whose signature tuples may have negative entries (the `@req all(x >= 0 for x in t)` in `-` is commented out for exactly that reason), but `_is_valid` never checked for it. For a definite space the difference has a negative number of positive (resp. negative) squares while still passing the determinant and Hasse conditions, so it was accepted as the class of an actual space.

Consequently every negative definite rational space of rank >= 5 was reported isotropic, and `represents` claimed that a negative definite space of rank >= 4 represents positive numbers.

```julia
julia> V = quadratic_space(QQ, -identity_matrix(QQ, 5));

julia> is_negative_definite(V)
true

julia> is_isotropic(V)          # must be false
true

julia> represents(quadratic_space(QQ, -identity_matrix(QQ, 4)), 1)   # must be false
true
```

The positive definite side answered correctly, which is why this went unnoticed.

Root cause, for the record:

```julia
julia> G1 = Hecke.isometry_class(quadratic_space(QQ, -identity_matrix(QQ, 5)));

julia> H  = Hecke.isometry_class(quadratic_space(QQ, QQ[0 1; 1 0]));

julia> Hecke.signature_tuples(G1 - H)
Dict{Union{PosInf, InfPlc}, Tuple{Int64, Int64, Int64}} with 1 entry:
  infinity => (-1, 0, 4)

julia> Hecke._is_valid(G1 - H)
true
```

**The fix** rejects a class whose signature tuple has a negative entry.

**Testing.** Checked `is_isotropic` against Hasse-Minkowski (isotropic over `R` and over every `Q_p`, computed through the independent `is_isotropic(V, p)` code path) on 400 random rational diagonal spaces of rank up to 6: no disagreements. `test/QuadForm/Quad/Spaces.jl` passes, and the new tests cover definite spaces of rank 1 to 8 over `QQ`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)