### PR TITLE
fix: default algorithm for closest_vectors

### DIFF
--- a/src/QuadForm/Enumeration.jl
+++ b/src/QuadForm/Enumeration.jl
@@ -775,7 +775,8 @@ function _short_vectors_gram_nolll_integral(::Type{T}, G, _lb, _ub, transform::X
 
   # We pass the following function through to the iterator
   # They are applied to the vector found and the length of the vector
-  cleanvec = v -> __clean_and_assemble(v, transform, !isnothing(transform) && !isone(transform), zeros_array(ZZ, n), S)
+  tmpvec = zeros_array(ZZ, n)
+  cleanvec = v -> __clean_and_assemble(v, transform, !isnothing(transform) && !isone(transform), tmpvec, S)
   cleanscalar = l -> l//d
   if ub isa ZZRingElem && fits(Int, ub)
     if _lb isa Nothing
@@ -1011,7 +1012,7 @@ function _shortest_vectors_gram_integral(::Type{S}, _G; is_lll_reduced_known::Bo
     Glll, T = lll_gram_with_transform(_G)
     if isone(T)
       T = nothing
-    end 
+    end
   end
   max = maximum([Glll[i, i] for i in 1:nrows(Glll)])
   @assert max > 0

--- a/src/QuadForm/IntegerLattices/CloseVectors.jl
+++ b/src/QuadForm/IntegerLattices/CloseVectors.jl
@@ -17,7 +17,7 @@ Both input and output are with respect to the basis matrix of `L`.
 The supported algorithms are `:embedding`, which reduces the problem to short
 vector enumeration in one additional dimension, and `:fincke_pohst`, which
 enumerates the target-shifted ellipsoid directly. The value `:default`
-currently selects `:embedding`.
+currently selects `:fincke_pohst`.
 
 # Examples
 
@@ -235,7 +235,7 @@ function _close_vectors_iterator(::Val{:default}, L::ZZLat,
                                  v::Vector{QQFieldElem}, lowerbound,
                                  upperbound::QQFieldElem,
                                  elem_type::Type{S} = ZZRingElem; kw...) where {S}
-  return _close_vectors_iterator(Val(:embedding), L, v, lowerbound,
+  return _close_vectors_iterator(Val(:fincke_pohst), L, v, lowerbound,
                                  upperbound, elem_type; kw...)
 end
 


### PR DESCRIPTION
- remove some unnecessary allocations
