### PR TITLE
fix: choose a large enough complement in `_isotropic_subspace`

### DIFF
--- a/src/QuadForm/Quad/Spaces.jl
+++ b/src/QuadForm/Quad/Spaces.jl
@@ -1249,8 +1249,9 @@ function _isotropic_subspace(q::QuadSpace{QQField, QQMatrix})
     q1 = quadratic_space(QQ, G; cached=false)
     @hassert :Lattice 1 is_regular(q1)
     ok, v = _isotropic_subspace(q1)
-    @hassert :Lattice 0 ok
-    v = vcat(B, v*C)
+    # The radical is totally isotropic on its own, so `q` is isotropic even when
+    # its non-degenerate part `q1` is not.
+    v = ok ? vcat(B, v*C) : B
     return true, v
   end
   # create an even lattice in some rescaling of q
@@ -1286,11 +1287,18 @@ function _isotropic_subspace(q::QuadSpace{QQField, QQMatrix})
   D = rescale(discriminant_group(M),-1; cached=false)
   (p,_,n) = signature_tuple(q)
   a = p - n
-  if a == 0 && !is_trivial(D.ab_grp)
-    s = (1, 1)
-  else
-    s = (0, a)
+  # We need a lattice R with discriminant form D, glued to M along the whole of
+  # D, and such that M + R has a balanced signature; the latter forces the
+  # signature pair of R to be of the shape (r, r + a). Milgram's formula holds
+  # for every such r, but r must be big enough for D to be the discriminant form
+  # of a lattice of rank 2*r + a. The minimal choice r = 0 is in general too
+  # small: D may need more generators than that.
+  r = 0
+  while !is_genus(D, (r, r + a))
+    r += 1
+    @req r <= ngens(D) + 2 "no lattice with discriminant form D and signature ($r, $(r + a))"
   end
+  s = (r, r + a)
   R = representative(genus(D, s))
   LL, inj = direct_sum(M, R; cached=false)
   MM = maximal_even_lattice(LL)

--- a/test/QuadForm/Quad/Spaces.jl
+++ b/test/QuadForm/Quad/Spaces.jl
@@ -368,6 +368,31 @@
     @test ok
     @test iszero(inner_product(q, v,v))
 
+    # the complementary lattice used to embed into a sum of hyperbolic planes
+    # must be big enough to carry the discriminant form
+    for d in Vector{QQFieldElem}[QQFieldElem[-3, -3, -1, 1, 1],
+                                 QQFieldElem[-6, -6, -1, 10, 2],
+                                 QQFieldElem[2, 2, 1, -5, -7],
+                                 QQFieldElem[3, -2, 5, -1, -1, 3],
+                                 QQFieldElem[-5, -3, -2, 7]]
+      q = quadratic_space(QQ, diagonal_matrix(d))
+      @test is_isotropic(q)
+      ok, v = is_isotropic_with_vector(q)
+      @test ok
+      @test any(!iszero, v)
+      @test iszero(inner_product(q, v, v))
+    end
+
+    # a degenerate space whose non-degenerate part is anisotropic: the isotropic
+    # vectors all live in the radical
+    for g in [QQ[-2//3 0; 0 0], QQ[2 0 0; 0 3 0; 0 0 0], QQ[-1 0 0; 0 -1 0; 0 0 0]]
+      q = quadratic_space(QQ, g)
+      ok, v = is_isotropic_with_vector(q)
+      @test ok
+      @test any(!iszero, v)
+      @test iszero(inner_product(q, v, v))
+    end
+
   #  too long even for a long test
   #   if long_test
   #     K,b = cyclotomic_field(16)


### PR DESCRIPTION
`_isotropic_subspace` produces an isotropic vector of a rational quadratic space `q` by embedding a maximal even lattice `M` in a rescaling of `q` into a sum of hyperbolic planes. That needs a lattice `R` whose discriminant form is the rescaled discriminant form `D` of `M`, with a signature pair of the shape `(r, r + a)` where `a = p - n`, so that `M + R` has a balanced signature.

The code hard-coded the minimal choice `r = 0`, with an ad hoc `r = 1` when `a == 0` and `D` is non-trivial. That rank is in general too small for `D`: no genus of rank `a` can carry a discriminant form needing more than `a` generators.

```julia
julia> V = quadratic_space(QQ, diagonal_matrix(QQ.([-3, -3, -1, 1, 1])));

julia> Hecke.signature_tuple(V)      # indefinite of rank 5, so isotropic
(2, 0, 3)

julia> is_isotropic(V)
true

julia> is_isotropic_with_vector(V)
ERROR: ArgumentError: This discriminant form and pair of signatures do not define a genus
```

Here `M` has Gram matrix `[2 1 0 0 0; 1 2 0 0 0; 0 0 -2 0 0; 0 0 0 -2 0; 0 0 0 0 6]` and `D` is `Z/2 x (Z/6)^2`, needing three generators, while `s` was `(0, 1)`. A second failure mode of the same line: when `a < 0`, `s = (0, a)` has a negative entry outright.

**The fix.** Milgram's formula holds for every `r` of this shape, so take the smallest `r` for which the genus exists. This reproduces the previous `a == 0` special case exactly. The dimension count that guarantees `M` meets the maximal isotropic subspace non-trivially needs `rank(R) < rank(M)`, i.e. `r < n`, and that held on every input tested.

**Also in this PR** (found while verifying the above): the degenerate branch asserted that the non-degenerate part of `q` is isotropic, which is false whenever `q` is isotropic only because of its radical.

```julia
julia> is_isotropic_with_vector(quadratic_space(QQ, QQ[-2//3 0; 0 0]))
ERROR: AssertionError: ok
```

The radical is totally isotropic on its own, so it is returned in that case.

**Testing.** Over all sorted diagonals with entries in `-3..3` of rank 3 to 6 that are indefinite and isotropic (728 spaces), plus 250 random ones of rank up to 7 and 151 random non-diagonal symmetric forms, `is_isotropic_with_vector` now returns a genuine non-zero isotropic vector on every input; before, it raised on 12 of them. `test/QuadForm/Quad/Spaces.jl` passes.

**Not addressed here:** `is_isotropic(q)` still raises `Matrix is not of full rank` for a degenerate *non-diagonal* Gram matrix such as `QQ[1 1; 1 1]`, because `__compute_isometry_class__` calls `_gram_schmidt` with `nondeg = true`. That is a separate issue in a different function.


🤖 Generated with [Claude Code](https://claude.com/claude-code)