### PR TITLE
Fix closure boxes by using fresh variable names

### DIFF
--- a/src/AlgAss/AbsAlgAss.jl
+++ b/src/AlgAss/AbsAlgAss.jl
@@ -1300,7 +1300,8 @@ function skolem_noether_conjugator(
   end
   sn = ker[1]
   while !first(is_invertible(sn))
-    cc = [rand(base_ring(alg), -length(ker):length(ker)) for _ in 1:length(ker)]
+    nk = length(ker)
+    cc = [rand(base_ring(alg), -nk:nk) for _ in 1:nk]
     sn = sum(cc .* ker)
   end
   for x in basis(domain(emb1))

--- a/src/AlgAss/AlgCyc.jl
+++ b/src/AlgAss/AlgCyc.jl
@@ -349,9 +349,9 @@ function is_isomorphic_with_map(
     _, s2 = is_split_with_map(cyclic_algebra(k2, c2.sigma, k(1)))
 
     function add_kronecker_prod!(trg, a, b)
-      d = number_of_rows(a)
-      for i in 1:d:d^2-1, j in 1:d:d^2-1
-        trg[i:i+d-1, j:j+d-1] .+= (a * b[div(i, d)+1, div(j, d)+1])
+      da = number_of_rows(a)
+      for i in 1:da:da^2-1, j in 1:da:da^2-1
+        trg[i:i+da-1, j:j+da-1] .+= (a * b[div(i, da)+1, div(j, da)+1])
       end
     end
 
@@ -437,10 +437,10 @@ function is_isomorphic_with_map(
   k2_over_k0, k2_over_k0_to_k2 = relative_simple_extension(k2, k0)
   dz = degree(k1_over_k0)
   d0 = degree(k0)
-  sigma1 = hom(k1_over_k0, k1_over_k0, k1_over_k0_to_k1\ (c1.sigma^d0)(k1_over_k0_to_k1(gen(k1_over_k0))))
-  sigma2 = hom(k2_over_k0, k2_over_k0, k2_over_k0_to_k2\ (c2.sigma^d0)(k2_over_k0_to_k2(gen(k2_over_k0))))
-  z1 = cyclic_algebra(k1_over_k0, sigma1, k0(c1.a))
-  z2 = cyclic_algebra(k2_over_k0, sigma2, k0(c2.a))
+  tau1 = hom(k1_over_k0, k1_over_k0, k1_over_k0_to_k1\ (c1.sigma^d0)(k1_over_k0_to_k1(gen(k1_over_k0))))
+  tau2 = hom(k2_over_k0, k2_over_k0, k2_over_k0_to_k2\ (c2.sigma^d0)(k2_over_k0_to_k2(gen(k2_over_k0))))
+  z1 = cyclic_algebra(k1_over_k0, tau1, k0(c1.a))
+  z2 = cyclic_algebra(k2_over_k0, tau2, k0(c2.a))
   if !first(local _, iso = is_isomorphic_with_map(z1, z2; linearly_disjoint=true))
     return false, hom(c1.sca, c2.sca, [c2.sca(0) for _ in 1:d^2]; check=false)
   end

--- a/src/AlgAss/Conversions.jl
+++ b/src/AlgAss/Conversions.jl
@@ -231,9 +231,9 @@ function StructureConstantAlgebra(I::AlgAssAbsOrdIdl, J::AlgAssAbsOrdIdl, p::Int
   let BmatJinI = BmatJinI, I = I, r = r, A = A, t = t, Fp = Fp
     function _image(a::AlgAssAbsOrdElem)
       elem_to_mat_row!(t, 1, _elem_in_algebra(a, copy = false))
-      t = mul!(t, t, basis_mat_inv(I, copy = false))
-      @assert isone(denominator(t)) "Not an element of the domain"
-      c = reduce_vector_mod_hnf(numerator(t), BmatJinI)
+      tt = mul!(t, t, basis_mat_inv(I, copy = false))
+      @assert isone(denominator(tt)) "Not an element of the domain"
+      c = reduce_vector_mod_hnf(numerator(tt), BmatJinI)
       return A([ Fp(c[i]) for i in basis_elts ])
     end
   end
@@ -250,8 +250,8 @@ function StructureConstantAlgebra(I::AlgAssAbsOrdIdl, J::AlgAssAbsOrdIdl, p::Int
         if is_zero(acoords[i])
           continue
         end
-        temppp = mul!(temppp, acoords[i], BI[basis_elts[i]])
-        z = add!(z, z, temppp)
+        prod_i = mul!(temppp, acoords[i], BI[basis_elts[i]])
+        z = add!(z, z, prod_i)
       end
       _zz = O(z)
       return _zz
@@ -361,8 +361,8 @@ function StructureConstantAlgebra(I::AbsNumFieldOrderIdeal, J::AbsNumFieldOrderI
         if is_zero(acoords[i])
           continue
         end
-        temppp = mul!(temppp, acoords[i], BI[basis_elts[i]])
-        z = add!(z, z, temppp)
+        prod_i = mul!(temppp, acoords[i], BI[basis_elts[i]])
+        z = add!(z, z, prod_i)
       end
       return z
     end

--- a/src/AlgAss/Ideal.jl
+++ b/src/AlgAss/Ideal.jl
@@ -520,17 +520,17 @@ function quo(a::AbsAlgAssIdl{S}, b::AbsAlgAssIdl{S}) where {S}
   # First compute the vector space quotient
   Ma = basis_matrix(a, copy = false)
   Mb = basis_matrix(b, copy = false)
-  M = hcat(transpose(Mb), transpose(Ma))
-  r = rref!(M)
+  Mab = hcat(transpose(Mb), transpose(Ma))
+  r = rref!(Mab)
   pivot_cols = Vector{Int}()
   j = 1
-  for i = 1:ncols(M)
-    if !iszero(M[j, i])
+  for i = 1:ncols(Mab)
+    if !iszero(Mab[j, i])
       if i > nrows(Mb)
         push!(pivot_cols, i - nrows(Mb))
       end
       j += 1
-      if j > nrows(M)
+      if j > nrows(Mab)
         break
       end
     end
@@ -575,8 +575,8 @@ function quo(a::AbsAlgAssIdl{S}, b::AbsAlgAssIdl{S}) where {S}
   AtoB = AbsAlgAssMor{typeof(A), typeof(B), typeof(M)}(A, B)
 
   function _image(x::AbstractAssociativeAlgebraElem)
-    t, y = can_solve_with_solution(Nctx, coefficients(x, copy = false), side = :left)
-    if t
+    fl, y = can_solve_with_solution(Nctx, coefficients(x, copy = false), side = :left)
+    if fl
       return B(y[1:dim(B)]; copy = false)
     else
       error("Element is not in the domain")

--- a/src/AlgAss/radical.jl
+++ b/src/AlgAss/radical.jl
@@ -416,7 +416,8 @@ function _radical_funfield(A::MatAlgebra)
       B = push!(copy(B), one(A))
     end
     d = length(B)
-    G = _trace_matrix(B, x -> _tr(Int(s), matrix(x, copy = false)))
+    si = Int(s)
+    G = _trace_matrix(B, x -> _tr(si, matrix(x, copy = false)))
     K = kernel(G; side = :left)
     # if 1 < s < |K| always satisfied
     sp = 1

--- a/src/AlgAssAbsOrd/Eichler.jl
+++ b/src/AlgAssAbsOrd/Eichler.jl
@@ -9,9 +9,9 @@ function principal_generator_eichler(I::AlgAssAbsOrdIdl)
   y = integral_coprime_representative(O, I, d)
   J = I*y
 
-  N = normred(J, O)
-  @assert denominator(N) == 1 # J should be integral
-  N = numerator(N)
+  Nq = normred(J, O)
+  @assert denominator(Nq) == 1 # J should be integral
+  N = numerator(Nq)
   @assert is_principal(N) "Ideal is not principal"
 
   primes = collect(keys(factor(N).fac))

--- a/src/AlgAssAbsOrd/Elem.jl
+++ b/src/AlgAssAbsOrd/Elem.jl
@@ -495,15 +495,15 @@ function is_divisible_mod_ideal(x::AlgAssAbsOrdElem, y::AlgAssAbsOrdElem, a::Alg
     V[1 + i, d + 1 + i] = 1
   end
 
-  V = hnf(V)
+  H = hnf(V)
 
   for i = 2:(d + 1)
-    if !iszero(V[1, i])
+    if !iszero(H[1, i])
       return false, O()
     end
   end
 
-  z = -O([ V[1, i] for i = (d + 2):(2*d + 1) ])
+  z = -O([ H[1, i] for i = (d + 2):(2*d + 1) ])
   return true, z
 end
 

--- a/src/AlgAssAbsOrd/Ideal.jl
+++ b/src/AlgAssAbsOrd/Ideal.jl
@@ -222,13 +222,12 @@ function ideal_from_lattice_gens(A::AbstractAssociativeAlgebra{QQFieldElem}, v::
   for i = 1:length(v)
     elem_to_mat_row!(M, i, v[i])
   end
-  M = _hnf_integral(M, :lowerleft)
-  i = something(findfirst(k -> !is_zero_row(M, k), 1:nrows(M)), nrows(M) + 1)
+  H = _hnf_integral(M, :lowerleft)
+  i = something(findfirst(k -> !is_zero_row(H, k), 1:nrows(H)), nrows(H) + 1)
   #if length(v) >= dim(A)
-  #  M = sub(M, (nrows(M) - dim(A) + 1):nrows(M), 1:dim(A))
+  #  H = sub(H, (nrows(H) - dim(A) + 1):nrows(H), 1:dim(A))
   #end
-  M = sub(M, i:nrows(M), 1:ncols(M))
-  return ideal(A, M; M_in_hnf=true)
+  return ideal(A, sub(H, i:nrows(H), 1:ncols(H)); M_in_hnf=true)
 end
 
 @doc raw"""

--- a/src/AlgAssAbsOrd/PIP/bley_hofmann_johnston.jl
+++ b/src/AlgAssAbsOrd/PIP/bley_hofmann_johnston.jl
@@ -435,7 +435,7 @@ function _lift_norm_one_unit_full_rational_matrix_algebra(x, F)
 
   nn = ZZ(n)
 
-  R, c = nice_order(M)
+  _, c = nice_order(M)
 
   xwrtR = c * elem_in_algebra(x) * inv(c)
 

--- a/src/AlgAssAbsOrd/PIP/bley_johnston.jl
+++ b/src/AlgAssAbsOrd/PIP/bley_johnston.jl
@@ -101,8 +101,8 @@ function __unit_reps_simple(M, F; GRH::Bool = true)
   else
     __units = collect(zip(UB, UB_reduced))
     @vprintln :PIP "Closing in the other case"
-    cl = closure(__units, (x, y) -> (x[1] * y[1], x[2] * y[2]), eq = (x, y) -> x[2] == y[2])
-    return first.(cl)
+    cl2 = closure(__units, (x, y) -> (x[1] * y[1], x[2] * y[2]), eq = (x, y) -> x[2] == y[2])
+    return first.(cl2)
   end
 end
 

--- a/src/AlgAssAbsOrd/ResidueRingMultGrp.jl
+++ b/src/AlgAssAbsOrd/ResidueRingMultGrp.jl
@@ -241,11 +241,11 @@ function _multgrp_mod_p(p::AlgAssAbsOrdIdl, P::AlgAssAbsOrdIdl)
 
   function disc_log(x::AlgAssAbsOrdElem)
     xx = OAtoOAP(OA(x))
-    g = GtoOAP\xx
-    b, h = has_preimage_with_preimage(HtoG, g)
-    @assert b
-    b, s = has_preimage_with_preimage(StoH, h)
-    @assert b
+    gx = GtoOAP\xx
+    fl, h = has_preimage_with_preimage(HtoG, gx)
+    @assert fl
+    fl2, s = has_preimage_with_preimage(StoH, h)
+    @assert fl2
     return [ s.coeff[1, i] for i = 1:ngens(S) ]
   end
 

--- a/src/AlgAssAbsOrd/UnitGroup.jl
+++ b/src/AlgAssAbsOrd/UnitGroup.jl
@@ -8,13 +8,13 @@ function unit_group(O::AlgAssAbsOrd; GRH::Bool = true)
   @assert is_commutative(O)
   mU = get_attribute!(O, :unit_group) do
     if is_maximal(O)
-      U, mU = _unit_group_maximal(O; GRH = GRH)
+      U, m = _unit_group_maximal(O; GRH = GRH)
     else
       OK = maximal_order(O)
       UU, mUU = unit_group(OK; GRH = GRH)
-      U, mU = _unit_group_non_maximal(O, OK, mUU)
+      U, m = _unit_group_non_maximal(O, OK, mUU)
     end
-    return mU
+    return m
   end::Map
   return domain(mU), mU
 end
@@ -23,13 +23,13 @@ function unit_group_fac_elem(O::AlgAssAbsOrd; GRH::Bool = true)
   @assert is_commutative(O)
   mU = get_attribute!(O, :unit_group_fac_elem) do
     if is_maximal(O)
-      U, mU = _unit_group_maximal_fac_elem(O; GRH = GRH)
+      U, m = _unit_group_maximal_fac_elem(O; GRH = GRH)
     else
       OK = maximal_order(O)
       UU, mUU = unit_group_fac_elem(OK; GRH = GRH)
-      U, mU = _unit_group_non_maximal(O, OK, mUU)
+      U, m = _unit_group_non_maximal(O, OK, mUU)
     end
-    return mU
+    return m
   end::Map
   return domain(mU), mU
 end

--- a/src/AlgAssRelOrd/NEQ.jl
+++ b/src/AlgAssRelOrd/NEQ.jl
@@ -125,7 +125,8 @@ function _norm_equation_relative(NC::NormCache, order_num::Int; max_num_fields::
           push!(fields_in_product, (LtoA, KtoL))
 
           G, pi = direct_product(G, UK, task = :prod)::Tuple{FinGenAbGroup, Tuple{FinGenAbGroupHom, FinGenAbGroupHom}}
-          GtoUk = hom(G, Uk, gens(G), [ GtoUk(pi[1](g)) + N(pi[2](g)) for g in gens(G) ])
+          old_GtoUk = GtoUk
+          GtoUk = hom(G, Uk, gens(G), [ old_GtoUk(pi[1](g)) + N(pi[2](g)) for g in gens(G) ])
           if is_surjective(GtoUk)
             NC.GtoUk_surjective[order_num] = true
           end

--- a/src/ConCrv/ConCrv.jl
+++ b/src/ConCrv/ConCrv.jl
@@ -404,8 +404,8 @@ function reduce_conic(v)
   w = lcm([ad, bd, cd])
   a, b, c = map(x -> w*x, [a, b, c])
   a,b,c = map(numerator, [a,b,c])
-  w = gcd(a,b,c)
-  a, b, c = map(x -> x/w, [a, b, c])
+  g = gcd(a,b,c)
+  a, b, c = map(x -> x/g, [a, b, c])
   lambda = mu = nu = 1
 
   facs_a = factor_squarefree(a)

--- a/src/FieldFactory/ab_exts.jl
+++ b/src/FieldFactory/ab_exts.jl
@@ -625,8 +625,8 @@ end
 ###############################################################################
 
 function C22_extensions(bound::Int)
-  Qx, x=polynomial_ring(ZZ, "x")
-  K, _=number_field(x-1, cached = false)
+  Qx, t=polynomial_ring(ZZ, "x")
+  K, _=number_field(t-1, cached = false)
   Kx,x=polynomial_ring(K,"x", cached=false)
   b1=ceil(Int,Base.sqrt(bound))
   n=2*b1+1

--- a/src/FiniteRings/Ideal.jl
+++ b/src/FiniteRings/Ideal.jl
@@ -275,9 +275,9 @@ function quo(I::FiniteRingIdeal, J::FiniteRingIdeal)
     !fl && error("Ideal not containing second argument")
     push!(gensJinI, x)
   end
-  Q, ItoQ = quo(I.B, gensJinI)
-  SQ, SQtoQ = snf(Q)
-  Q, ItoQ = SQ, ItoQ * inv(SQtoQ)
+  Q0, ItoQ0 = quo(I.B, gensJinI)
+  Q, SQtoQ = snf(Q0)
+  ItoQ = ItoQ0 * inv(SQtoQ)
   gensQ = gens(Q)
   homs = FinGenAbGroupHom[]
   for a in gensQ

--- a/src/FiniteRings/Ring.jl
+++ b/src/FiniteRings/Ring.jl
@@ -479,9 +479,9 @@ Finite ring with additive group
     b = FiniteRingElem(R, a)
     push!(imgs, sum(injs[i](data(b * z[i] - z[i] * b)) for i in 1:length(injs)))
   end
-  _K, KtoA = kernel(hom(A, D, imgs))
+  _K, _KtoA = kernel(hom(A, D, imgs))
   K, StoK = snf(_K)
-  KtoA = StoK * KtoA
+  KtoA = StoK * _KtoA
   mult = FinGenAbGroupHom[]
   for k in gens(K)
     h = hom(K, K, [preimage(KtoA, data(FiniteRingElem(R, KtoA(k)) * FiniteRingElem(R, KtoA(l)))) for l in gens(K)])

--- a/src/FunField/Factor.jl
+++ b/src/FunField/Factor.jl
@@ -281,8 +281,9 @@ function Hecke.swinnerton_dyer(V::Vector, x::Generic.Poly{<:Generic.RationalFunc
   S = base_ring(x)
   T = gen(S)
   X = gen(parent(x))
-  l = [(X^2 + T + i) for i = V]
-  l = [ vcat([2*one(S)], polynomial_to_power_sums(x, 2^n)) for x = l]
+  l0 = [(X^2 + T + i) for i = V]
+  nps = 2^n
+  l = [ vcat([2*one(S)], polynomial_to_power_sums(x, nps)) for x = l0]
   while n > 1
     i = 1
     while 2*i <= n

--- a/src/GenOrd/Auxiliary.jl
+++ b/src/GenOrd/Auxiliary.jl
@@ -57,9 +57,9 @@ function hnf_modular(M::MatElem{T}, d::T, is_prime::Bool = false, shape::Symbol 
   # make sure to pin the type of H: the result of both branches has typeof(M)
   #   but compiler cannot infer it
   H::typeof(M) = if is_prime
-    _, mR = residue_field(parent(d), d)
-    r, h = rref(map_entries(mR, M))
-    map_entries(x->preimage(mR, x), h[1:r, :])
+    _, mF = residue_field(parent(d), d)
+    r, h = rref(map_entries(mF, M))
+    map_entries(x->preimage(mF, x), h[1:r, :])
   else
     _, mR = residue_ring(parent(d), d)
     map_entries(x->preimage(mR, x), hnf(map_entries(mR, M)))

--- a/src/GenOrd/GenOrd.jl
+++ b/src/GenOrd/GenOrd.jl
@@ -549,8 +549,8 @@ function ring_of_multipliers(O::GenOrd{S, T}, I::MatElem{P}, p::P, is_prime::Boo
                   _ring_of_multipliers_reduce_nonprime(m, p, degree(O))
   H = hnf_modular(mm, p, is_prime)
 
-  @vtime :GenOrd 2 Hi, d = pseudo_inv(H)
-  return GenOrd(O, transpose(Hi), d, check = false)::GenOrd{S, T}
+  @vtime :GenOrd 2 Hi, dH = pseudo_inv(H)
+  return GenOrd(O, transpose(Hi), dH, check = false)::GenOrd{S, T}
 end
 
 # ring_of_multipliers function-barrier helpers: it fixes the return type
@@ -596,10 +596,9 @@ function ring_of_multipliers(O::GenOrd, I::MatElem)
   end
   H = mm
 
-  @vtime :GenOrd 2 Hi, d = pseudo_inv(H)
+  @vtime :GenOrd 2 Hi, dH = pseudo_inv(H)
 
-  O = GenOrd(O, transpose(Hi), d, check = false)
-  return O
+  return GenOrd(O, transpose(Hi), dH, check = false)
 end
 
 ################################################################################

--- a/src/GenOrd/Types.jl
+++ b/src/GenOrd/Types.jl
@@ -36,12 +36,12 @@
 
     # f is not monic: need Lenstra Order
 
-    d = degree(F)
-    M = zero_matrix(Qt, d, d)
+    n = degree(F)
+    M = zero_matrix(Qt, n, n)
     M[1, 1] = one(Qt)
-    for i in 2:d
+    for i in 2:n
       for j in i:-1:1
-        M[i, j] = coeff(f, d - (i - j))
+        M[i, j] = coeff(f, n - (i - j))
       end
     end
     return GenOrd(r, M, one(Qt), check = check)

--- a/src/GrpAb/GrpAbFinGen.jl
+++ b/src/GrpAb/GrpAbFinGen.jl
@@ -1872,7 +1872,8 @@ function find_isomorphism_with_abelian_group(G::Vector{<:NumFieldHom{AbsSimpleNu
     for i in 1:length(S)
       el = compose_mod(el, pow(Rx(S[i].prim_img), (x, y) -> Hecke.compose_mod(x, y, Rx(K.pol)), v[i], gen(Rx)), Rx(K.pol))
     end
-		ind = findfirst(x -> Rx(x.prim_img) == el, G)
+    img = el
+		ind = findfirst(x -> Rx(x.prim_img) == img, G)
 		@assert ind !== nothing
     AsnftoG[a] = G[ind]
   end
@@ -2213,8 +2214,8 @@ function saturate(U::FinGenAbGroup, G::FinGenAbGroup)
   for (p, k) = lf
     for i=k:-1:1
       h = hom(G, G, [p^i*g for g = gens(G)])
-      i, mi = image(h)
-      s = intersect(i, U)
+      im, mi = image(h)
+      s = intersect(im, U)
       fl, mp = is_subgroup(s, G)
       q, mq = quo(s, h(U)[1])
       if order(q) != 1
@@ -2242,9 +2243,9 @@ function has_complement(m::FinGenAbGroupHom, to_lattice::Bool = true)
   G = codomain(m)
   if !isfinite(G)
     U = domain(m)
-    q, mq = quo(G, U, false)
-    q, _mq = snf(q)
-    mq = mq*inv(_mq)
+    q0, mq0 = quo(G, U, false)
+    q, _mq = snf(q0)
+    mq = mq0*inv(_mq)
     Cgens = [preimage(mq, g) for g = gens(q)]
     C, mC = sub(G, Cgens, false)
     _, sumUC = sub(G, append!(m.(gens(U)), Cgens), false)

--- a/src/Hecke.jl
+++ b/src/Hecke.jl
@@ -352,6 +352,7 @@ function conjugate_data_arb_roots(K::AbsSimpleNumField, p::Int)
       # Use that e^(i phi) = cos(phi) + i sin(phi)
       # Call sincospi to determine these values
       pstart = max(p, 2) # Sometimes this gets called with -1
+      prec = p
       local _rall::Vector{Tuple{ArbFieldElem, ArbFieldElem}}
       rreal = ArbFieldElem[]
       rcomplex = Vector{AcbFieldElem}(undef, div(degree(K), 2))
@@ -359,7 +360,7 @@ function conjugate_data_arb_roots(K::AbsSimpleNumField, p::Int)
         R = ArbField(pstart, cached = false)
         # We need to pair them
         _rall = Tuple{ArbFieldElem, ArbFieldElem}[ sincospi(QQFieldElem(2*k, f), R) for k in 1:f if gcd(f, k) == 1]
-        if all(x -> radiuslttwopower(x[1], -p) && radiuslttwopower(x[2], -p), _rall)
+        if all(x -> radiuslttwopower(x[1], -prec) && radiuslttwopower(x[2], -prec), _rall)
           CC = AcbField(pstart, cached = false)
           rall = AcbFieldElem[ CC(l[2], l[1]) for l in _rall]
           j = 1
@@ -383,24 +384,26 @@ function conjugate_data_arb_roots(K::AbsSimpleNumField, p::Int)
   elseif has_attribute(K, :maxreal) #Nemo.is_maxreal_type(K) is broken, wait for Nemo 0.54.2
     p = max(p, 2)
     d = degree(K)
-    fl, f = is_real_cyclotomic_type(K)
+    fl, fc = is_real_cyclotomic_type(K)
     @assert fl
-    L, = cyclotomic_field(f; cached = false)
+    L, = cyclotomic_field(fc; cached = false)
     # we need a bit more precsion, since we multiply the real part by two
     i = 1
     while true
       i += 1
       cp = conjugate_data_arb_roots(L, p + i)
-      rreal = ArbFieldElem[]
-      rall = AcbFieldElem[]
+      rr = ArbFieldElem[]
+      ra = AcbFieldElem[]
       @assert length(cp.complex_roots) == d
       for c in cp.complex_roots
         cc = real(c)
         mul2exp!(cc, cc, 1)
-        push!(rreal, cc)
-        push!(rall, parent(c)(cc))
+        push!(rr, cc)
+        push!(ra, parent(c)(cc))
       end
-      if all(!overlaps(rreal[i], rreal[j]) for i in 1:d for j in 1:i-1)
+      if all(!overlaps(rr[i], rr[j]) for i in 1:d for j in 1:i-1)
+        rreal = rr
+        rall = ra
         break
       end
     end

--- a/src/HypellCrv/G2Twists.jl
+++ b/src/HypellCrv/G2Twists.jl
@@ -318,14 +318,15 @@ function g2_models_FF_char2_M160(g2_invs::Vector{T}, all_twists::Bool = true) wh
   E1 = x^16 + x
   V = vector_space(GF(2), degree(F))
   S, phi = sub(V, [ V([E1(v[i]) for i in (1:degree(F))]) for v in basis(V)])
-  W, pi = quo(V, S)
+  Wq, pi = quo(V, S)
 
-  W = [w for w in W if w != zero(W)]
+  W = [w for w in Wq if w != zero(Wq)]
   o = gen(F)
   P, _ = polynomial_ring(GF(2))
 
   for i in (1:3)
-    vec = [preimage(pi, W[1])[i] for i in (1:degree(F)) ]
+    w1 = preimage(pi, W[1])
+    vec = [w1[i] for i in (1:degree(F)) ]
     a = P(vec)(o)
     H = hyperelliptic_curve(x^5 + a*x^4, R(1))
     push!(twists, H)

--- a/src/HypellCrv/HypellCrv.jl
+++ b/src/HypellCrv/HypellCrv.jl
@@ -753,7 +753,8 @@ function repos(S2::Vector{AcbFieldElem}, S_inf::Int)
       end
     end
   end
-  delta = sum(map(x -> real(x)/(abs(x)^2 + exp(2*eta0)), S))
+  e2 = exp(2*eta0)
+  delta = sum(map(x -> real(x)/(abs(x)^2 + e2), S))
   if delta >= 0
     return true
   else

--- a/src/HypellCrv/Isomorphisms.jl
+++ b/src/HypellCrv/Isomorphisms.jl
@@ -285,9 +285,9 @@ function _adjoin_root(K, f::PolyRingElem)
     return L, embed, r
   end
   if K isa FqField
-    L, h = Nemo._residue_field(f)
+    Lf, h = Nemo._residue_field(f)
     Kx = parent(f)
-    return L, a -> h(Kx(a)), h(gen(Kx))
+    return Lf, a -> h(Kx(a)), h(gen(Kx))
   end
   error("_adjoin_root not yet implemented for base field of type $(typeof(K)). Please implement this stub.")
 end
@@ -408,15 +408,15 @@ function is_gl2_equivalent(f1::PolyRingElem{T}, f2::PolyRingElem{T}, n::Int) whe
       end
     end
   elseif d == 2
-    f_irred = first(p for (p, _) in fact1 if degree(p) == d)
-    L1, embed1, rf = _adjoin_root(K, f_irred)
+    f_quad = first(p for (p, _) in fact1 if degree(p) == d)
+    L1, embed1, rf = _adjoin_root(K, f_quad)
 
     sorted_degs = sort(degs1; rev = true)
     d1 = sorted_degs[2]  # second-largest degree of a factor  # second largest (possibly equal to d=2)
 
     if d1 == 2
       # Need a second degree-2 factor of f1
-      ff_irred = first(p for (p, _) in fact1 if degree(p) == 2 && p != f_irred)
+      ff_irred = first(p for (p, _) in fact1 if degree(p) == 2 && p != f_quad)
       L2, embed2, rff = _adjoin_root(K, ff_irred)
 
       e1 = vcat(_coords(one(L1), L1, K), _coords(one(L2), L2, K))

--- a/src/LargeField/basis.jl
+++ b/src/LargeField/basis.jl
@@ -17,9 +17,9 @@ function lll_basis_profile(A::AbsNumFieldOrderIdeal{AbsSimpleNumField, AbsSimple
   Hecke.shift!(g, -prec)
   g += nrows(g)*one(parent(g))
 
-  l = lll_gram(g)
+  lg = lll_gram(g)
 
-  lp = [ div(l[i,i], ZZRingElem(2)^prec) for i=1:nrows(l)]
+  lp = [ div(lg[i,i], ZZRingElem(2)^prec) for i=1:nrows(lg)]
   return lp
 end
 

--- a/src/LinearAlgebra/Solve.jl
+++ b/src/LinearAlgebra/Solve.jl
@@ -96,7 +96,8 @@ function rational_reconstruction2(A::Generic.Mat{AbsSimpleNumFieldElem}, M::ZZRi
       else
         n, dn = algebraic_reconstruction(a, M)
         d*=dn
-        if any(i->!small_coeff(d, sM, i), 1:a_len)
+        dcur = d
+        if any(i->!small_coeff(dcur, sM, i), 1:a_len)
           println("early $i $j abort")
           return false, B
         end

--- a/src/LinearAlgebra/SolveIntegral.jl
+++ b/src/LinearAlgebra/SolveIntegral.jl
@@ -23,12 +23,12 @@ function AbstractAlgebra.Solve._can_solve_internal_no_check(::PseudoHermiteFormT
   R = base_ring(A)
   @assert is_maximal(R)
   AP = pseudo_matrix(A)
-  H, T = pseudo_hnf_with_transform(AP)
+  H0, T = pseudo_hnf_with_transform(AP)
   # compute the rank
-  r = something(findlast(i -> !is_zero_row(matrix(H), i), 1:nrows(H)), nrows(H))
+  r = something(findlast(i -> !is_zero_row(matrix(H0), i), 1:nrows(H0)), nrows(H0))
   # We have to only take the full rank part of H, otherwise is _contained_in_span_...
   # confused.
-  H = sub(H, 1:r, 1:ncols(H))
+  H = sub(H0, 1:r, 1:ncols(H0))
   if task === :only_check
     Kb = nf(R).(b)
     for i in 1:nrows(b)

--- a/src/LocalField/Completions.jl
+++ b/src/LocalField/Completions.jl
@@ -24,9 +24,9 @@ function image(f::CompletionMap, a::AbsSimpleNumFieldElem; pr::Int = precision(c
   end
 
   if iszero(z) || valuation(z) < 0
-    v = valuation(a, f.P)
-    av = abs(v)
-    b = a*uniformizer(f.P).elem_in_nf^-v
+    va = valuation(a, f.P)
+    av = abs(va)
+    b = a*uniformizer(f.P).elem_in_nf^-va
 
     e = absolute_ramification_index(C)
 
@@ -43,7 +43,7 @@ function image(f::CompletionMap, a::AbsSimpleNumFieldElem; pr::Int = precision(c
          evaluate(Qx(b), setprecision(f.prim_img, min(f.precision, pr + e*vv  + av + e)))
       end
     end
-    z *= uniformizer(parent(z), v; prec = pr)
+    z *= uniformizer(parent(z), va; prec = pr)
   end
 
   if precision(z) < pr
@@ -184,7 +184,8 @@ function _lift(a::AbsSimpleNumFieldElem, f::ZZPolyRingElem, prec::Int, P::AbsNum
   end
   O = order(P)
   lp = prime_decomposition(O, minimum(P))
-  v = [valuation(bi, p[1]) for p = lp]
+  b = bi
+  v = [valuation(b, p[1]) for p = lp]
   c = one(O)
   Q = P^prec
   for i=1:length(v)
@@ -253,7 +254,8 @@ function _increase_precision(a::AbsSimpleNumFieldElem, f::ZZPolyRingElem, prec::
 
   O = order(P)
   lp = prime_decomposition(O, minimum(P))
-  v = [valuation(a, p[1]) for p = lp]
+  b = a
+  v = [valuation(b, p[1]) for p = lp]
   c = one(O)
   Q = P^new_prec
   for i=1:length(v)

--- a/src/LocalField/Conjugates.jl
+++ b/src/LocalField/Conjugates.jl
@@ -365,8 +365,8 @@ function special_gram(m::Vector{Vector{QadicFieldElem}})
 end
 
 function special_gram(m::Vector{Vector{PadicFieldElem}})
-  n = transpose(matrix(m))
-  n = transpose(n)*n
+  mt = transpose(matrix(m))
+  n = transpose(mt)*mt
   return [[n[i,j] for j=1:ncols(n)] for i = 1:nrows(n)]
 end
 
@@ -406,8 +406,8 @@ function regulator_iwasawa(u::Vector{T}, C::qAdicConj, n::Int = 10) where {T<: U
   k = base_ring(u[1])
   @assert is_totally_real(k)
   c = map(x -> conjugates_log(x, C, n, all = true, flat = false), u)
-  m = matrix(c)
-  m = vcat(m, matrix(base_ring(m), 1, ncols(m), [one(base_ring(m)) for i=1:ncols(m)]))
+  m0 = matrix(c)
+  m = vcat(m0, matrix(base_ring(m0), 1, ncols(m0), [one(base_ring(m0)) for i=1:ncols(m0)]))
   return det(m)//degree(k)
 end
 
@@ -574,14 +574,14 @@ function completion(K::AbsSimpleNumField, ca::QadicFieldElem; cached::Bool = tru
   i = findfirst(x->parent(r[x]) == parent(ca) && r[x] == ca, 1:length(r))
   Zx = polynomial_ring(ZZ, cached = false)[1]
   function inj(a::AbsSimpleNumFieldElem)
-    d = denominator(a)
+    den = denominator(a)
     pr = precision(parent(ca))
     if pr > precision(ca)
       ri = roots(C.C, precision(parent(ca)))[i]
     else
       ri = ca
     end
-    return inv(parent(ca)(d))*(Zx(a*d)(ri))
+    return inv(parent(ca)(den))*(Zx(a*den)(ri))
   end
   # gen(K) -> conj(a, p)[i] -> a = sum a_i o^i
   # need o = sum o_i a^i
@@ -628,27 +628,27 @@ function completion(K::AbsSimpleNumField, ca::QadicFieldElem; cached::Bool = tru
       #XXX this changes (c, pc) inplace as a cache
       #probably should be done with a new map type that can
       #store c, pc on the map.
-      d = lift_root(f, a, b, p, precision(x))
+      rt = lift_root(f, a, b, p, precision(x))
 #  Kjj = number_field(lf[jj][1], check = false, cached = false)[1]
 #  ajj = Kjj(parent(Kjj.pol)(a))
 #  bjj = Kjj(parent(Kjj.pol)(b))
 #  djj = lift_root(f, ajj, bjj, p, 10)
-#  d = K(parent(K.pol)(djj))
-      ccall((:nf_elem_set, libflint), Nothing, (Ref{AbsSimpleNumFieldElem}, Ref{AbsSimpleNumFieldElem}, Ref{AbsSimpleNumField}), c, d, K)
+#  rt = K(parent(K.pol)(djj))
+      ccall((:nf_elem_set, libflint), Nothing, (Ref{AbsSimpleNumFieldElem}, Ref{AbsSimpleNumFieldElem}, Ref{AbsSimpleNumField}), c, rt, K)
       set!(pc, precision(x))
     elseif precision(x) < pc
-      d = mod_sym(c, p^precision(x))
+      rt = mod_sym(c, p^precision(x))
     else
-      d = c
+      rt = c
     end
     n = x.length
-    r = K(lift(ZZ, coeff(x, n-1)))
+    res = K(lift(ZZ, coeff(x, n-1)))
     pk = p^precision(x)
     while n > 1
       n -= 1
-      r = mod_sym(r*d, pk) + lift(ZZ, coeff(x, n-1))
+      res = mod_sym(res*rt, pk) + lift(ZZ, coeff(x, n-1))
     end
-    return r#*K(p)^valuation(x)
+    return res#*K(p)^valuation(x)
   end
   return parent(ca), MapFromFunc(K, parent(ca), inj, lif)
 end

--- a/src/LocalField/Poly.jl
+++ b/src/LocalField/Poly.jl
@@ -924,8 +924,9 @@ function lift(C::HenselCtxdr, mx::Int)
   N = minimum([precision(x) for x in C.lf])
   N = min(N, minimum([precision(x) for x in C.la]))
   #have: N need mx
-  one = setprecision(parent(p), mx) do
-    Base.one(parent(p))
+  K = parent(p)
+  one = setprecision(K, mx) do
+    Base.one(K)
   end
   ch = Int[mx]
   while ch[end] > N

--- a/src/LocalField/automorphisms.jl
+++ b/src/LocalField/automorphisms.jl
@@ -69,19 +69,19 @@ function refine_roots1(f::Generic.Poly{T}, rt::Vector{T}) where T <: Union{Padic
   rtnew = setprecision(base_ring(f), precision(f)) do
     der = derivative(f)
     @assert precision(der) >= target_prec
-    rtnew = [setprecision(x, target_prec) for x = rt]
-    wvect = [(der(rtnew[i])) for i = 1:length(rt)]
+    rts = [setprecision(x, target_prec) for x = rt]
+    wvect = [(der(rts[i])) for i = 1:length(rt)]
     prec_loss = Int(absolute_ramification_index(parent(rt[1]))*maximum(valuation, wvect))
     wvect = map(inv, wvect)
     for i in 1:length(chain)
-      for j = 1:length(rtnew)
-        rtnew[j] = rtnew[j] - wvect[j]*f(rtnew[j])
+      for j = 1:length(rts)
+        rts[j] = rts[j] - wvect[j]*f(rts[j])
         if i < length(chain)
-          wvect[j] = wvect[j]*(2-wvect[j]*der(rtnew[j]))
+          wvect[j] = wvect[j]*(2-wvect[j]*der(rts[j]))
         end
       end
     end
-    return [setprecision(x, target_prec - prec_loss) for x= rtnew]
+    return [setprecision(x, target_prec - prec_loss) for x= rts]
   end
   return rtnew
 end

--- a/src/LocalField/map.jl
+++ b/src/LocalField/map.jl
@@ -233,12 +233,12 @@ function map_data_given_base_field_data(K::LocalField, L, z, y; check = true)
   if check
     setprecision(base_field(K), precision(yy)) do
       f = map_coefficients(w -> image(z, L, w), defining_polynomial(K), cached = false)
-      y = evaluate(f, yy)
-      if !iszero(y)
-        @show valuation(y), precision(y), y, precision(yy)
+      img = evaluate(f, yy)
+      if !iszero(img)
+        @show valuation(img), precision(img), img, precision(yy)
       end
 
-      !iszero(y) && error("Data does not define a morphism")
+      !iszero(img) && error("Data does not define a morphism")
     end
   end
 

--- a/src/LocalField/neq.jl
+++ b/src/LocalField/neq.jl
@@ -83,7 +83,8 @@ function Nemo.basis(K::FinField, k::FinField)
   b = basis(K)
   K = base_field(K)
   while absolute_degree(K) > absolute_degree(k)
-    b = [x*y for x = basis(K) for y = b]
+    bb = b
+    b = [x*y for x = basis(K) for y = bb]
     K = base_field(K)
   end
   if K != k
@@ -203,7 +204,8 @@ end
 function coordinates(a::Union{QadicFieldElem, LocalFieldElem}, k)
   c = [coeff(a, i) for i=0:degree(parent(a))-1]
   while absolute_degree(parent(c[1])) > absolute_degree(k)
-    c = reduce(vcat, [[coeff(x, i) for i=0:(degree(parent(c[1]))-1)] for x = c])
+    d = degree(parent(c[1]))
+    c = reduce(vcat, [[coeff(x, i) for i=0:d-1] for x = c])
   end
   if parent(c[1]) != k
     if isa(parent(c[1]), QadicField) && degree(parent(c[1])) ==1
@@ -261,10 +263,10 @@ function solve_1_units(a::Vector{T}, b::T) where T
     pk = ZZRingElem(p)
 
     val_offset = e .* map(valuation, absolute_basis(K))
-    cur_b = setprecision(b, k+e)
-    cur_a = [setprecision(x, k+e) for x = a]
-    b = setprecision(b, k+e)
-    a = [setprecision(x, k+e) for x = a]
+    b_prec = setprecision(b, k+e)
+    a_prec = [setprecision(x, k+e) for x = a]
+    cur_b = b_prec
+    cur_a = a_prec
     pow_b = ZZRingElem(1)
 
     while l <= k
@@ -286,7 +288,8 @@ function solve_1_units(a::Vector{T}, b::T) where T
       end
       @assert e*valuation(cur_b-one) >= l
       @assert precision(cur_b) > k
-      @assert all(x->isone(x) || e*valuation(x-one) >= l, cur_a)
+      lvl = l # `l` is reassigned below and must not be captured
+      @assert all(x->isone(x) || e*valuation(x-one) >= lvl, cur_a)
 
       A = abelian_group([p^max(0, ceil(Int, (l-v)//e)) for v = val_offset])
       h = hom(free_abelian_group(length(cur_a)), A, [A([lift(ZZ, x) for x =  absolute_coordinates(divexact(y-one, pi^l))]) for y = cur_a]; check = false)
@@ -317,12 +320,13 @@ function solve_1_units(a::Vector{T}, b::T) where T
 
       expo += s.coeff * expo_mult
       expo_mult = reduce(vcat, [_mk(x).coeff for x = gens(_k)])*expo_mult
-      cur_a = [prod(cur_a[i]^_mk(x)[i] for i=1:length(cur_a)) for x = gens(_k)]
+      ca = cur_a
+      cur_a = [prod(ca[i]^_mk(x)[i] for i=1:length(ca)) for x = gens(_k)]
   #    @show [e*valuation(x-1) for x = cur_a]
 
 
-      pa = prod(a[i]^expo[i] for i=1:length(a))
-      cur_b = divexact(b^pow_b, pa)
+      pa = prod(a_prec[i]^expo[i] for i=1:length(a_prec))
+      cur_b = divexact(b_prec^pow_b, pa)
       if iszero(cur_b-one) || e*valuation(cur_b-one) >= k
         break
       end
@@ -1538,11 +1542,11 @@ function norm_ctx(mc::Map{AbsSimpleNumField, <:Hecke.LocalField}, mC::Map{AbsSim
     push!(pow_pi, pow_pi[end]*pi_C)
   end
 
-  pow_rho = [one(base_field(C))]
-  while length(pow_rho) < fC/fc
-    push!(pow_rho, pow_rho[end]*rho_C)
+  pow_rho_base = [one(base_field(C))]
+  while length(pow_rho_base) < fC/fc
+    push!(pow_rho_base, pow_rho_base[end]*rho_C)
   end
-  pow_rho = map(C, pow_rho)
+  pow_rho = map(C, pow_rho_base)
 
   b_k = absolute_basis(c)
   b_kK = [mC(mkK(preimage(mc, x))) for x = b_k]
@@ -1557,11 +1561,11 @@ function norm_ctx(mc::Map{AbsSimpleNumField, <:Hecke.LocalField}, mC::Map{AbsSim
     e = divexact(eC, ec)
     f = divexact(fC, fc)
     n = length(b_k)
-    img = S*matrix(hcat([absolute_coordinates(x*t) for t = pow_pi]...))
-    m = matrix(C, length(pow_pi), length(pow_pi), [sum(img[(i-1)*f*n+j, k]*b_K[j] for j=1:f*n) for i=1:e for k=1:e])
+    img_pi = S*matrix(hcat([absolute_coordinates(x*t) for t = pow_pi]...))
+    m = matrix(C, length(pow_pi), length(pow_pi), [sum(img_pi[(i-1)*f*n+j, k]*b_K[j] for j=1:f*n) for i=1:e for k=1:e])
     d = det(m)
-    img = S*matrix(hcat([absolute_coordinates(d*t) for t = pow_rho]...))
-    m = matrix(c, length(pow_rho), length(pow_rho), [sum(img[j+(i-1)*n, k]*b_k[j] for j=1:n) for i=1:f for k=1:f])
+    img_rho = S*matrix(hcat([absolute_coordinates(d*t) for t = pow_rho]...))
+    m = matrix(c, length(pow_rho), length(pow_rho), [sum(img_rho[j+(i-1)*n, k]*b_k[j] for j=1:n) for i=1:f for k=1:f])
     return det(m)
   end
   return norm

--- a/src/LocalField/pAdic.jl
+++ b/src/LocalField/pAdic.jl
@@ -79,7 +79,8 @@ function my_log_one_minus(x::QadicFieldElem)
   S, _ = residue_ring(R, map_coefficients(x->QQ(lift(ZZ, x)), defining_polynomial(parent(x)), parent = R))
   while true
     Y = 1-X
-    y = S(R([lift(ZZ, coeff(Y, i)) % pp for i=0:length(Y)]))
+    m = pp
+    y = S(R([lift(ZZ, coeff(Y, i)) % m for i=0:length(Y)]))
     lg += parent(x)(my_log_one_minus_inner(y, precision(x), le, prime(parent(x))).data)
     X = X*inv(parent(x)(1-y.data))
     pp *= pp

--- a/src/LocalField/qAdic.jl
+++ b/src/LocalField/qAdic.jl
@@ -21,11 +21,11 @@ function residue_field(Q::QadicField)
     return k(_z)
   end
   lif = function(x::FqFieldElem)
-    z = Q()
+    res = Q()
     for i=0:degree(Q)-1
-      setcoeff!(z, i, lift(ZZ, coeff(x, i)))
+      setcoeff!(res, i, lift(ZZ, coeff(x, i)))
     end
-    return z
+    return res
   end
   mk = MapFromFunc(Q, k, pro, lif)
   set_attribute!(Q, :ResidueFieldMap => mk)

--- a/src/Map/FqPolyRing.jl
+++ b/src/Map/FqPolyRing.jl
@@ -118,11 +118,11 @@ mutable struct FqPolyRingToFqMor{S, T, PolyType, MatType} <: Map{S, T, HeckeMap,
       for k = 0:n*m - 1
         x_mat[k + 1, 1] = Fp(coeff(x, k))
       end
-      x_mat = invM*x_mat
+      y_mat = invM*x_mat
       f = parent(h)()
       t = Fqm()
       for j = 0:m - 1
-        tt = parent(g)([ x_mat[i + n*j + 1, 1] for i = 0:n - 1 ])
+        tt = parent(g)([ y_mat[i + n*j + 1, 1] for i = 0:n - 1 ])
         if isnmod
           ccall((:fq_nmod_set, libflint), Nothing, (Ref{fqPolyRepFieldElem}, Ref{fpPolyRingElem}, Ref{fqPolyRepField}), t, tt, Fq)
         else

--- a/src/Map/NfRelOrd.jl
+++ b/src/Map/NfRelOrd.jl
@@ -243,7 +243,7 @@ mutable struct NfRelOrdToFqFieldRelMor{S} <: Map{S, FqField, HeckeMap, NfRelOrdT
       ccall((:fq_default_poly_set, libflint), Nothing, (Ref{FqPolyRingElem}, Ref{FqPolyRingElem}, Ref{FqField}), hh, h, FK)
       z.poly_of_the_field = hh
 
-      FE, mE = Nemo._residue_field(hh)
+      FE, mFE = Nemo._residue_field(hh)
 
       #FE = RelFinField(hh, :v)
       #FEabs, FEabstoFE = Hecke.absolute_field(FE, cached = false)
@@ -258,11 +258,11 @@ mutable struct NfRelOrdToFqFieldRelMor{S} <: Map{S, FqField, HeckeMap, NfRelOrdT
         else
           ff = FKx([ mmK(coeff(f, i)) for i =0:degree(f)])
         end
-        return image(mE, ff)
+        return image(mFE, ff)
       end
 
       function _preimage(x::FqFieldElem)
-        f = preimage(mE, x)
+        f = preimage(mFE, x)
         immK = pseudo_inv(mmK)
         y = nf(O)([ immK(coeff(f,i)) for i=0:degree(f)])
         res = O(y)
@@ -350,7 +350,7 @@ mutable struct NfRelOrdToRelFinFieldMor{S, T} <: Map{S, RelFinField{T}, HeckeMap
       FEabs, FEabstoFE = Hecke.absolute_field(FE, cached = false)
       FE2, mE2 = field_extension(hh)
       FE2toFEabs = hom(FE2, FEabs, gen(FEabs))
-      mE = compose(mE2, compose(FE2toFEabs, FEabstoFE))
+      mFE = compose(mE2, compose(FE2toFEabs, FEabstoFE))
 
       function _image(x::RelNumFieldOrderElem)
         f = parent(nf(O).pol)(elem_in_nf(x))
@@ -359,11 +359,11 @@ mutable struct NfRelOrdToRelFinFieldMor{S, T} <: Map{S, RelFinField{T}, HeckeMap
         else
           ff = FKx([ mmK(coeff(f, i)) for i =0:degree(f)])
         end
-        return image(mE, ff)
+        return image(mFE, ff)
       end
 
       function _preimage(x::RelFinFieldElem)
-        f = preimage(mE, x)
+        f = preimage(mFE, x)
         immK = pseudo_inv(mmK)
         y = nf(O)([ immK(coeff(f,i)) for i=0:degree(f)])
         return O(y)
@@ -452,7 +452,7 @@ mutable struct NfRelOrdToRelFinFieldMor{S, T} <: Map{S, RelFinField{T}, HeckeMap
       FKxtoFKabsz = MapFromFunc(FKx, FKabsz, f -> FKabsz(FKtoFKabs.(collect(coefficients(f)))))
       FE2, mE2 = field_extension(hh)
       FE2toFEabs = hom(FE2, FEabs, gen(FEabs))
-      mE = compose(FKxtoFKabsz,compose(mE2, compose(FE2toFEabs, FEabstoFE)))
+      mFE = compose(FKxtoFKabsz,compose(mE2, compose(FE2toFEabs, FEabstoFE)))
 
       function _image(x::RelNumFieldOrderElem)
         f = parent(nf(O).pol)(elem_in_nf(x))
@@ -461,11 +461,11 @@ mutable struct NfRelOrdToRelFinFieldMor{S, T} <: Map{S, RelFinField{T}, HeckeMap
         else
           ff = FKx([ mmK(coeff(f, i)) for i =0:degree(f)])
         end
-        return image(mE, ff)
+        return image(mFE, ff)
       end
 
       function _preimage(x::RelFinFieldElem)
-        f = preimage(mE, x)
+        f = preimage(mFE, x)
         immK = pseudo_inv(mmK)
         y = nf(O)([ immK(coeff(f,i)) for i=0:degree(f)])
         return O(y)

--- a/src/Map/NumberField.jl
+++ b/src/Map/NumberField.jl
@@ -526,8 +526,8 @@ function small_generating_set(G::Vector{<: NumFieldHom{AbsSimpleNumField, AbsSim
     end
 	  R = Native.GF(p, cached = false)
 		Rx = polynomial_ring(R, "x", cached = false)[1]
-    gmodp = change_base_ring(R, g; parent = Rx)
-    if degree(gmodp) == degree(g) && !is_zero(discriminant(gmodp))
+    gp = change_base_ring(R, g; parent = Rx)
+    if degree(gp) == degree(g) && !is_zero(discriminant(gp))
       break
     end
   end

--- a/src/Misc/Poly.jl
+++ b/src/Misc/Poly.jl
@@ -554,7 +554,7 @@ end
 function charpoly_mod(M::Generic.Mat{AbsSimpleNumFieldElem}; integral::Bool = false, normal::Bool = false, proof::Bool = true)
   K = base_ring(M)
   p = p_start
-  Kt, t = polynomial_ring(K, cached = false)
+  Kt, _ = polynomial_ring(K, cached = false)
   f = Kt()
   f_last = f
   d = ZZRingElem(1)

--- a/src/Misc/PseudoPolynomial.jl
+++ b/src/Misc/PseudoPolynomial.jl
@@ -45,8 +45,8 @@ function can_reduce(f::PseudoPoly{S, T}, G::Vector{PseudoPoly{S, T}}) where {S, 
   simplify(b)
   if isone(denominator(b))
     c = sum(leading_coefficient(G[i]) for i in I)//coefficient_ideal(f)
-    l = _contains(leading_coefficient(polynomial(f)), [leading_coefficient(G[i])//coefficient_ideal(f) for i in I])
-    l = AbsSimpleNumFieldElem[ l[i]//leading_coefficient(polynomial(G[I[i]])) for i in 1:length(I)]
+    l0 = _contains(leading_coefficient(polynomial(f)), [leading_coefficient(G[i])//coefficient_ideal(f) for i in I])
+    l = AbsSimpleNumFieldElem[ l0[i]//leading_coefficient(polynomial(G[I[i]])) for i in 1:length(I)]
     g = deepcopy(polynomial(f))
     @assert leading_coefficient(polynomial(f)) == sum(l[i] * leading_coefficient(polynomial(G[I[i]])) for i in 1:length(I))
     for i in 1:length(I)

--- a/src/Misc/QQBar.jl
+++ b/src/Misc/QQBar.jl
@@ -9,7 +9,8 @@ function _primitive_element(a::Vector{QQBarFieldElem})
     k, _ = number_field(f, check = false, cached = false)
     lf = collect(keys(factor(k, g).fac))
     for j = 1:length(lf)
-      h = map_coefficients(x->Qx(x)(pe), lf[j])
+      cur = pe
+      h = map_coefficients(x->Qx(x)(cur), lf[j])
       if is_zero(h(a[i]))
         d = degree(f) * degree(h)
         mu = 0

--- a/src/Misc/RatRecon.jl
+++ b/src/Misc/RatRecon.jl
@@ -308,10 +308,10 @@ end
 function berlekamp_massey_naive(L::Vector{T}; parent = polynomial_ring(parent(L[1]), "x", cached = false)[1]) where T
      R_s = Nemo.parent(L[1])
      lg = length(L)
-     L = [R_s(L[lg-i]) for i in 0:lg-1]
+     Lrev = [R_s(L[lg-i]) for i in 0:lg-1]
      Ry = parent
      Y = gen(Ry)
-     g = Ry(L)
+     g = Ry(Lrev)
      if iszero(g)
        return true, g
      end
@@ -415,7 +415,8 @@ function listprimes(f::Vector{QQPolyRingElem}, p::ZZRingElem, M::Int)
    i=0; L = ZZRingElem[]
    while true
     i += 1
-    if all(x-> testPrime_jl(x,p), f)
+    q = p
+    if all(x-> testPrime_jl(x,q), f)
        push!(L, p)
     end
     if i == M

--- a/src/Misc/RelFiniteField.jl
+++ b/src/Misc/RelFiniteField.jl
@@ -710,13 +710,13 @@ function absolute_field(F::RelFinField{T}; cached::Bool = true) where T <: FinFi
       aux[1, j] = coeff(x, j-1)
     end
     mul!(aux, aux, Minv)
-    el = F()
+    res = F()
     for i = 1:degree(K)
       if !iszero(aux[1, i])
-        el += F(aux[1, i])*abs_basis[i]
+        res += F(aux[1, i])*abs_basis[i]
       end
     end
-    return el
+    return res
   end
 
   Fpx = polynomial_ring(Fp)[1]

--- a/src/Misc/nmod_poly.jl
+++ b/src/Misc/nmod_poly.jl
@@ -1260,8 +1260,9 @@ function unit_group_1_part(f::fqPolyRepPolyRingElem, k::Int)
     # 1+f^p1/1+f^p2 = f^p1/f^p2 = f^(p2-p1), latter additively
     ngens = [1+(x^i)*f1*c for i=0:(degree(f)*(p2-p1)-1) for c = b]
     nr = matrix(ZZ, 0, length(ngens), [])
-    for j=1:nrows(rels)
-      g = rem(prod(powermod(gens[k], rels[j, k], f2) for k=1:ncols(rels)), f2) - 1
+    rl = rels
+    for j=1:nrows(rl)
+      g = rem(prod(powermod(gens[k], rl[j, k], f2) for k=1:ncols(rl)), f2) - 1
       q,r = divrem(g, f1)
       @assert iszero(r)
       nr = vcat(nr, matrix(ZZ, 1, ncols(nr), [(coeff(coeff(q, k), l)) for k = 0:degree(f)*(p2-p1)-1 for l = 0:degree(K)-1]))

--- a/src/NumField/NfAbs/CompactRepresentation.jl
+++ b/src/NumField/NfAbs/CompactRepresentation.jl
@@ -126,20 +126,21 @@ function compact_presentation(a::FacElem{AbsSimpleNumFieldElem, AbsSimpleNumFiel
 
   while k>=1
     @vprintln :CompactPresentation 1 "k now: $k"
-    D = Dict((p, div(ZZRingElem(v), n^k)) for (p, v) = de if v >= n^k)
+    nk = n^k
+    D = Dict((p, div(ZZRingElem(v), nk)) for (p, v) = de if v >= nk)
     if length(D) == 0
       A = FacElem(Dict(ideal(ZK, 1) => 1))
     else
       A = FacElem(D)
     end
-    vv = ArbFieldElem[x//n^k for x = v]
+    vv = ArbFieldElem[x//nk for x = v]
     vvv = ZZRingElem[]
     el_embs = a*be
     for i=1:r1
       while !radiuslttwopower(vv[i], -5)
         arb_prec *= 2
         v = conjugates_arb_log_normalise(el_embs, arb_prec)
-        vv = ArbFieldElem[x//n^k for x = v]
+        vv = ArbFieldElem[x//nk for x = v]
       end
       push!(vvv, round(ZZRingElem, vv[i]//log(2)))
     end
@@ -147,7 +148,7 @@ function compact_presentation(a::FacElem{AbsSimpleNumFieldElem, AbsSimpleNumFiel
       while !radiuslttwopower(vv[i], -5)
         arb_prec *= 2
         v = conjugates_arb_log_normalise(el_embs, arb_prec)
-        vv = ArbFieldElem[x//n^k for x = v]
+        vv = ArbFieldElem[x//nk for x = v]
       end
       local r = round(ZZRingElem, vv[i]//log(2)//2)
       push!(vvv, r)

--- a/src/NumField/NfAbs/MPolyAbsFact.jl
+++ b/src/NumField/NfAbs/MPolyAbsFact.jl
@@ -119,10 +119,10 @@ mutable struct HenselCtxFqRelSeries{T}
     k = base_ring(lf[1])
     if isa(k, Nemo.fpField)
       p = Int(characteristic(k))
-      k = quo(ZZ, p)[1]
-      kt, t = polynomial_ring(k, cached = false)
-      lf = [map_coefficients(k, x, parent = kt) for x = lf]
-      lg = [map_coefficients(k, x, parent = kt) for x = lg]
+      Zp = quo(ZZ, p)[1]
+      kt, t = polynomial_ring(Zp, cached = false)
+      lf = [map_coefficients(Zp, x, parent = kt) for x = lf]
+      lg = [map_coefficients(Zp, x, parent = kt) for x = lg]
     end
 
     return HenselCtxFqRelSeries(f, lf, lg, n, s)
@@ -877,18 +877,18 @@ function field(RC::RootCtx, m::MatElem)
   kS = power_series_ring(k, tf+2, "s")[1]
   for x = HH.lf[1:HH.n]
     f = MPolyBuildCtx(kXY)
-    lc = one(kt)
+    den = one(kt)
     cz = []
     z = x
     for i=0:degree(x)
       c = coeff(z, i)
       local fl, n, d = rational_reconstruction(c, parent = kt)
       @assert fl
-      b = lcm(lc, d)
+      b = lcm(den, d)
       n *= divexact(b, d)
-      if b != lc
-        cz = divexact(b, lc) .* cz
-        lc = b
+      if b != den
+        cz = divexact(b, den) .* cz
+        den = b
       end
       push!(cz, n)
     end
@@ -1074,19 +1074,19 @@ function field(RC::RootCtx, m::MatElem)
 
     @vprintln :AbsFact 1  "using as number field: $k"
 
-    m = transpose(matrix([[pe(x)^l for x = fl] for l=0:degree(k)-1]))
+    mm = transpose(matrix([[pe(x)^l for x = fl] for l=0:degree(k)-1]))
     kx, x = polynomial_ring(k, "x", cached = false)
     kX, _ = polynomial_ring(k, ["X", "Y"], cached = false)
     B = MPolyBuildCtx(kX)
     for j=1:length(el[1])
       n = transpose(matrix([[coeff(x, j)] for x = fl]))
-      s = Hecke.solve(m, transpose(n); side = :right)
+      s = Hecke.solve(mm, transpose(n); side = :right)
       @assert all(x->iszero(coeff(s[x, 1], 1)), 1:degree(k))
-      s = [rational_reconstruction(coeff(s[i, 1], 0)) for i=1:degree(k)]
-      if !all(x->x[1], s)
+      sr = [rational_reconstruction(coeff(s[i, 1], 0)) for i=1:degree(k)]
+      if !all(x->x[1], sr)
         break
       end
-      push_term!(B, k([x[2]//x[3] for x = s]), exponent_vector(el[1], j))
+      push_term!(B, k([x[2]//x[3] for x = sr]), exponent_vector(el[1], j))
     end
     q = finish(B)
     if length(q) < length(el[1])
@@ -1244,10 +1244,10 @@ function lift_prime_power(
     ok, I = Hecke.AbstractAlgebra.MPolyFactor.pfracinit(md, 1, minorvars, alphas)
     @assert ok  # evaluation of fac's should be pairwise coprime
 
-    a = map_coefficients(ZZ, a, parent = parent(fac[1]))
+    aa = map_coefficients(ZZ, a, parent = parent(fac[1]))
 
     for l in kstart:kstop
-        error = a - prod(fac)
+        error = aa - prod(fac)
 
         for c in coefficients(error)
           if valuation(c) < l

--- a/src/NumField/NfAbs/MPolyFactor.jl
+++ b/src/NumField/NfAbs/MPolyFactor.jl
@@ -222,8 +222,8 @@ function hlift_have_lcs_crt(
       pA = modular_proj(fqPolyRepFieldElem, A, me)
 
       # make sure no leading coeff vanishes
-      plcs = [modular_proj(fqPolyRepFieldElem, lc, me) for lc in lcs]
-      plcs = [[plcs[j][i] for j in 1:r] for i in 1:s]
+      plcs0 = [modular_proj(fqPolyRepFieldElem, lc, me) for lc in lcs]
+      plcs = [[plcs0[j][i] for j in 1:r] for i in 1:s]
       ok = true
       for i in 1:s, j in 1:r
         ok = ok && !iszero(plcs[i][j])
@@ -233,8 +233,8 @@ function hlift_have_lcs_crt(
       end
 
       # make sure univariate factorizations remain pairwise prime
-      pAuf = [modular_proj(fqPolyRepFieldElem, f, me) for f in Auf]
-      pAuf = [[pAuf[j][i] for j in 1:r] for i in 1:s]
+      pAuf0 = [modular_proj(fqPolyRepFieldElem, f, me) for f in Auf]
+      pAuf = [[pAuf0[j][i] for j in 1:r] for i in 1:s]
       ok = true
       for i in 1:s
         ok = ok && is_pairwise_coprime(pAuf[i])
@@ -243,8 +243,8 @@ function hlift_have_lcs_crt(
         continue
       end
 
-      palphas = [deepcopy(Hecke.modular_proj(alphas[j], me)) for j in 1:n]
-      palphas = [[palphas[j][i] for j in 1:n] for i in 1:s]
+      palphas0 = [deepcopy(Hecke.modular_proj(alphas[j], me)) for j in 1:n]
+      palphas = [[palphas0[j][i] for j in 1:n] for i in 1:s]
 
     catch ee
       if ee <: Hecke.BadPrime
@@ -253,7 +253,8 @@ function hlift_have_lcs_crt(
       rethrow(ee)
     end
 
-    pAf = [eltype(pA)[] for j in 1:r]
+    T_pA = eltype(pA)
+    pAf = [T_pA[] for j in 1:r]
     for i in 1:s
       ok, t = AbstractAlgebra.MPolyFactor.hlift_have_lcs(
                        pA[i], pAuf[i], plcs[i], mainvar, minorvars, palphas[i])

--- a/src/NumField/NfAbs/Poly.jl
+++ b/src/NumField/NfAbs/Poly.jl
@@ -105,8 +105,8 @@ function gcd_modular(a::Generic.Poly{AbsSimpleNumFieldElem}, b::Generic.Poly{Abs
     me = modular_init(K, p)
     t = Hecke.modular_proj(a, me)
     fp = deepcopy(t)::Vector{fqPolyRepPolyRingElem}  # bad!!!
-    gp = Hecke.modular_proj(b, me)
-    gp = [gcd(fp[i], gp[i]) for i=1:length(gp)]::Vector{fqPolyRepPolyRingElem}
+    gp0 = Hecke.modular_proj(b, me)
+    gp = [gcd(fp[i], gp0[i]) for i=1:length(gp0)]::Vector{fqPolyRepPolyRingElem}
     gc = Hecke.modular_lift(gp, me)::Generic.Poly{AbsSimpleNumFieldElem}
     if isone(gc)
       return parent(a)(1)

--- a/src/NumField/NfAbs/prational.jl
+++ b/src/NumField/NfAbs/prational.jl
@@ -96,7 +96,7 @@ function _mod(Zell2x, u::FacElem, dpoly, dpolymodl, Zellx; D = Dict{AbsSimpleNum
   res = one(Zell2x)
   w = Zellx()
   for (b, e) in u
-    v = get!(D, b) do
+    v0 = get!(D, b) do
       _mod(Zell2x, b, dpoly, dpolymodl, Zellx)
     end
     if e < 0
@@ -113,7 +113,7 @@ function _mod(Zell2x, u::FacElem, dpoly, dpolymodl, Zellx; D = Dict{AbsSimpleNum
         twowinv2 = 2*winv2
         Hecke.mul!(winv2, winv2, winv2)
         Hecke.mod!(winv2, winv2, dpoly)
-        Hecke.mul!(winv2, winv2, v)
+        Hecke.mul!(winv2, winv2, v0)
         Hecke.mod!(winv2, winv2, dpoly)
         _v = sub!(twowinv2, twowinv2, winv2)
         #_v = mod(2*winv2 - v * winv2^2, dpoly)
@@ -124,6 +124,8 @@ function _mod(Zell2x, u::FacElem, dpoly, dpolymodl, Zellx; D = Dict{AbsSimpleNum
         _v
       end
       e = -e
+    else
+      v = v0
     end
     res = Hecke.mul!(res, res, powermod(v, e, dpoly))
     res = Hecke.mod!(res, res, dpoly)

--- a/src/NumField/NfRel/NEQ.jl
+++ b/src/NumField/NfRel/NEQ.jl
@@ -27,14 +27,14 @@ function is_norm_fac_elem(K::RelSimpleNumField{AbsSimpleNumFieldElem}, a::AbsSim
   s = Set(ideal_type(order_type(AbsSimpleNumField))[minimum(mkK, I) for I = S])
   #make S relative Galois closed:
   PS = IdealSet(ZKa)
-  S = reduce(vcat, Vector{ideal_type(ZKa)}[collect(keys(factor(PS(mkK, p)))) for p = s], init = Vector{ideal_type(ZKa)}())
+  Sc = reduce(vcat, Vector{ideal_type(ZKa)}[collect(keys(factor(PS(mkK, p)))) for p = s], init = Vector{ideal_type(ZKa)}())
 
   local U::FinGenAbGroup
 
-  if length(S) == 0
+  if length(Sc) == 0
     U, mU = unit_group_fac_elem(ZKa)
   else
-    U, mU = sunit_group_fac_elem(collect(S))
+    U, mU = sunit_group_fac_elem(collect(Sc))
   end
 
   class_group(parent(a))
@@ -57,13 +57,13 @@ function is_norm_fac_elem(K::RelSimpleNumField{AbsSimpleNumFieldElem}, a::AbsSim
   #the weights are somewhat random
   # - val*norm(P) so that size of P does matter a bit
   # - scale by 1000 so that small units do not vanish to zero
-  k, mk = kernel(No)
-  k, _mk = snf(k)
-  mk = _mk*mk
+  k0, mk0 = kernel(No)
+  k, _mk = snf(k0)
+  mk = _mk*mk0
   gk = [mU(mk(g)) for g = gens(k)]
   pushfirst!(gk, mU(so))
-  if length(S) > 0
-    v = matrix(ZZ, length(gk), length(S), [valuation(g, P)*norm(P) for g = gk for P = S])
+  if length(Sc) > 0
+    v = matrix(ZZ, length(gk), length(Sc), [valuation(g, P)*norm(P) for g = gk for P = Sc])
   else
     v = zero_matrix(ZZ, length(gk), 0)
   end

--- a/src/NumField/NonSimpleNumField/Conjugates.jl
+++ b/src/NumField/NonSimpleNumField/Conjugates.jl
@@ -45,8 +45,9 @@ function conjugates_arb(a::RelNonSimpleNumFieldElem{T}, prec::Int = 32) where {T
     end
     CC = AcbField(prec1, cached = false)
     CCy, y = polynomial_ring(CC, ngens(L), cached = false)
+    w = wprec
     for i = 1:length(plcK)
-      pols[_absolute_index(plcK[i])] = map_coefficients(x -> evaluate(x, plcK[i], wprec), f, parent = CCy)
+      pols[_absolute_index(plcK[i])] = map_coefficients(x -> evaluate(x, plcK[i], w), f, parent = CCy)
     end
     ind = 1
     for (p, pt) in data

--- a/src/NumField/Selmer.jl
+++ b/src/NumField/Selmer.jl
@@ -63,7 +63,8 @@ function pselmer_group_fac_elem(p::Int, S::Vector{<:AbsNumFieldOrderIdeal{AbsSim
       (norm(pi) < 1000 || degree(pi) == 1) || continue
       c = preimage(mC, pi)
       has_preimage_with_preimage(ms, c)[1] && continue
-      s, ms = sub(C, vcat([ms(g) for g in gens(s)], [c]))
+      ms_old = ms
+      s, ms = sub(C, vcat([ms_old(g) for g in gens(s)], [c]))
       push!(D, pi)
     end
     pr, pos = iterate(P, pos)
@@ -85,9 +86,9 @@ function pselmer_group_fac_elem(p::Int, S::Vector{<:AbsNumFieldOrderIdeal{AbsSim
   end
   #so k should be the SelmerGroup...
   #sorry: k mod p*k is it.
-  Sel, mSel = quo(k, p .* gens(k))
-  Sel, m = snf(Sel)
-  mSel = mSel * pseudo_inv(m)
+  Sel0, mSel0 = quo(k, p .* gens(k))
+  Sel, m = snf(Sel0)
+  mSel = mSel0 * pseudo_inv(m)
 
   #the forward map has a couple of possibilities:
   # - take any lift to k, map to U map to K
@@ -118,11 +119,11 @@ function pselmer_group_fac_elem(p::Int, S::Vector{<:AbsNumFieldOrderIdeal{AbsSim
   end
   function toSel(x::FacElem{AbsSimpleNumFieldElem, AbsSimpleNumField}; check::Bool = check)
     if check
-      A = ideal(ZK, x)
+      IA = ideal(ZK, x)
       for P = S
-        A = A*FacElem([P//1], [-valuation(A, P)])
+        IA = IA*FacElem([P//1], [-valuation(IA, P)])
       end
-      I = evaluate(A)
+      I = evaluate(IA)
       n, d = integral_split(I)
       fl, _ = is_power(n, p)
       fl || error("not in the image")
@@ -150,14 +151,14 @@ function pselmer_group_fac_elem(p::Int, S::Vector{<:AbsNumFieldOrderIdeal{AbsSim
     else
       sp = PrimesSet(Int(maximum(minimum(P) for P = keys(disc_log_data))), -1, p, 1)
     end
-    pr, pos = iterate(sp)
+    q, qpos = iterate(sp)
     while rank(dl) < ngens(Sel)
-      lp = prime_decomposition(ZK, pr)
+      lp = prime_decomposition(ZK, q)
       for (pi, ei) = lp
         ei > 1 && continue
-        F, mF = Hecke.ResidueFieldSmall(ZK, pi)
+        F, mF0 = Hecke.ResidueFieldSmall(ZK, pi)
         u, mu = unit_group(F, n_quo = p)
-        mF = Hecke.extend_easy(mF, K)
+        mF = Hecke.extend_easy(mF0, K)
         va = try [preimage(mu, mF(toK(g)))[1] for g = gens(Sel)]
              catch e
                isa(e, Hecke.BadPrime) || rethrow(e)
@@ -174,7 +175,7 @@ function pselmer_group_fac_elem(p::Int, S::Vector{<:AbsNumFieldOrderIdeal{AbsSim
         dx = vcat(dx, matrix(Fp, 1, 1, [v]))
         dl = vcat(dl, matrix(Fp, 1, ngens(Sel), va))
       end
-      pr, pos = iterate(sp, pos)
+      q, qpos = iterate(sp, qpos)
     end
     fl, sol = can_solve_with_solution(dl, dx; side = :right)
     @assert fl

--- a/src/NumFieldOrd/NfOrd/Clgp/FacBase_Euc.jl
+++ b/src/NumFieldOrd/NfOrd/Clgp/FacBase_Euc.jl
@@ -24,7 +24,8 @@ function FactorBase(x::Union{Set{T}, AbstractVector{T}}; check::Bool = true) whe
   end
   ax = [ node{T}(p) for p in x]
   while length(ax) > 1
-    bx = [ _compose(ax[2*i-1], ax[2*i], check) for i=1:div(length(ax), 2)]
+    a = ax
+    bx = [ _compose(a[2*i-1], a[2*i], check) for i=1:div(length(a), 2)]
     if isodd(length(ax))
       push!(bx, ax[end])
     end

--- a/src/NumFieldOrd/NfOrd/Clgp/Map.jl
+++ b/src/NumFieldOrd/NfOrd/Clgp/Map.jl
@@ -618,8 +618,8 @@ function reduce_mod_units(a::Vector{FacElem{AbsSimpleNumFieldElem, AbsSimpleNumF
 
   if isdefined(U, :tentative_regulator)
     #TODO: improve here - it works, kind of...
-    B = Hecke._conj_arb_log_matrix_normalise_cutoff(b, prec)::ArbMatrix
-    bd = maximum(sqrt(sum((B[i,j]::ArbFieldElem)^2 for j=1:ncols(B)))::ArbFieldElem for i=1:nrows(B))
+    B0 = Hecke._conj_arb_log_matrix_normalise_cutoff(b, prec)::ArbMatrix
+    bd = maximum(sqrt(sum((B0[i,j]::ArbFieldElem)^2 for j=1:ncols(B0)))::ArbFieldElem for i=1:nrows(B0))
     bd = bd/root(U.tentative_regulator, length(U.units))
     if isfinite(bd)
       s = ccall((:arb_bits, libflint), Int, (Ref{ArbFieldElem}, ), bd)

--- a/src/NumFieldOrd/NfOrd/Clgp/Saturate.jl
+++ b/src/NumFieldOrd/NfOrd/Clgp/Saturate.jl
@@ -36,11 +36,12 @@ function mod_p(R::Vector{FacElem{AbsSimpleNumFieldElem, AbsSimpleNumField}}, Q::
       y *= x
     end
   end
+  gen_x = x
   ma = Vector{Int}(undef, length(R))
   for i in 1:length(R)
     imgd = image(mF1, R[i], D[i], cached, pp)^e
     ma[i] = get!(dl, imgd) do
-      Hecke.baby_step_giant_step(x, pp, imgd, dl) % p
+      Hecke.baby_step_giant_step(gen_x, pp, imgd, dl) % p
     end
   end
   return matrix(T, 1, length(R), ma)
@@ -454,7 +455,8 @@ function saturate!(d::Hecke.ClassGrpCtx, U::Hecke.UnitGrpCtx, n::Int, stable::Fl
         end
       end
 
-      decom = Dict{AbsNumFieldOrderIdeal{AbsSimpleNumField, AbsSimpleNumFieldElem}, ZZRingElem}((c.FB.ideals[k], v) for (k, v) = fac_a)
+      ideals = c.FB.ideals
+      decom = Dict{AbsNumFieldOrderIdeal{AbsSimpleNumField, AbsSimpleNumFieldElem}, ZZRingElem}((ideals[k], v) for (k, v) = fac_a)
 
       @vprintln :Saturate 1 "Testing if element is an n-th power"
       @vtime :Saturate 1 fl, x = is_power(a, n, decom = decom, easy = easy_root)

--- a/src/NumFieldOrd/NfOrd/Clgp/Sunits.jl
+++ b/src/NumFieldOrd/NfOrd/Clgp/Sunits.jl
@@ -143,13 +143,13 @@ function sunit_mod_units_group_fac_elem(I::Vector{AbsNumFieldOrderIdeal{AbsSimpl
           push!(b.values, v)
         end
       end
-      s, d = _solve_ut(S1, b)
-      @assert d == 1  # this would indicate element is not in group...
-      c = zeros(ZZRingElem, length(I))
+      s, dd = _solve_ut(S1, b)
+      @assert dd == 1  # this would indicate element is not in group...
+      cc = zeros(ZZRingElem, length(I))
       for (p,v) = s
-        c[p] = v
+        cc[p] = v
       end
-      return C(c)
+      return C(cc)
     end
 
     function log(a::AbsSimpleNumFieldElem)

--- a/src/NumFieldOrd/NfOrd/Hensel.jl
+++ b/src/NumFieldOrd/NfOrd/Hensel.jl
@@ -605,9 +605,11 @@ function _hensel(f::Generic.Poly{AbsSimpleNumFieldElem},
         cf = lift(ZX, (change_base_ring(Q, RT[j]*den; parent = Qt) % pgg)*ap % pgg)
       end
 
-      ve = matrix(ZZ, 1, n, [coeff(cf, k) for k=0:n-1])
+      cfj = cf
+      dd = d
+      ve = matrix(ZZ, 1, n, [coeff(cfj, k) for k=0:n-1])
       _ve = ve*Mi
-      mu = matrix(ZZ, 1, n,  [ round(ZZRingElem, _ve[1, k], d) for k=1:n])
+      mu = matrix(ZZ, 1, n,  [ round(ZZRingElem, _ve[1, k], dd) for k=1:n])
       ve = ve - mu*M
       z = ZX()
       for kk=1:n

--- a/src/NumFieldOrd/NfOrd/Ideal/Prime.jl
+++ b/src/NumFieldOrd/NfOrd/Ideal/Prime.jl
@@ -1340,6 +1340,7 @@ function prime_dec_nonindex(O::AbsNumFieldOrder{AbsNonSimpleNumField,AbsNonSimpl
   RT = []
   RE = []
   while true
+    cs = all_c
     re = elem_type(Fpx)[]
     RE = []
     #= TODO: this is suboptimal...
@@ -1379,8 +1380,8 @@ function prime_dec_nonindex(O::AbsNumFieldOrder{AbsNonSimpleNumField,AbsNonSimpl
         end
         push!(RT, [_lift_p2(Fq2, change_base_ring(ZZ, to_univariate(Globals.Qx, all_f[ti]); parent = Zx), i) for i = rt[end]])
       end
-      append!(re, [minpoly(Fpx, sum([rrt[i] * all_c[i] for i=1:length(all_c)])) for rrt in cartesian_product_iterator(rt, inplace = true)])
-      append!(RE, [sum([rrt[i] * all_c[i] for i=1:length(all_c)]) for rrt in cartesian_product_iterator(RT), inplace = true])
+      append!(re, [minpoly(Fpx, sum([rrt[i] * cs[i] for i=1:length(cs)])) for rrt in cartesian_product_iterator(rt, inplace = true)])
+      append!(RE, [sum([rrt[i] * cs[i] for i=1:length(cs)]) for rrt in cartesian_product_iterator(RT), inplace = true])
     end
     if length(Set(re)) < length(re)
       all_c = [rand(1:p-1) for f = all_c]

--- a/src/NumFieldOrd/NfOrd/Overorders.jl
+++ b/src/NumFieldOrd/NfOrd/Overorders.jl
@@ -301,11 +301,11 @@ function _minimal_overorders_nonrecursive_meataxe(O, M)
     end
     #L = _Order(K, potential_basis)
     # A minimal overorder must be a minimal submodule
-    fl, bL = defines_order(K, potential_basis)
+    fl, bL0 = defines_order(K, potential_basis)
     if !fl
       continue
     end
-    bL = _hnf!_integral(bL)
+    bL = _hnf!_integral(bL0)
     #bL = basis_matrix(L, copy = false)
     if any(x -> basis_matrix(FakeFmpqMat, x, copy = false) == bL, orders)
       continue

--- a/src/QuadForm/Herm/GenusRep.jl
+++ b/src/QuadForm/Herm/GenusRep.jl
@@ -586,9 +586,9 @@ function genus_generators(L::HermLat)
         I = EabstoE(Iabs)
         J = I * inv(a(I))
         Jabs = EabstoE\J
-        ok, x = is_principal_with_data(Jabs)
-        u = f(nnorm\(-(ff\FacElem(nf(RR)(norm(x))))))
-        x = x * u
+        ok, x0 = is_principal_with_data(Jabs)
+        u = f(nnorm\(-(ff\FacElem(nf(RR)(norm(x0))))))
+        x = x0 * u
         @assert norm(x) == 1
         if evaluate(x) == 1
           y = w(V([zero(F) for _ in 1:length(PP)]))
@@ -616,9 +616,9 @@ function genus_generators(L::HermLat)
       I = EabstoE(Iabs)
       J = I * inv(a(I))
       Jabs = EabstoE\J
-      ok, x = is_principal_with_data(Jabs)
-      u = f(nnorm\(-(ff\FacElem(nf(RR)(norm(x))))))
-      x = x * u
+      ok, x0 = is_principal_with_data(Jabs)
+      u = f(nnorm\(-(ff\FacElem(nf(RR)(norm(x0))))))
+      x = x0 * u
       @assert norm(x) == 1
       if evaluate(x) == 1
         y = [zero(F) for _ in 1:length(PP)]

--- a/src/QuadForm/Herm/Mass.jl
+++ b/src/QuadForm/Herm/Mass.jl
@@ -290,7 +290,8 @@ function _standard_mass(L::HermLat, prec::Int = 10)
   local relzeta::ArbFieldElem
 
   while true
-    relzeta = prod(_L_function(E, 1 - i, wprec) for i in 1:2:m; init = one(ArbField(wprec, cached = false)))
+    w = wprec
+    relzeta = prod(_L_function(E, 1 - i, w) for i in 1:2:m; init = one(ArbField(w, cached = false)))
     if radiuslttwopower(relzeta * _stdmass, -prec)
       break
     end

--- a/src/QuadForm/IntegerLattices/ShortVectorsTarget.jl
+++ b/src/QuadForm/IntegerLattices/ShortVectorsTarget.jl
@@ -1351,7 +1351,8 @@ function __short_vectors_with_condition_direct(G::ZZMatrix, GInt::Matrix{Int}, g
     end
     target_invariant[i] = _signed_hash(inv_tmp, seed)
   end
-  target_invariant = [_signed_hash(append!(fixed_space_dual[:, i], [v[i] for v in vector_sums]), seed) for i in 1:n]
+  vs = vector_sums
+  target_invariant = [_signed_hash(append!(fixed_space_dual[:, i], [v[i] for v in vs]), seed) for i in 1:n]
   weyl_group_order = _weyl_group_order(root_types)
   grams = ZZMatrix[G, matrix(ZZ,gram2)]
 

--- a/src/QuadForm/IntegerLattices/ZGenus.jl
+++ b/src/QuadForm/IntegerLattices/ZGenus.jl
@@ -2514,15 +2514,15 @@ Further Delta is in bijection with the proper spinor genera of `G`.
 @attr Any function _automorphous_numbers(G::ZZGenus)
   @assert is_integral(G)
   P = [prime(g) for g in local_symbols(G)]
-  A, proj, inj, diagonal_map = local_multiplicative_group_modulo_squares(P)
+  A, _, inj, diagonal_map = local_multiplicative_group_modulo_squares(P)
   gens_automorph = elem_type(A)[]
   for g in local_symbols(G)
     p = prime(g)
     for r in automorphous_numbers(g)
       r = QQ(r)
       S = [i for i in P if i!=p]
-      pv,u = ppio(ZZ(r),p)
-      pv = QQ(pv); u = QQ(u)
+      pv0, u0 = ppio(ZZ(r),p)
+      pv = QQ(pv0); u = QQ(u0)
       push!(gens_automorph, inj[p](u) + sum([inj[q](pv) for q in S], init=A()))
     end
   end

--- a/src/QuadForm/IntegerLattices/ZGenusRep.jl
+++ b/src/QuadForm/IntegerLattices/ZGenusRep.jl
@@ -140,11 +140,11 @@ function make_admissible!(
 
   # Solve the system to find v'
   vK = reduce(vcat, dense_matrix_type(K)[identity_matrix(K, 1), vK])
-  L = kernel(vK)
-  @hassert :ZGenRep 3 !iszero(view(L, :, 1))
-  j = findfirst(j -> !iszero(L[j, 1]), 1:nrows(L))
+  L0 = kernel(vK)
+  @hassert :ZGenRep 3 !iszero(view(L0, :, 1))
+  j = findfirst(j -> !iszero(L0[j, 1]), 1:nrows(L0))
   @hassert :ZGenRep 3 !isnothing(j)
-  L = map_entries(b -> b//L[j, 1], L)
+  L = map_entries(b -> b//L0[j, 1], L0)
   v = ZZRingElem[lift(ZZ, a) for a in L[j, 2:ncols(L)]]
 
   # Now we modify the entries in w by adding p*v
@@ -808,8 +808,9 @@ function _enumerate_definite_genus!(
     return invariant_function(M)
   end
 
+  lats = res
   callback = function(M::ZZLat)
-    any(isequal(M), res) && return false
+    any(isequal(M), lats) && return false
     invM = _invariants(M)
     !haskey(inv_dict, invM) && return true
     keep = all(N -> !is_isometric(N, M), inv_dict[invM])

--- a/src/QuadForm/IntegerLattices/ZLatticeMorphism.jl
+++ b/src/QuadForm/IntegerLattices/ZLatticeMorphism.jl
@@ -470,10 +470,10 @@ function _compress_gram_matrices!(res::Vector{ZZMatrix}, vector_set::Vector)
     resize!(n, 2)
     n[2] = d
   end
-  Gcompressed = sum(a[i]*res_to_compress[i] for i in 1:l)
-  res = [res[1], Gcompressed]
-  @assert _fits_small_init(res, vector_set)
-  return res, vector_set
+  Gcompressed = sum(a .* res_to_compress)
+  res_new = [res[1], Gcompressed]
+  @assert _fits_small_init(res_new, vector_set)
+  return res_new, vector_set
 end
 
 # documented in ../Lattices.jl

--- a/src/QuadForm/IntegerLattices/ZLattices.jl
+++ b/src/QuadForm/IntegerLattices/ZLattices.jl
@@ -979,12 +979,12 @@ function is_maximal_even(L::ZZLat, p::IntegerUnion; check=true)
     findzero_mod4 = function(HR)
       z = R4(0)
       i = findfirst(==(z), R4.(diagonal(HR)))
-      v = zero_matrix(ZZ, 1, nrows(HR))
+      w = zero_matrix(ZZ, 1, nrows(HR))
       if !(i isa Nothing)
-        v[1, i] = 1
-        return true, v
+        w[1, i] = 1
+        return true, w
       else
-        return false, v
+        return false, w
       end
     end
     n = min(4, nrows(H))

--- a/src/QuadForm/Lattices.jl
+++ b/src/QuadForm/Lattices.jl
@@ -1510,10 +1510,10 @@ function assert_has_automorphisms(L::AbstractLat{<: NumField}; redo::Bool = fals
                             for g in t_gens)
 
   pm = pseudo_matrix(L)
-  C = coefficient_ideals(pm)
+  CI = coefficient_ideals(pm)
 
   for g in t_gens
-    @hassert :Lattice 1 all(g[i, j] in C[j] * inv(C[i])
+    @hassert :Lattice 1 all(g[i, j] in CI[j] * inv(CI[i])
                               for i in 1:nrows(g), j in 1:nrows(g))
   end
 

--- a/src/QuadForm/LineOrbits.jl
+++ b/src/QuadForm/LineOrbits.jl
@@ -74,7 +74,8 @@ function Base.rand(P::LineEnumCtx)
     v = rand(K, n)
   end
   j = findfirst(!iszero, v)
-  map!(x -> x*inv(v[j]), v, v)
+  vj_inv = inv(v[j])
+  map!(x -> x*vj_inv, v, v)
   return v
 end
 

--- a/src/QuadForm/Misc.jl
+++ b/src/QuadForm/Misc.jl
@@ -348,10 +348,10 @@ function _strong_approximation_easy(S, ep, xp)
   if length(S) == 1
     p = S[1]
     ap = uniformizer(p)
-    z = xp[1] - ap^(ep[1])
-    @assert valuation(xp[1] - z, S[1]) == ep[1]
-    @assert z == 0 || all(p -> (valuation(z, p) >= 0 || p in S), support(z * order(S[1])))
-    return z
+    z1 = xp[1] - ap^(ep[1])
+    @assert valuation(xp[1] - z1, S[1]) == ep[1]
+    @assert z1 == 0 || all(p -> (valuation(z1, p) >= 0 || p in S), support(z1 * order(S[1])))
+    return z1
   end
   OK = order(S[1])
   # assume ep non-negative and xp in R

--- a/src/QuadForm/Morphism.jl
+++ b/src/QuadForm/Morphism.jl
@@ -726,21 +726,21 @@ function init_vector_sums(C::ZLatAutoCtx{S1, S2, S3}, depth::Int) where {S1, S2,
         end
       end
     end
-    B, T = lll_with_transform(M)
+    B0, T = lll_with_transform(M)
     # Compute the coefficients of the vector sums in the basis
     invT = inv(T)
 
     # Remove the zero rows from B and the corresponding rows / columns from T
     # and invT. The zero rows are on the top.
     k = 1
-    for r in 1:nrows(B)
-      !is_zero_row(B, r) && break
+    for r in 1:nrows(B0)
+      !is_zero_row(B0, r) && break
       k += 1
     end
 
     # We leave these matrices "big" (i.e. of type ZZMatrix) even if the short
     # vectors fit in Int
-    B = sub(B, k:nrows(B), 1:ncols(B))
+    B = sub(B0, k:nrows(B0), 1:ncols(B0))
     C.scpcomb[i].trans = sub(T, k:nrows(T), 1:ncols(T))
     C.scpcomb[i].coef = sub(invT, 1:nrows(invT), k:ncols(invT))
 

--- a/src/QuadForm/Torsion.jl
+++ b/src/QuadForm/Torsion.jl
@@ -1780,12 +1780,12 @@ function normal_form(
     end
 
     D1, U1 = _normalize(D, ZZ(p), false)
-    UR = U1 * UR
+    U1R = U1 * UR
     #apply U to the generators
-    n1 = ncols(UR)
+    n1 = ncols(U1R)
     Gp =  gens(D_p);
-    for i in 1:nrows(UR)
-      g = sum(lift(UR[i,j]) * Gp[j] for j in 1:ncols(UR))
+    for i in 1:nrows(U1R)
+      g = sum(lift(U1R[i,j]) * Gp[j] for j in 1:ncols(U1R))
       push!(normal_gens, I_p(g))
     end
   end
@@ -2494,8 +2494,8 @@ function snf(T::TorQuadModule)
   if is_snf(A)
     return T, id_hom(T)
   end
-  G, f = snf(A)
-  S, f = sub(T, [T(f(g)) for g in gens(G)])
+  G, mG = snf(A)
+  S, f = sub(T, [T(mG(g)) for g in gens(G)])
   @assert is_bijective(f)
   return (S, f)::Tuple{TorQuadModule, TorQuadModuleMap}
 end

--- a/src/RCF/autos.jl
+++ b/src/RCF/autos.jl
@@ -761,7 +761,8 @@ function extend_aut_pp(A::ClassField, autos::Vector{<:NumFieldHom{AbsSimpleNumFi
   frob_gens = find_gens(KK, act_on_gens, minimum(defining_modulus(A)[1]), ind_image)
   if ind_image > 1 #the hard case: the big Kummer ext will be
                    #smaller than it looks..(by ind_image)
-    c = [canonical_frobenius(x, KK) for x = frob_gens]
+    KKc = KK
+    c = [canonical_frobenius(x, KKc) for x = frob_gens]
     kummer = KK.AutG
     Zd = abelian_group([d])
     sc = [divexact(d, exps[i]) for i=1:length(exps)]
@@ -773,7 +774,8 @@ function extend_aut_pp(A::ClassField, autos::Vector{<:NumFieldHom{AbsSimpleNumFi
     fl, emb = is_subgroup(k, kummer)
     @assert fl
     s, ms = snf(k)
-    rels = [emb(ms(s[i])) for i=1:ngens(s)]
+    embk, sk = emb, s
+    rels = [embk(ms(sk[i])) for i=1:ngens(sk)]
     @assert length(rels) <= 2 #should be == 1 for d = p^k odd or d = 4, can be 1 or two
                     #otherwise (compositum with Z_n - which is almost cyclic)
     #I think I'd like then in echelon form (to have ones and zeros above)
@@ -812,16 +814,16 @@ function extend_aut_pp(A::ClassField, autos::Vector{<:NumFieldHom{AbsSimpleNumFi
     ng = []
     for rel = rels
       ex = [rel[i]//exps[i] for i=1:length(exps)]
-      d = mapreduce(denominator, lcm, ex)
-      a = prod(KK.gen[i]^numerator(d*ex[i]) for i=1:length(exps))
-      fl, rt = is_power(a, Int(d), with_roots_unity = true)
+      dd = mapreduce(denominator, lcm, ex)
+      a = prod(KKc.gen[i]^numerator(dd*ex[i]) for i=1:length(exps))
+      fl, rt = is_power(a, Int(dd), with_roots_unity = true)
       @assert fl
       ps = findfirst(x->numerator(ex[x]) == 1 && denominator(ex[x]) <= exps[x], 1:length(exps))
       #we'll be changing this gen
       @assert !(ps in new) #we don't won't to change twice
       push!(new, ps)
-      # the new gen will be rt^1/d
-      push!(ng, (ps, rt, Int(exps[ps]//d), ex))
+      # the new gen will be rt^1/dd
+      push!(ng, (ps, rt, Int(exps[ps]//dd), ex))
     end
     for i=1:length(exps)
       if i in new
@@ -839,6 +841,7 @@ function extend_aut_pp(A::ClassField, autos::Vector{<:NumFieldHom{AbsSimpleNumFi
     K, gK = number_field(KK)
     #I need the inclusions of the single extensions Cp[i].K in the new K
     incs = Vector{morphism_type(RelSimpleNumField{AbsSimpleNumFieldElem}, RelNonSimpleNumField{AbsSimpleNumFieldElem})}(undef, length(Cp))
+    gKn = gK
     for i = 1:length(Cp)
       @assert ng[i][1] == i
       ex = ng[i][4]
@@ -846,7 +849,7 @@ function extend_aut_pp(A::ClassField, autos::Vector{<:NumFieldHom{AbsSimpleNumFi
       ex .*= denominator(ex[i])//exps[i]
       #entry j deals with the new one...
       #rel[j][4] has the rational expo of the relation
-      incs[i] = hom(Cp[i].K, K, abs_emb[i], gK[i]^numerator(ng[i][4][i])*prod(gK[l]^(divexact(exps[l], denominator(ng[i][4][l]))*numerator(-ng[i][4][l])) for l=1:length(exps) if l != i), check = checkAuto)
+      incs[i] = hom(Cp[i].K, K, abs_emb[i], gKn[i]^numerator(ng[i][4][i])*prod(gKn[l]^(divexact(exps[l], denominator(ng[i][4][l]))*numerator(-ng[i][4][l])) for l=1:length(exps) if l != i), check = checkAuto)
     end
 
     act_on_gens = Vector{Vector{FacElem{AbsSimpleNumFieldElem, AbsSimpleNumField}}}(undef, length(KK.gen))

--- a/src/RCF/class_fields.jl
+++ b/src/RCF/class_fields.jl
@@ -670,9 +670,9 @@ function grunwald_wang(dp::Dict{<:NumFieldOrderIdeal, Int}, di::Dict{<:NumFieldE
 end
 
 function _grunwald_wang(d::Dict{<:Any, Int})
-  lp = collect(keys(d))
-  li = [x for x = lp if isa(x, NumFieldEmb)]
-  lp = [x for x = lp if isa(x, NumFieldOrderIdeal)]
+  keys_d = collect(keys(d))
+  li = [x for x = keys_d if isa(x, NumFieldEmb)]
+  lp = [x for x = keys_d if isa(x, NumFieldOrderIdeal)]
   @assert length(lp) + length(li) == length(d)
 
   if length(li) == 0
@@ -782,7 +782,8 @@ function _grunwald_wang_pp(d::Dict{<:Any, Int})
     else
       if iseven(deg) && length(l2) > 0
         S1 = ray_class_field(mR)
-        S2 = [ray_class_field(divexact(con, p^valuation(con, p)), n_quo = deg) for p = l2]
+        cur_con = con
+        S2 = [ray_class_field(divexact(cur_con, p^valuation(cur_con, p)), n_quo = deg) for p = l2]
         ngp = norm_group_map(S1, S2)
         s, _ = sub(R, [val[i] for i = 1:length(lp)])
         s += preimage(S1.quotientmap, sum(kernel(x)[1] for x = ngp))[1]
@@ -792,9 +793,9 @@ function _grunwald_wang_pp(d::Dict{<:Any, Int})
       s = saturate(s, R)
       fl, s = has_complement(s, R)
       @assert fl
-      c, mc = quo(R, s)
-      c, _mc = quo(c, FinGenAbGroupElem[d[lp[i]] * mc(val[i]) for i = 1:length(lp)])
-      mc = mc * _mc
+      c0, mc0 = quo(R, s)
+      c, _mc = quo(c0, FinGenAbGroupElem[d[lp[i]] * mc0(val[i]) for i = 1:length(lp)])
+      mc = mc0 * _mc
       if all(i->order(mc(val[i])) == d[lp[i]], 1:length(lp))
 #        @show :cyc, snf(c)[1]
         for (u, mu) = subgroups(c, quotype = [deg])

--- a/src/RieSrf/PeriodMatrix.jl
+++ b/src/RieSrf/PeriodMatrix.jl
@@ -134,9 +134,9 @@ function big_period_matrix(RS::RiemannSurface)
   s_m = SymmetricGroup(m) # ::AbstractAlgebra.Generic.SymmetricGroup{Int}
 
   ys = Vector{AcbFieldElem}()
+  Cp = AcbField(max_prec)
   for path in paths
-    Cc = AcbField(max_prec)
-		integral_matrix = zero_matrix(Cc, m, g)
+		integral_matrix = zero_matrix(Cp, m, g)
     subpaths = path.sub_paths
     x0 = start_point(subpaths[1])
 		ys =  sort!(roots(f(x0, y), initial_prec = prec), lt = sheet_ordering)
@@ -145,7 +145,7 @@ function big_period_matrix(RS::RiemannSurface)
 
 			integration_scheme = RS.integration_schemes[subpath.integration_scheme_index]
 
-			path_difference_matrix = zero_matrix(Cc, m, g)
+			path_difference_matrix = zero_matrix(Cp, m, g)
       abscissae = integration_scheme.abscissae
       N = length(abscissae)
 			An = analytic_continuation(RS, subpath, abscissae, ys)[2:end]
@@ -158,7 +158,7 @@ function big_period_matrix(RS::RiemannSurface)
           # point, multiply it with the correct weight and add it to the
           # intrgral.
 					integral_matrix_contribution = RS.evaluate_differential_factors_matrix(embedded_differentials, An[i][1],An[i][2])
-					integral_matrix_contribution = change_base_ring(Cc, integral_matrix_contribution)
+					integral_matrix_contribution = change_base_ring(Cp, integral_matrix_contribution)
           integral_matrix_contribution *= integration_scheme.weights[i]
 					path_difference_matrix += integral_matrix_contribution
 				end
@@ -168,7 +168,7 @@ function big_period_matrix(RS::RiemannSurface)
 			else
         for i in (1:N)
 					integral_matrix_contribution = RS.evaluate_differential_factors_matrix(embedded_differentials,An[i][1],An[i][2])
-          integral_matrix_contribution = change_base_ring(Cc, integral_matrix_contribution)
+          integral_matrix_contribution = change_base_ring(Cp, integral_matrix_contribution)
           # For arcs and circles we need to multiply with an additional dx.
           integral_matrix_contribution *= integration_scheme.weights[i] * evaluate_d(path, abscissae[i])
 					path_difference_matrix += integral_matrix_contribution
@@ -223,7 +223,7 @@ function big_period_matrix(RS::RiemannSurface)
     chain = mon[1]
     chain_length = length(chain)
     chain_permutation = mon[2]
-    chain_integral = zero_matrix(Cc, m, g)
+    chain_integral = zero_matrix(Cp, m, g)
     sigma = one(s_m)
 
     for k in (1:chain_length)
@@ -246,7 +246,7 @@ function big_period_matrix(RS::RiemannSurface)
   #forms.
   for cycle in cycles
 
-		cycle_integral = [zero(Cc) for x in 1:g]
+		cycle_integral = [zero(Cp) for x in 1:g]
 		l = 1
 		while l < length(cycle)
       #Identify sheet we end up in after moving along the chain.
@@ -358,7 +358,8 @@ function compute_ellipse_bound_rigorous(subpath, dif_basis, int_group_rs, RS)
     current_endpoint = 1
     gmin = minpoly(g)
     while (interval[end] != 1)
-      if minimum([abs(alpha - (1//2) * (interval[end] + current_endpoint)) for alpha in rs]) > (1//2) * abs(current_endpoint - interval[end])
+      mid = (1//2) * (interval[end] + current_endpoint)
+      if minimum([abs(alpha - mid) for alpha in rs]) > (1//2) * abs(current_endpoint - interval[end])
         push!(interval, current_endpoint)
         current_endpoint = 1
       else 
@@ -371,16 +372,16 @@ function compute_ellipse_bound_rigorous(subpath, dif_basis, int_group_rs, RS)
       z_0 = (interval[j] + interval[j-1])/2
       delta = minimum([abs(alpha - z_0) for alpha in rs]) + (abs(interval[j] - interval[j-1]))/2 
       lis = [denominator(coeff(gmin, i)) for i in (0:degree(gmin))]
-      gmin = lcm(lis) * gmin
+      gmin_int = lcm(lis) * gmin
       CC = RS.complex_field
       v = embedding(RS)
       _, CCx = polynomial_ring(CC, "x")
-      coeffs = [numerator(coeff(gmin,i)) for i in (0:degree(gmin))]
+      coeffs = [numerator(coeff(gmin_int,i)) for i in (0:degree(gmin_int))]
       #precompose with the path
       #the coefficients in the minimal polynomial of g are rational functions from the path P to CC.
       #The paper [BDG24] requires this equation to hold on [-1,1]. The straight path P is encoded as a fucntion [-1,1] -> P 
       #so in order to get an equation on [-1,1] we precompose the coefficients with the formula for the straight path. 
-      if base_ring(base_ring(parent(gmin))) == QQ
+      if base_ring(base_ring(parent(gmin_int))) == QQ
         coeffs = [sum(CC(coeff(a,i)) * ( (CCx+1)*v_end/2 + (1-CCx)*v_start/2 )^i for i in (0:length(coefficients(a)))) for a in coeffs]
       else 
         coeffs = [sum(CC(embedding(v)(coeff(a,i))) * ( (CCx+1)*v_end/2 + (1-CCx)*v_start/2 )^i for i in (0:length(coefficients(a)))) for a in coeffs]
@@ -430,15 +431,15 @@ function compute_ellipse_bound_heuristic(subpath::CPath, differentials_test, int
 	  ImSgn = sign(Int, imag(x))
 	  ReSgn = sign(Int, real(x))
 
-	  x = abs(real(x)) + I*abs(imag(x))
+	  xa = abs(real(x)) + I*abs(imag(x))
 	  s = function(t)
-		  return cos(t)*sin(t)-r*real(x)*sin(t)+b*imag(x)*cos(t)
+		  return cos(t)*sin(t)-r*real(xa)*sin(t)+b*imag(xa)*cos(t)
 	  end
 
 	  sp = function(t)
-		  return (cos(t)^2 - sin(t)^2) - r*real(x)*cos(t) - b*imag(x)*sin(t)
+		  return (cos(t)^2 - sin(t)^2) - r*real(xa)*cos(t) - b*imag(xa)*sin(t)
 	  end
-    nt = real(acos(x))
+    nt = real(acos(xa))
 	  t = nt - s(nt)/sp(nt)
 	  while abs(t-nt) > 10^-3
 		  nt = t

--- a/src/RieSrf/RiemannSurface.jl
+++ b/src/RieSrf/RiemannSurface.jl
@@ -264,14 +264,14 @@ mutable struct RiemannSurface
 
     function evaluate_differential_factors_matrix(factors, x0, ys)
       Kxy = parent(factors[1])
-      Ky, y = polynomial_ring(base_ring(Kxy), "y")
+      Ky, yy = polynomial_ring(base_ring(Kxy), "y")
       CC = base_ring(factors[1])
       m = length(ys)
 
       result = matrix(CC, m , g, [one(CC) for t in (1:m*g)])
       for l in 1:length(factors)
-        f = factors[l]
-        fx0 = f(x0, y)
+        fl = factors[l]
+        fx0 = fl(x0, yy)
         for s in 1:m
           fx0ys = CC(fx0(ys[s]))
           factor_at_xys = [fx0ys^min_pows[l] ]

--- a/src/analytic.jl
+++ b/src/analytic.jl
@@ -41,8 +41,8 @@ function rho_coeff(x::T, prec::Int = 55; all::Bool = false) where T<: Number
   end
 
   while k>a.valid[2]
-    d = [ sum([a.coeff[j+1]/(i*(a.valid[2]+1)^(i-j)) for j=0:(i-1) ])  for i=1:prec]
-    d = vcat([1/(a.valid[2]) * sum([d[j]/(j+1) for j=1:prec ])] , d)
+    d0 = [ sum([a.coeff[j+1]/(i*(a.valid[2]+1)^(i-j)) for j=0:(i-1) ])  for i=1:prec]
+    d = vcat([1/(a.valid[2]) * sum([d0[j]/(j+1) for j=1:prec ])] , d0)
     a.coeff = d
     a.valid = (a.valid[1]+1, a.valid[2]+1)
     if all


### PR DESCRIPTION
A variable captured by a closure and assigned more than once is stored in a `Core.Box` and inferred as `Any`, which slows down the closure and everything computed from its result. `Test.detect_closure_boxes` (Julia 1.14) lists such methods.

Give each new value its own name, or alias a captured value under a name that is assigned exactly once. No behaviour change.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

---

First commit of PR #2386. While it is big, I feel it is fairly easy to review anyway, as this is only renaming variables. Still: if you prefer, I can split it further.