### PR TITLE
fix: picard group of orders in etale algebras

### DIFF
--- a/src/AlgAssAbsOrd/PicardGroup.jl
+++ b/src/AlgAssAbsOrd/PicardGroup.jl
@@ -164,6 +164,22 @@ function _trivial_picard(O::AlgAssAbsOrd, R::FinGenAbGroup, mR)
 
 end
 
+# Return a lift of x modulo m which is non-zero in every simple component.
+function _non_zero_divisor_lift(x::AlgAssAbsOrdElem, m::AlgAssAbsOrdIdl)
+  O = parent(x)
+  @assert O === order(m)
+  A = algebra(O)
+  y = elem_in_algebra(x)
+  for (K, AtoK) in as_number_fields(A)
+    if iszero(AtoK(y))
+      y += AtoK\one(K)
+    end
+  end
+  z = O(y)
+  @hassert :AlgAssOrd 1 z - x in m
+  return z
+end
+
 # See Bley, Endres "Picard Groups and Refined Discrete Logarithms".
 function _picard_group_non_maximal(O::AlgAssAbsOrd, prepare_ref_disc_log::Bool = false)
   A = algebra(O)
@@ -198,6 +214,7 @@ function _picard_group_non_maximal(O::AlgAssAbsOrd, prepare_ref_disc_log::Bool =
     GinR = Vector{FinGenAbGroupElem}()
     for i = 1:ngens(G)
       g = OO(OtoQ\(GtoQ(G[i])))
+      g = _non_zero_divisor_lift(g, FOO)
       r = mR\(ideal(OO, g))
       push!(GinR, r)
     end
@@ -236,6 +253,7 @@ function _picard_group_non_maximal(O::AlgAssAbsOrd, prepare_ref_disc_log::Bool =
     end
     for i = (ngens(R) + 1):(ngens(R) + ngens(G))
       g = OO(OtoQ\(GtoQ(G[i - ngens(R)])))
+      g = _non_zero_divisor_lift(g, FOO)
       gOO = ideal(OO, g)
       a, r = disc_log_generalized_ray_class_grp(gOO, mR)
 

--- a/test/AlgAssAbsOrd/PicardGroup.jl
+++ b/test/AlgAssAbsOrd/PicardGroup.jl
@@ -65,6 +65,25 @@ end
   @test ngens(P) == 0
   @test mP\ideal(O, one(O)) in P
 
+  # A lift from (O/F)^* may be zero in components on which F is the unit ideal.
+  b1 = zero_matrix(QQ, 6, 6)
+  b1[1, 1] = 1
+  b2 = identity_matrix(QQ, 6)
+  b2[1, 1] = 0
+  b3 = matrix(QQ, [0  0  0  0  0  0;
+                   0  0  1 -1 -1  1;
+                   0  0 -1  0  0  0;
+                   0 -1 -1  0  1 -1;
+                   0 -1 -1  1  0 -1;
+                   0  2  2 -2 -2  1])
+  A = matrix_algebra(QQ, [b1, b2, b3])
+  O = order(A, [b1, b2, b3])
+  @test !is_maximal(O)
+  P, mP = picard_group(O)
+  @test elementary_divisors(P) == ZZRingElem[2]
+  @test mP\ideal(O, one(O)) == zero(P)
+  @test mP\(mP(P[1])) == P[1]
+
   G = abelian_group([3, 3])
   A = GroupAlgebra(QQ, G)
   O = order(A, basis(A))


### PR DESCRIPTION
- make sure elements are lifted to regular elements
- closes #2374
