### PR TITLE
Fix MethodError in embed/embed_in_unimodular error paths

### DIFF
--- a/src/QuadForm/IntegerLattices/ZGenus.jl
+++ b/src/QuadForm/IntegerLattices/ZGenus.jl
@@ -3306,7 +3306,7 @@ function embed(S::ZZLat, G::ZZGenus, primitive::Bool=true)
     pos, neg = signature_pair(G)
     return embed_in_unimodular(S, pos, neg; primitive, even = iseven(G))
   end
-  throw(NotImplementedError("for now G needs to be even unimodular, but you can use Nikulin's theory to get a primitive embedding by 'hand' in the non-unimodular cases"))
+  error("for now G needs to be even unimodular, but you can use Nikulin's theory to get a primitive embedding by 'hand' in the non-unimodular cases")
 end
 
 @doc raw"""
@@ -3358,7 +3358,7 @@ function embed_in_unimodular(S::ZZLat, pos::IntegerUnion, neg::IntegerUnion; pri
   @vprintln :Lattice 1 "computing embedding in L_$(n)"
   pS, kS, nS = signature_tuple(S)
   @req kS == 0 "S must be non-degenerate"
-  even || throw(NotImplementedError("for now we need the unimodular lattice to be even."))
+  even || error("for now we need the unimodular lattice to be even.")
   pR = pos - pS
   nR = neg - nS
   DS = discriminant_group(S)

--- a/test/QuadForm/Quad/ZGenus.jl
+++ b/test/QuadForm/Quad/ZGenus.jl
@@ -624,6 +624,13 @@ end
 @testset "Fix issues" begin
   ## Issue 1103
   @test sprint(show, "text/plain", genus(root_lattice(:E, 8), 2)) isa String
+
+  ## `embed`/`embed_in_unimodular` used to raise a MethodError from
+  ## inside their own error paths (NotImplementedError takes a Symbol,
+  ## not a String), hiding the intended explanation.
+  G = integer_genera((14, 0), 243; even = true)[1]
+  @test_throws ErrorException embed(root_lattice(:A, 2), G, true)
+  @test_throws ErrorException embed_in_unimodular(root_lattice(:A, 2), 10, 0; even = false)
 end
 
 @testset "Canonical symbols" begin


### PR DESCRIPTION
### Problem

`AbstractAlgebra.NotImplementedError` is constructed from a `Symbol` followed by the offending arguments:

```julia
struct NotImplementedError <: Exception
  head::Symbol
  args::Tuple
end
NotImplementedError(h::Symbol, args...) = NotImplementedError(h, args)
```

Two call sites in `src/QuadForm/IntegerLattices/ZGenus.jl` pass a `String` instead, so the error paths themselves fail:

```julia
julia> using Hecke

julia> G = integer_genera((14,0), 243, even=true)[1];

julia> embed(root_lattice(:A, 2), G, true)
ERROR: MethodError: no method matching NotImplementedError(::String)

julia> embed_in_unimodular(root_lattice(:A, 2), 10, 0; even=false)
ERROR: MethodError: no method matching NotImplementedError(::String)
```

The user gets a `MethodError` pointing into `AbstractAlgebra`, and the intended explanation is never shown. This is unfortunate here because the first message is genuinely useful — it tells the caller that non-unimodular genera can be handled by hand via Nikulin's theory.

### Fix

Both messages are informative, so they are preserved by switching to `error`. That also matches the prevailing style in Hecke for message-carrying "not implemented" conditions (14 uses of `error("... not implemented ...")` against 5 typed `NotImplementedError(:symbol, ...)`).

After the change:

```julia
julia> embed(root_lattice(:A, 2), G, true)
ERROR: for now G needs to be even unimodular, but you can use Nikulin's theory to get a
primitive embedding by 'hand' in the non-unimodular cases

julia> embed_in_unimodular(root_lattice(:A, 2), 10, 0; even=false)
ERROR: for now we need the unimodular lattice to be even.
```

If you would rather keep the typed exception, `throw(NotImplementedError(:embed, S, G))` also works, but the explanatory text would be lost — happy to switch if you prefer that.

### Tests

Added to the `"Fix issues"` testset in `test/QuadForm/Quad/ZGenus.jl`, asserting `ErrorException` rather than `MethodError` at both sites. The working unimodular path is unaffected (`embed(root_lattice(:A,5), integer_genera((8,0),1,even=true)[1])` still returns an embedding into a rank-8 lattice).

### Context

Found while looking for a primitive-embedding filter for a mass computation over genera of rank-14 lattices, where `embed` is called with a non-unimodular target genus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0185QET2jk91FMRdXdzQVJWJ