### PR TITLE
fix: do not negate the Gram matrix of the input in `short_vectors_affine`

### DIFF
--- a/src/QuadForm/IntegerLattices/ShortVectors.jl
+++ b/src/QuadForm/IntegerLattices/ShortVectors.jl
@@ -502,8 +502,8 @@ function short_vectors_affine(
   if n > 1
     sol = _short_vectors_affine(gram, v_S, _alpha, _d)
   else
-    map_entries!(-, gram, gram)
-    sol = _short_vectors_affine(gram, v_S, -_alpha, -_d)
+    # `gram` is the cached Gram matrix of `S`, so it must not be negated in place
+    sol = _short_vectors_affine(-gram, v_S, -_alpha, -_d)
   end
   B = basis_matrix(S)
   return QQMatrix[s*B for s in sol]
@@ -622,8 +622,8 @@ function short_vectors_affine_iterator(
   if n > 1
     sol = _short_vectors_affine_iterator(gram, v_S, _alpha, _d)
   else
-    map_entries!(-, gram, gram)
-    sol = _short_vectors_affine_iterator(gram, v_S, -_alpha, -_d)
+    # `gram` is the cached Gram matrix of `S`, so it must not be negated in place
+    sol = _short_vectors_affine_iterator(-gram, v_S, -_alpha, -_d)
   end
   B = basis_matrix(S)
   elem_type = typeof(v)
@@ -688,7 +688,7 @@ struct ShortVectorsAffineIterator{S, elem_type}
 end
 
 Base.IteratorSize(::Type{<:ShortVectorsAffineIterator}) = Base.SizeUnknown()
-Base.eltype(::Type{ShortVectorsAffineIterator{X, elem_type}}) where {X, elem_type} = Tuple{Vector{elem_type}}
+Base.eltype(::Type{ShortVectorsAffineIterator{X, elem_type}}) where {X, elem_type} = elem_type
 
 function Base.iterate(C::ShortVectorsAffineIterator{X, elem_type}, start = nothing) where {X, elem_type}
   if start === nothing
@@ -716,7 +716,7 @@ end
 
 
 Base.IteratorSize(::Type{<:ShortVectorsAffineLatIterator}) = Base.SizeUnknown()
-Base.eltype(::Type{ShortVectorsAffineLatIterator{X, elem_type}}) where {X, elem_type} = Tuple{Vector{elem_type}}
+Base.eltype(::Type{ShortVectorsAffineLatIterator{X, elem_type}}) where {X, elem_type} = elem_type
 
 function Base.iterate(C::ShortVectorsAffineLatIterator{X, elem_type}, start = nothing) where {X, elem_type}
   if start === nothing

--- a/test/QuadForm/ShortVectors.jl
+++ b/test/QuadForm/ShortVectors.jl
@@ -136,6 +136,37 @@ end
   @test all(w -> w*G*vT == -2, sva)
 end
 
+@testset "Short vectors affine leaves the lattice untouched" begin
+  # For a lattice with at most one negative square the form is negated
+  # internally. That must not touch the cached Gram matrix of the lattice.
+  A2 = root_lattice(:A, 2)
+  G = deepcopy(gram_matrix(A2))
+  v = matrix(QQ, 1, 2, [1, 0])
+  sva = short_vectors_affine(A2, v, QQ(1), QQ(2))
+  @test gram_matrix(A2) == G
+  @test is_positive_definite(A2)
+  @test length(sva) == 2
+  @test all(w -> (w*G*transpose(w))[1, 1] == 2, sva)
+  @test all(w -> (w*G*transpose(v))[1, 1] == 1, sva)
+
+  svi = collect(short_vectors_affine_iterator(A2, v, QQ(1), QQ(2)))
+  @test gram_matrix(A2) == G
+  @test Set(svi) == Set(sva)
+
+  @test eltype(short_vectors_affine_iterator(A2, v, QQ(1), QQ(2))) == QQMatrix
+  @test eltype(short_vectors_affine_iterator(G, v, QQ(1), QQ(2))) == QQMatrix
+
+  # hyperbolic plane: signature (1, 1), so the same branch is taken
+  U = integer_lattice(gram = QQ[0 1; 1 0])
+  GU = deepcopy(gram_matrix(U))
+  w = matrix(QQ, 1, 2, [1, 1])
+  svu = short_vectors_affine(U, w, QQ(1), QQ(0))
+  @test gram_matrix(U) == GU
+  @test length(svu) == 2
+  @test all(x -> (x*GU*transpose(x))[1, 1] == 0, svu)
+  @test all(x -> (x*GU*transpose(w))[1, 1] == 1, svu)
+end
+
 @testset "Center density" begin
   L = root_lattice(:E, 6)
   r = center_density(L)


### PR DESCRIPTION
`short_vectors_affine(S::ZZLat, ...)` and `short_vectors_affine_iterator(S::ZZLat, ...)` normalize the form of a lattice with at most one negative square by negating it. They did so with `map_entries!(-, gram, gram)` where `gram = gram_matrix(S)` — the *cached* Gram matrix of `S`. The call therefore silently replaced `S` by `S(-1)`.

```julia
julia> S = root_lattice(:A, 2);

julia> gram_matrix(S)
[ 2   -1]
[-1    2]

julia> short_vectors_affine(S, matrix(QQ, 1, 2, [1, 0]), QQ(1), QQ(2))
2-element Vector{QQMatrix}:
 [1 1]
 [0 -1]

julia> gram_matrix(S)
[-2    1]
[ 1   -2]

julia> is_positive_definite(S)
false
```

The returned vectors are correct; everything done with `S` afterwards is not. The branch is taken for every positive definite lattice, which is why the existing tests — on a lattice of signature `(1, 12)`, which takes the other branch — did not catch it.

**The fix** negates a copy.

**Also in this PR:** the `eltype` of both affine iterators claimed `Tuple{Vector{elem_type}}` while `iterate` yields a single `elem_type`, so `collect` on them raised a `MethodError`. The regression test for the aliasing bug needs `collect` on the iterator path.

**Testing.** New tests check that the Gram matrix survives the call for `A_2` and for the hyperbolic plane, on both the eager and the iterator path, and that the returned vectors satisfy `x^2 == d` and `x.v == alpha`. Separately checked against exhaustive search over `A_3` for all `alpha` in `-3..3` and `d` in `{2, 4, 6, 8}`: identical result sets. `test/QuadForm/ShortVectors.jl` passes.


🤖 Generated with [Claude Code](https://claude.com/claude-code)