### PR TITLE
Fixed gcd sircana corner cases

### DIFF
--- a/src/Misc/nmod_poly.jl
+++ b/src/Misc/nmod_poly.jl
@@ -809,45 +809,86 @@ function gcd_sircana(f::PolyRingElem{T}, g::PolyRingElem{T}) where T <: ResElem{
   @assert isone(content(f))
   @assert isone(content(g))
   local qf, qg
+  quots = typeof(f)[]
   while !iszero(g)
     if !is_unit(leading_coefficient(g))
-      cp = coprime_base(vcat(map(x->gcd(lift(x), modulus(R)), coefficients(g)), [modulus(R)]))
+      # NOTE: coprime base should be "fine" enough to allow BOTH f and g to admit
+      #   a Weierstrass split
+      cp = coprime_base(vcat( map(x->gcd(lift(x), modulus(R)), coefficients(f)),
+                              map(x->gcd(lift(x), modulus(R)), coefficients(g)),
+                              [modulus(R)]))
       cp = [x for x in cp if !is_unit(x)]
       gc = NTuple{3, ZZPolyRingElem}[]
+      crt_mod = ZZRingElem[]
       for p in cp
-        F, mF = quo(parent(p), p^valuation(modulus(R), p))
+        pe = p^valuation(modulus(R), p)
+        push!(crt_mod, pe)
+
+        F, mF = quo(parent(p), pe)
         gp = map_coefficients(x -> mF(lift(ZZ, x)), g; cached = false)
         @assert base_ring(gp) == F
         fp = map_coefficients(x -> mF(lift(ZZ, x)), f; parent = parent(gp))
+
+        fu = one(parent(fp))
+        gu = one(parent(gp))
+        # NOTE: we need primitive polynomial for recursion. Further, having primitive
+        #   polynomial will guarantee that some coefficient is a unit
+        #   for fun_factor below.
+        # We move common divisor into the "units" fu, gu; we will apply them later
+        #   to reconstruct cofactors
+        if !iszero(fp) && !is_unit(content(fp))
+          cf, fp = primsplit(fp)
+          fu = fu*cf
+        end
+        if !iszero(gp) && !is_unit(content(gp))
+          cg, gp = primsplit(gp)
+          gu = gu*cg
+        end
+
         if !is_unit(leading_coefficient(fp))
           if iszero(fp)
             fp = zero(parent(fp))
           else
-            _, fp = fun_factor(fp)
+            u, fp = fun_factor(fp)
+            fu = fu*u
           end
         end
         if !is_unit(leading_coefficient(gp))
           if iszero(gp)
             gp = zero(parent(gp))
           else
-            _, gp = fun_factor(gp)
+            u, gp = fun_factor(gp)
+            gu = gu*u
           end
         end
-        push!(gc, map(y->map_coefficients(x->lift(x), y, cached = false), gcd_sircana(fp, gp)))
+        # NOTE: we get gcd for monic parts, so we need to apply units (from fun_factor)
+        dp, qfp, qgp = gcd_sircana(fp, gp)
+        push!(gc, map(y->map_coefficients(x->lift(x), y, cached = false), (dp, fu*qfp, gu*qgp)))
       end
-      f = map_coefficients(R, induce_crt([x[1] for x = gc], cp), parent = parent(f))
-      qf = map_coefficients(R, induce_crt([x[2] for x = gc], cp), parent = parent(f))
-      qg = map_coefficients(R, induce_crt([x[3] for x = gc], cp), parent = parent(f))
+      f = map_coefficients(R, induce_crt([x[1] for x = gc], crt_mod), parent = parent(f))
+      qf = map_coefficients(R, induce_crt([x[2] for x = gc], crt_mod), parent = parent(f))
+      qg = map_coefficients(R, induce_crt([x[3] for x = gc], crt_mod), parent = parent(f))
       break
     else
-      f, g = g, rem(f, g)
+      # we run (possibly) several Euclid steps and then the branch above at most once (see the break)
+      # we still need to "undo" the Euclid steps we did
+      # we walk quotients back (unwinding the call stack) doing (f, g) <- (g, f - q*g)
+      q, r = divrem(f, g)
+      push!(quots, q)
+      f, g = g, r
       if iszero(g)
-        qf = divexact(_F, f)
-        qg = divexact(_G, f)
+        qf = one(Rt)
+        qg = zero(Rt)
         break
       end
     end
   end
+
+  # restore cofactors: go backwards through Euclid quotients doing (f, g) <- (g, f - q*g)
+  for q in Iterators.reverse(quots)
+    qf, qg = qg + q*qf, qf
+  end
+
   c = canonical_unit(leading_coefficient(f))
   f = divexact(f, c)
   qf *= c

--- a/src/Misc/nmod_poly.jl
+++ b/src/Misc/nmod_poly.jl
@@ -780,124 +780,58 @@ end
 #
 ################################################################################
 
-@doc raw"""
-    gcd_sircana(f::PolyRingElem{T}, g::PolyRingElem{T}) where T <: ResElem{S} where S <: IntegerUnion -> T
+# f = u * h with h primitive and invertible leading coefficient
+function _gcd_sircana_normal_form(f::PolyRingElem{T}) where T <: ResElem{S} where S <: IntegerUnion
+  u = one(parent(f))
+  iszero(f) && return u, f
 
-The 'gcd' of $f$ and $g$ together with the 'cofactors' using a quadratic-time algorithm.
-"""
-function gcd_sircana(f::PolyRingElem{T}, g::PolyRingElem{T}) where T <: ResElem{S} where S <: IntegerUnion
-  Nemo.check_parent(f, g)
-  _F = f
-  _G = g
-  @assert typeof(f) == typeof(g)
-  iszero(g) && return f, one(parent(f)), zero(parent(f))
-  iszero(f) && return g, zero(parent(f)), one(parent(f))
-  isone(f) && return f, f, g
-  isone(g) && return g, f, g
+  if !is_unit(content(f))
+    c, f = primsplit(f)
+    u *= c
+  end
 
+  if !is_unit(leading_coefficient(f))
+    v, f = fun_factor(f)
+    u *= v
+  end
+
+  return u, f
+end
+
+# GCD of f and g in (Z/pe)[x], lifted to ZZ[x] for the crt
+function _gcd_sircana_component(f::PolyRingElem{T}, g::PolyRingElem{T}, pe::ZZRingElem) where T <: ResElem{S} where S <: IntegerUnion
+  F, mF = residue_ring(ZZ, pe; cached = false)
+  Fx, = polynomial_ring(F, :x; cached = false)
+  fp = map_coefficients(c -> mF(lift(ZZ, c)), f; parent = Fx)
+  gp = map_coefficients(c -> mF(lift(ZZ, c)), g; parent = Fx)
+
+  uf, fp = _gcd_sircana_normal_form(fp)
+  ug, gp = _gcd_sircana_normal_form(gp)
+
+  d, qf, qg = gcd_sircana(fp, gp)
+  return lift(Globals.Zx, d), lift(Globals.Zx, uf*qf), lift(Globals.Zx, ug*qg)
+end
+
+# The leading coefficient of g is a zero divisor. We split the ring into components
+#   in which both f and g have a well defined unit * (primitive monic) splitting
+function _gcd_sircana_split(f::PolyRingElem{T}, g::PolyRingElem{T}) where T <: ResElem{S} where S <: IntegerUnion
   Rt = parent(f)
   R = base_ring(Rt)
   m = ZZRingElem(modulus(R))
-  #from Sircana: if content is nilpotent, then removing the content
-  # results in s.th. that has a non-nilpotent content
-  # one should be able to use this to split the ring
-  # recall: if the leading coeff is nilpotent, but the polynomial is not
-  #   then the polynomial splits into unit * monic. The unit is not
-  #   used for gcd.
-  # start with primitive polynomials - in contrast to fields we
-  # cannot ignore the contents as it can contribute...
-  @assert isone(content(f))
-  @assert isone(content(g))
-  local qf, qg
-  quots = typeof(f)[]
-  while !iszero(g)
-    if !is_unit(leading_coefficient(g))
-      # NOTE: coprime base should be "fine" enough to allow BOTH f and g to admit
-      #   a Weierstrass split
-      cp = coprime_base(vcat( map(x->gcd(lift(x), modulus(R)), coefficients(f)),
-                              map(x->gcd(lift(x), modulus(R)), coefficients(g)),
-                              [modulus(R)]))
-      cp = [x for x in cp if !is_unit(x)]
-      gc = NTuple{3, ZZPolyRingElem}[]
-      crt_mod = ZZRingElem[]
-      for p in cp
-        pe = p^valuation(modulus(R), p)
-        push!(crt_mod, pe)
 
-        F, mF = quo(parent(p), pe)
-        gp = map_coefficients(x -> mF(lift(ZZ, x)), g; cached = false)
-        @assert base_ring(gp) == F
-        fp = map_coefficients(x -> mF(lift(ZZ, x)), f; parent = parent(gp))
+  # NOTE: coprime base should be "fine" enough to allow BOTH f and g to admit
+  #   a Weierstrass split.
+  cp = coprime_base(vcat(map(x -> gcd(lift(x), m), coefficients(f)),
+                         map(x -> gcd(lift(x), m), coefficients(g)),
+                         [m]))
+  cp = ZZRingElem[p for p in cp if !is_unit(p)]
+  pe = ZZRingElem[p^valuation(m, p) for p in cp]
 
-        fu = one(parent(fp))
-        gu = one(parent(gp))
-        # NOTE: we need primitive polynomial for recursion. Further, having primitive
-        #   polynomial will guarantee that some coefficient is a unit
-        #   for fun_factor below.
-        # We move common divisor into the "units" fu, gu; we will apply them later
-        #   to reconstruct cofactors
-        if !iszero(fp) && !is_unit(content(fp))
-          cf, fp = primsplit(fp)
-          fu = fu*cf
-        end
-        if !iszero(gp) && !is_unit(content(gp))
-          cg, gp = primsplit(gp)
-          gu = gu*cg
-        end
+  gc = [_gcd_sircana_component(f, g, q) for q in pe]
 
-        if !is_unit(leading_coefficient(fp))
-          if iszero(fp)
-            fp = zero(parent(fp))
-          else
-            u, fp = fun_factor(fp)
-            fu = fu*u
-          end
-        end
-        if !is_unit(leading_coefficient(gp))
-          if iszero(gp)
-            gp = zero(parent(gp))
-          else
-            u, gp = fun_factor(gp)
-            gu = gu*u
-          end
-        end
-        # NOTE: we get gcd for monic parts, so we need to apply units (from fun_factor)
-        dp, qfp, qgp = gcd_sircana(fp, gp)
-        push!(gc, map(y->map_coefficients(x->lift(x), y, cached = false), (dp, fu*qfp, gu*qgp)))
-      end
-      f = map_coefficients(R, induce_crt([x[1] for x = gc], crt_mod), parent = parent(f))
-      qf = map_coefficients(R, induce_crt([x[2] for x = gc], crt_mod), parent = parent(f))
-      qg = map_coefficients(R, induce_crt([x[3] for x = gc], crt_mod), parent = parent(f))
-      break
-    else
-      # we run (possibly) several Euclid steps and then the branch above at most once (see the break)
-      # we still need to "undo" the Euclid steps we did
-      # we walk quotients back (unwinding the call stack) doing (f, g) <- (g, f - q*g)
-      q, r = divrem(f, g)
-      push!(quots, q)
-      f, g = g, r
-      if iszero(g)
-        qf = one(Rt)
-        qg = zero(Rt)
-        break
-      end
-    end
-  end
-
-  # restore cofactors: go backwards through Euclid quotients doing (f, g) <- (g, f - q*g)
-  for q in Iterators.reverse(quots)
-    qf, qg = qg + q*qf, qf
-  end
-
-  c = canonical_unit(leading_coefficient(f))
-  f = divexact(f, c)
-  qf *= c
-  qg *= c
-
-  @assert f*qf == _F
-  @assert f*qg == _G
-
-  return f, qf, qg
+  return (map_coefficients(R, induce_crt([x[1] for x in gc], pe), parent = Rt),
+          map_coefficients(R, induce_crt([x[2] for x in gc], pe), parent = Rt),
+          map_coefficients(R, induce_crt([x[3] for x in gc], pe), parent = Rt))
 end
 
 function induce_crt(f::Vector{<:PolyRingElem{T}}, m::Vector{ZZRingElem}, parent::ZZPolyRing = Hecke.Globals.Zx) where {T}
@@ -908,6 +842,60 @@ function induce_crt(f::Vector{<:PolyRingElem{T}}, m::Vector{ZZRingElem}, parent:
     setcoeff!(g, i, crt([coeff(x, i) for x = f], ce))
   end
   return g
+end
+
+@doc raw"""
+    gcd_sircana(f::PolyRingElem{T}, g::PolyRingElem{T}) where T <: ResElem{S} where S <: IntegerUnion -> T
+
+The 'gcd' of $f$ and $g$ together with the 'cofactors' using a quadratic-time algorithm.
+"""
+function gcd_sircana(f::PolyRingElem{T}, g::PolyRingElem{T}) where T <: ResElem{S} where S <: IntegerUnion
+  Nemo.check_parent(f, g)
+  @assert typeof(f) == typeof(g)
+
+  iszero(g) && return f, one(parent(f)), zero(parent(f))
+  iszero(f) && return g, zero(parent(f)), one(parent(f))
+  isone(f) && return f, f, g
+  isone(g) && return g, f, g
+
+  _F = f
+  _G = g
+
+  Rt = parent(f)
+
+  # In contrast to fields we cannot ignore the contents as it can contribute
+  @assert isone(content(f))
+  @assert isone(content(g))
+
+  # Do Euclid steps as long as the leading coefficient is invertible
+  # Note that we cannot update cofactors as we go: we need to store quotients
+  #   and then unwind cofactors from the final result
+  quots = typeof(f)[]
+  while !iszero(g) && is_unit(leading_coefficient(g))
+    q, r = divrem(f, g)
+    push!(quots, q)
+    f, g = g, r
+  end
+
+  if iszero(g)
+    qf, qg = one(Rt), zero(Rt)
+  else
+    f, qf, qg = _gcd_sircana_split(f, g)
+  end
+
+  # Restore cofactors: go backwards through Euclid quotients doing (f, g) <- (g, f - q*g)
+  for q in Iterators.reverse(quots)
+    qf, qg = qg + q*qf, qf
+  end
+
+  c = canonical_unit(leading_coefficient(f))
+  f = divexact(f, c)
+  qf *= c
+  qg *= c
+
+  @hassert :AbsNumFieldOrder 1 f*qf == _F
+  @hassert :AbsNumFieldOrder 1 f*qg == _G
+  return f, qf, qg
 end
 
 ################################################################################

--- a/test/FunField/HessQR.jl
+++ b/test/FunField/HessQR.jl
@@ -54,10 +54,7 @@ import Hecke.HessQRModule: HessQRElem
     end
 
     # divrem
-    # rem(s1, s2) currently results in assert in gcd_sircana
-    # rem(s1, S(84)) currently results in crash in gcd_sircana
-    # for a in [s1, s2, u1, S(0), S(-5), S(7)], b in [s1, s2, u1, S(-35), S(84)]
-    for a in [s1, s2, s3, u1, S(0), S(-5), S(175)], b in [s1, u1, S(-35)]
+    for a in [s1, s2, s3, u1, S(0), S(-5), S(7), S(175)], b in [s1, s2, u1, S(-35), S(84)]
       q, r = divrem(a, b)
       @test q*b + r == a
       @test iszero(r) || abs(r.c) < abs(b.c)

--- a/test/Misc/nmod_poly.jl
+++ b/test/Misc/nmod_poly.jl
@@ -8,6 +8,24 @@
     d = u*f + v*g
     @test is_zero(rem(d, a))
 
+    F, = residue_ring(ZZ, 12); x = F[:x][2]
+    d, u, v = Hecke.gcd_sircana((x+7)*(x+1), (x+7)*(2*x+1))
+    @test d == x + 7
+
+    F, = residue_ring(ZZ, 210); x = F[:x][2]
+    d, u, v = Hecke.gcd_sircana(x^2+1, x+1)
+    @test d*u == x^2+1
+    @test d*v == x+1
+
+    F, = residue_ring(ZZ, 12); x = F[:x][2]
+    d, u, v = Hecke.gcd_sircana(x^2+1, x+1)
+    @test d*u == x^2+1
+    @test d*v == x+1
+
+    F, = residue_ring(ZZ, 9); x = F[:x][2]
+    d, u, v = Hecke.gcd_sircana(x^2, x*(x^2-5*x+6))
+    @test d == x
+
 #=
     g *= x
     a, u, v = Hecke.gcd_sircana(f,g)


### PR DESCRIPTION
Fixed several missed corner cases in sircana gcd implementation:
- Use full powers of the coprime-base factors as CRT moduli so that their product recovers the original, possibly nonsquarefree, modulus.
- Record and unwind Euclidean quotients to reconstruct cofactors of the original polynomials (we can have several Euclidean steps). Include content and Weierstrass unit factors in the reconstructed cofactors as well.
- Build the coprime base from the coefficients of both inputs and make each CRT component primitive before calling fun_factor. Together, these conditions ensure that every nonzero input to fun_factor has a unit coefficient.

Also refactored the implementation to be easier to follow.
Added tests (from https://github.com/thofma/Hecke.jl/issues/2218) and restored disabled HessQR tests

To ease the review, it is advisable to check two commits one-by-one: first is a pure bug fix, the second is pure refactoring (the only "real" change is `@assert` -> `@hassert` for the result check.

