### PR TITLE
fix: `is_reduced` threw for binary forms of square discriminant

### DIFF
--- a/src/QuadForm/QuadBin.jl
+++ b/src/QuadForm/QuadBin.jl
@@ -724,15 +724,14 @@ function is_reduced(f::QuadBin{ZZRingElem})
       return false
     end
 
-    R = ArbField(64, cached = false)
-    d = sqrt(R(D))
-    z = abs(d - 2 * abs(a))
-    @assert !contains(z, b)
-    if z < b
-      return true
-    else
-      return false
-    end
+    # The remaining condition is abs(sqrt(D) - 2*abs(a)) < b. Decide it with
+    # exact integer arithmetic: writing t = 2*abs(a), it says that b > 0, that
+    # sqrt(D) < t + b, and that sqrt(D) > t - b. For a square discriminant the
+    # two sides can be equal, in which case a ball arithmetic comparison cannot
+    # decide the inequality at any precision.
+    b <= 0 && return false
+    t = 2 * abs(a)
+    return D < (t + b)^2 && (t - b < 0 || D > (t - b)^2)
   end
 end
 

--- a/src/QuadForm/QuadBin.jl
+++ b/src/QuadForm/QuadBin.jl
@@ -731,7 +731,8 @@ function is_reduced(f::QuadBin{ZZRingElem})
     # decide the inequality at any precision.
     b <= 0 && return false
     t = 2 * abs(a)
-    return D < (t + b)^2 && (t - b < 0 || D > (t - b)^2)
+    return (t^2 < D <= (b+t)^2) || ((t-b)^2 < D < t^2)
+    # return D < (t + b)^2 && (t - b < 0 || D > (t - b)^2)
   end
 end
 

--- a/src/QuadForm/QuadBin.jl
+++ b/src/QuadForm/QuadBin.jl
@@ -726,9 +726,7 @@ function is_reduced(f::QuadBin{ZZRingElem})
 
     # The remaining condition is abs(sqrt(D) - 2*abs(a)) < b. Decide it with
     # exact integer arithmetic: writing t = 2*abs(a), it says that b > 0, that
-    # sqrt(D) < t + b, and that sqrt(D) > t - b. For a square discriminant the
-    # two sides can be equal, in which case a ball arithmetic comparison cannot
-    # decide the inequality at any precision.
+    # sqrt(D) < t + b, and that sqrt(D) > t - b. 
     b <= 0 && return false
     t = 2 * abs(a)
     return (t^2 < D <= (b+t)^2) || ((t-b)^2 < D < t^2)

--- a/src/QuadForm/QuadBin.jl
+++ b/src/QuadForm/QuadBin.jl
@@ -729,8 +729,7 @@ function is_reduced(f::QuadBin{ZZRingElem})
     # sqrt(D) < t + b, and that sqrt(D) > t - b. 
     b <= 0 && return false
     t = 2 * abs(a)
-    return (t^2 < D <= (b+t)^2) || ((t-b)^2 < D < t^2)
-    # return D < (t + b)^2 && (t - b < 0 || D > (t - b)^2)
+    return D < (t + b)^2 && (t - b < 0 || D > (t - b)^2)
   end
 end
 

--- a/test/QuadForm/QuadBin.jl
+++ b/test/QuadForm/QuadBin.jl
@@ -98,6 +98,21 @@
     # indefinite
     @test is_reduced(binary_quadratic_form(1, 9, 4)) == false
     @test is_reduced(binary_quadratic_form(1, 5, -1)) == true
+    # square discriminant: the boundary abs(sqrt(D) - 2*abs(a)) == b is attained
+    @test is_reduced(binary_quadratic_form(0, 3, 2)) == false
+    @test is_reduced(binary_quadratic_form(0, 2, 3)) == false
+    @test is_reduced(binary_quadratic_form(3, 3, 0)) == false
+    @test is_reduced(binary_quadratic_form(0, 4, 5)) == false
+    @test is_reduced(binary_quadratic_form(2, 3, 0)) == true
+    @test is_reduced(binary_quadratic_form(1, 3, 0)) == true
+    @test is_reduced(binary_quadratic_form(0, 3, 0)) == true
+    # reduction of a primitive reducible form lands on a reduced form
+    for (a, b, c) in [(15, -7, 0), (15, 7, 0), (2, 5, 3), (1, 4, 3), (6, 5, 1),
+                      (4, 8, 3), (3, 7, 2), (5, 9, 4)]
+      f = binary_quadratic_form(a, b, c)
+      is_square(discriminant(f)) && is_primitive(f) || continue
+      @test is_reduced(Hecke.reduction(f))
+    end
     #@test reduce(binary_quadratic_form(195751, 37615, 1807)) == binary_quadratic_form(1, 1, 1)
     #@test reduce(binary_quadratic_form(33, 11, 5)) == binary_quadratic_form(5, -1, 27)
     #@test reduce(binary_quadratic_form(15, 0, 15)) == binary_quadratic_form(15, 0, 15)


### PR DESCRIPTION
For an indefinite binary form, `is_reduced` ends in a ball arithmetic comparison of `abs(sqrt(D) - 2*abs(a))` with `b`, guarded by `@assert !contains(z, b)` against insufficient precision. When `D` is a perfect square the two sides can be *exactly* equal, and then no precision decides the comparison, so the assertion fires on ordinary input.

```julia
julia> is_reduced(binary_quadratic_form(0, 3, 2))
ERROR: AssertionError: !(contains(z, b))

julia> is_reduced(binary_quadratic_form(0, 2, 3))
ERROR: AssertionError: !(contains(z, b))

julia> is_reduced(binary_quadratic_form(3, 3, 0))
ERROR: AssertionError: !(contains(z, b))
```

**The fix** decides the inequality exactly. With `t = 2*abs(a)`, `abs(sqrt(D) - t) < b` says that `b > 0`, that `sqrt(D) < t + b` and that `sqrt(D) > t - b`, i.e.

```julia
b > 0 && D < (t + b)^2 && (t - b < 0 || D > (t - b)^2)
```

This also removes the precision assumption for non-square discriminants and saves the `ArbField` allocation.

**Testing.** Compared against the previous implementation on all forms `[a, b, c]` with entries in `-20..20`: the two agree on all 67430 inputs where the old one returned, and the new one also answers the 1491 inputs on which it threw. Separately checked that `reduction` of every primitive reducible form with entries in `-30..30` still lands on a form that `is_reduced` accepts. `test/QuadForm/QuadBin.jl` passes.

One thing this does **not** change: for a square discriminant the implementation's notion of reduced (`c == 0`, `b == sqrt(D)`, `0 <= a < b`, as produced by `_reduction_reducible`) is wider than the condition stated in the docstring (`c == 0` and `-b < 2a <= b`), so e.g. `is_reduced(binary_quadratic_form(2, 3, 0))` is `true`. Aligning the docstring with the implementation is left for a separate change.


🤖 Generated with [Claude Code](https://claude.com/claude-code)