### PR TITLE
fix: correct the base change returned by `lll_gram_indef_ternary_hyperbolic`

### DIFF
--- a/src/QuadForm/IntegerLattices/indefiniteLLL.jl
+++ b/src/QuadForm/IntegerLattices/indefiniteLLL.jl
@@ -335,21 +335,24 @@ end
                                                            MatElem{ZZRingElem}
 
 Given a full-rank symmetric matrix `G` with integer entries which defines the
-Gram matrix of a non-degenerate ternary hyperbolic integral quadratic form `L`,
+Gram matrix of a unimodular ternary hyperbolic integral quadratic form `L`,
 compute an LLL-reduced basis `U` of `L` and return `(G', U)` where `G'` is the
-Gram matrix of `L` with respect to `U`.
+Gram matrix of `L` with respect to `U`, that is `G' == U*G*transpose(U)`.
 
 # Examples
 ```jldoctest
 julia> G = ZZ[1 0 0; 0 4 3; 0 3 2];
 
-julia> lll_gram_indef_ternary_hyperbolic(G)
-([0 0 -1; 0 1 0; -1 0 0], [-1 -1 0; 0 0 -1; -2 -1 0])
+julia> Gr, U = lll_gram_indef_ternary_hyperbolic(G)
+([0 0 -1; 0 1 0; -1 0 0], [0 1 -2; 1 0 0; 0 1 -1])
+
+julia> U*G*transpose(U) == Gr
+true
 ```
 """
 function lll_gram_indef_ternary_hyperbolic(G::MatElem{ZZRingElem}; check::Bool = false)
 
-  @req !check || (is_symmetric(G) && ncols(G) != 3 && _check_for_lll_gram_indefinite2(change_base_ring(QQ, G))) "Input should be the Gram matrix of a non-degenerate indefinite integral form of rank 3"
+  @req !check || (is_symmetric(G) && ncols(G) == 3 && abs(det(G)) == 1 && _check_for_lll_gram_indefinite2(change_base_ring(QQ, G))) "Input should be the Gram matrix of a unimodular indefinite integral form of rank 3"
 
   e = det(G) == -1 ? 1 : -1
 
@@ -368,7 +371,9 @@ function lll_gram_indef_ternary_hyperbolic(G::MatElem{ZZRingElem}; check::Bool =
   cc = mod(G3[1,1],2)
   U3 = ZZ[1 cc round(-(G3[1,1]+cc*(2*G3[1,2]+G3[2,2]*cc))//2//G3[1,3]); 0 1 round(-(G3[1,2]+cc*G3[2,2])//G3[1,3]); 0 0 1]
 
-  return e*U3*G3*transpose(U3), red[2]*U3*U2*U1
+  # `red[2]` is applied first, then `U1`, `U2` and `U3`, so the accumulated base
+  # change is their product in this order.
+  return e*U3*G3*transpose(U3), U3*U2*U1*red[2]
 end
 
 function _check_for_lll_gram_indefinite2(A::MatElem{QQFieldElem})

--- a/test/QuadForm/indefiniteLLL.jl
+++ b/test/QuadForm/indefiniteLLL.jl
@@ -181,4 +181,24 @@ end
   gamma_H = find_gamma(change_base_ring(QQ,H))
   gamma_G = find_gamma(change_base_ring(QQ,G))
   @test gamma_H < gamma_G
+  # U must be the base change from G to H
+  @test U*G*transpose(U) == H
+  @test abs(det(U)) == 1
+  @test Hecke.lll_gram_indef_ternary_hyperbolic(G; check = true) == (H, U)
+
+  for G0 in [ZZ[1 0 0; 0 4 3; 0 3 2], ZZ[0 0 1; 0 1 0; 1 0 0],
+             ZZ[1 0 0; 0 1 0; 0 0 -1], ZZ[-1 0 0; 0 4 3; 0 3 2]]
+    for T in [ZZ[1 0 0; 1 1 0; 0 0 1], ZZ[1 2 0; 0 1 0; -1 0 1],
+              ZZ[1 0 -2; 0 1 1; 0 0 1], ZZ[1 1 1; 0 1 2; 0 0 1]]
+      GG = T*G0*transpose(T)
+      HH, UU = Hecke.lll_gram_indef_ternary_hyperbolic(GG)
+      @test UU*GG*transpose(UU) == HH
+      @test abs(det(UU)) == 1
+    end
+  end
+
+  # wrong rank, or not unimodular indefinite of signature (2, 1) or (1, 2)
+  @test_throws ArgumentError Hecke.lll_gram_indef_ternary_hyperbolic(ZZ[1 0; 0 -1]; check = true)
+  @test_throws ArgumentError Hecke.lll_gram_indef_ternary_hyperbolic(ZZ[1 0 0; 0 1 0; 0 0 1]; check = true)
+  @test_throws ArgumentError Hecke.lll_gram_indef_ternary_hyperbolic(ZZ[2 1 0; 1 2 0; 0 0 -1]; check = true)
 end


### PR DESCRIPTION
`lll_gram_indef_ternary_hyperbolic` is documented to return `(G', U)` where `G'` is the Gram matrix of the form with respect to `U`. The relation `U*G*transpose(U) == G'` did not hold for any input tested, including the matrix in its own docstring.

```julia
julia> G = ZZ[1 0 0; 0 4 3; 0 3 2];

julia> Gr, U = lll_gram_indef_ternary_hyperbolic(G)
([0 0 -1; 0 1 0; -1 0 0], [-1 -1 0; 0 0 -1; -2 -1 0])

julia> U*G*transpose(U) == Gr
false
```

The transformations are applied in the order `red[2]`, `U1`, `U2`, `U3`, so the accumulated base change is `U3*U2*U1*red[2]`; the code returned `red[2]*U3*U2*U1`. `G'` itself was always right.

Nothing caught this: the existing test only compares reducedness measures of `G'`, never the relation between `G'` and `U`, and the doctest only compares printed output.

**Also in this PR:** the `check = true` precondition read `ncols(G) != 3` and so rejected every valid input, including the docstring example. It now requires a symmetric unimodular 3x3 matrix of signature `(2, 1)` or `(1, 2)`. The determinant condition is part of the input being hyperbolic — without it the algorithm divides by `G3[1, 3] == 0` and raises a `DivideError`, e.g. for `ZZ[2 1 0; 1 2 0; 0 0 -1]` — and since `check = true` previously accepted nothing at all, no behaviour is lost by making it exact.

**Testing.** Checked on 240 unimodular conjugates of four ternary hyperbolic forms: `U*G*transpose(U) == G'` and `abs(det(U)) == 1` throughout. The docstring now states and checks the relation, and the test file asserts it. `test/QuadForm/indefiniteLLL.jl` passes.


🤖 Generated with [Claude Code](https://claude.com/claude-code)