### PR TITLE
fix: `can_solve` for binary quadratic forms missed solutions with y = 0

### DIFF
--- a/src/QuadForm/QuadBin.jl
+++ b/src/QuadForm/QuadBin.jl
@@ -158,24 +158,38 @@ end
 
 For a binary quadratic form `f` with negative discriminant and an integer `n`,
 return the tuple `(true, (x, y))` if $f(x, y) = n$ for integers `x`, `y`.
-If no such integers exist, return `(false, (0, 0))`
+If no such integers exist, return `(false, (0, 0))`.
+
+Note that $f(0, 0) = 0$, so `n == 0` is always solvable.
 """
 function can_solve_with_solution(f::QuadBin, n::IntegerUnion; sol::Bool = true)
-  @req discriminant(f) < 0 "f must have negative discriminant"
-  for y in 1:Int(floor(sqrt(Int(4*f[1]*n)//abs(Int(discriminant(f))))))
+  D = discriminant(f)
+  @req D < 0 "f must have negative discriminant"
+  a = f[1]
+  _n = ZZ(n)
+  # A definite form only represents values of the sign of its leading
+  # coefficient, so there is nothing to enumerate otherwise.
+  if sign(a) * sign(_n) < 0
+    return false, (ZZ(0), ZZ(0))
+  end
+  # From 4*a*f(x, y) = (2*a*x + f[2]*y)^2 - D*y^2 we get, for f(x, y) = n,
+  # that abs(D)*y^2 <= 4*a*n. Both signs of y give the same values of f, but
+  # y == 0 has to be looked at as well.
+  ybound = isqrt(fdiv(4 * a * _n, abs(D)))
+  for y in ZZ(0):ybound
     #now f(x,y) quadratic in one variable -> use quadratic formula
-    aq = f[1]
+    aq = a
     bq = f[2] * y
-    cq = f[3] * y^2 - n
+    cq = f[3] * y^2 - _n
     d = bq^2 - 4*aq*cq
     if is_square(d)
       if divides(-bq + sqrt(d), 2*aq)[1]
         !sol && return true, (ZZ(0), ZZ(0))
-        return true, (divexact(-bq + sqrt(d), 2*aq), ZZ(y))
+        return true, (divexact(-bq + sqrt(d), 2*aq), y)
       end
       if divides(-bq - sqrt(d), 2*aq)[1]
         !sol && return true, (ZZ(0), ZZ(0))
-        return true, (divexact(-bq - sqrt(d), 2*aq), ZZ(y))
+        return true, (divexact(-bq - sqrt(d), 2*aq), y)
       end
     end
   end

--- a/src/QuadForm/QuadBin.jl
+++ b/src/QuadForm/QuadBin.jl
@@ -172,7 +172,9 @@ function can_solve_with_solution(f::QuadBin, n::IntegerUnion; sol::Bool = true)
   if sign(a) * sign(_n) < 0
     return false, (ZZ(0), ZZ(0))
   end
-  # From 4*a*f(x, y) = (2*a*x + f[2]*y)^2 - D*y^2 we get, for f(x, y) = n,
+  # f = a x^2 + b xy + c y^2
+  # D = b^2 - 4ac
+  # From 4*a*f(x, y) = (2*a*x + b*y)^2 - D*y^2 we get, for f(x, y) = n,
   # that abs(D)*y^2 <= 4*a*n. Both signs of y give the same values of f, but
   # y == 0 has to be looked at as well.
   ybound = isqrt(fdiv(4 * a * _n, abs(D)))

--- a/test/QuadForm/QuadBin.jl
+++ b/test/QuadForm/QuadBin.jl
@@ -145,6 +145,44 @@
     @test can_solve_with_solution(binary_quadratic_form(1,1,6), 3) == (false, (0, 0))
     @test !can_solve(binary_quadratic_form(1,1,6), 5)
     @test can_solve_with_solution(binary_quadratic_form(1,1,6), 6) == (true, (0, 1))
+
+    # solutions with y == 0
+    f = binary_quadratic_form(1, 0, 5)
+    @test f(2, 0) == 4
+    @test can_solve(f, 4)
+    @test can_solve_with_solution(f, 4) == (true, (2, 0))
+    @test can_solve_with_solution(binary_quadratic_form(1, 0, 7), 9) == (true, (3, 0))
+
+    # a definite form represents nothing of the opposite sign
+    @test !can_solve(binary_quadratic_form(1, 0, 1), -1)
+    @test can_solve_with_solution(binary_quadratic_form(1, 0, 1), -1) == (false, (0, 0))
+    @test !can_solve(binary_quadratic_form(-1, 0, -1), 1)
+
+    # negative definite forms
+    @test can_solve(binary_quadratic_form(-1, 0, -1), -5)
+    let (fl, (x, y)) = can_solve_with_solution(binary_quadratic_form(-1, 0, -1), -5)
+      @test fl && binary_quadratic_form(-1, 0, -1)(x, y) == -5
+    end
+
+    # every form represents 0
+    @test can_solve_with_solution(binary_quadratic_form(1, 0, 1), 0) == (true, (0, 0))
+
+    # no overflow for large targets
+    @test can_solve_with_solution(binary_quadratic_form(1, 0, 1), ZZ(10)^30 + 1) ==
+          (true, (ZZ(10)^15, ZZ(1)))
+
+    # exhaustive check against a naive search
+    for a in -4:4, b in -4:4, c in -4:4
+      b^2 - 4*a*c < 0 || continue
+      f = binary_quadratic_form(a, b, c)
+      for n in -12:12
+        fl, (x, y) = can_solve_with_solution(f, n)
+        naive = any(f(ZZ(u), ZZ(v)) == n for u in -30:30, v in -30:30)
+        @test fl == naive
+        @test fl == can_solve(f, n)
+        fl && @test f(x, y) == n
+      end
+    end
   end
 
   @testset "PrimeForm" begin


### PR DESCRIPTION
The enumeration in `can_solve_with_solution(f::QuadBin, n)` ran `for y in 1:floor(sqrt(4*a*n/abs(D)))`, so solutions with `y == 0` were never examined.

```julia
julia> f = binary_quadratic_form(1, 0, 5)
Binary quadratic form over ZZ: x^2 + 5*y^2

julia> f(2, 0)
4

julia> can_solve(f, 4)
false
```

The bound itself is right — from `4*a*f(x, y) = (2*a*x + f[2]*y)^2 - D*y^2` one gets `abs(D)*y^2 <= 4*a*n` — but `f(x, y) == f(-x, -y)` only lets one drop the *negative* values of `y`, not `y == 0`. The loop now starts at `0`.

Two further problems on the same line:

```julia
julia> can_solve(binary_quadratic_form(1, 0, 1), -1)
ERROR: DomainError with -1.0:
sqrt was called with a negative real argument ...
```

For `n` of the sign opposite to the leading coefficient the bound is the square root of a negative rational. A definite form represents nothing of the opposite sign, so this returns `false` early now. And the `Int(...)` conversions overflowed for large arguments; the remaining arithmetic is done over `ZZ`.

**Behaviour change to note:** `can_solve(f, 0)` is now `true` with solution `(0, 0)`. That matches the docstring (`f(0, 0) = 0`) and the convention used elsewhere in Hecke that every quadratic form represents 0.

**Testing.** Compared against a naive search over all 46604 pairs of a definite form `[a, b, c]` with entries in `-6..6` and a target in `-30..30`: the results agree everywhere, and every reported solution evaluates to the target. The existing assertions in `test/QuadForm/QuadBin.jl` are unchanged and still pass; a smaller exhaustive comparison is now part of the test file.


🤖 Generated with [Claude Code](https://claude.com/claude-code)