### PR TITLE
Fix characteristic_vectors(::ZZLat) by lll reducing the projected lattices

### DIFF
--- a/src/QuadForm/IntegerLattices/CharacteristicVectors.jl
+++ b/src/QuadForm/IntegerLattices/CharacteristicVectors.jl
@@ -382,6 +382,8 @@ end
 
 # Return the fundamental roots of `L` together with the characteristic vectors
 # of norm different from 1 and 2 lying in the closed fundamental Weyl chamber.
+# Note which closed fundamental Weyl chamber is chosen depends internally
+# on the choice of an lll reduced basis.
 function _reduced_characteristic_vectors(L::ZZLat)
   if !iseven(L)     # splitt off ones if there are any
     ones = ZZMatrix[matrix(ZZ, 1, rank(L), v) for (v, _) in short_vectors(L, 1, 1, Int; check=false)]

--- a/src/QuadForm/IntegerLattices/CharacteristicVectors.jl
+++ b/src/QuadForm/IntegerLattices/CharacteristicVectors.jl
@@ -351,7 +351,7 @@ function _reduced_characteristic_vectors_without_1(L::ZZLat)
   # the matrix of a generating system of `L2`.
   L0 = lattice(rational_span(L))
   pr = identity_matrix(QQ, n) - change_base_ring(QQ, gram_roots*dweights)*QQ(1, dd)
-  L2 = lattice(ambient_space(L0), pr; isbasis=false, check=false)
+  L2 = lll(lattice(ambient_space(L0), pr; isbasis=false, check=false)) # the hnf basis can be badly conditioned
   PZ = change_base_ring(ZZ, solve(basis_matrix(L2), pr; side=:left))
   cv2 = _characteristic_vectors(L2)
   # `_characteristic_vectors` returns the characteristic vectors only up to
@@ -391,7 +391,7 @@ function _reduced_characteristic_vectors(L::ZZLat)
       # `M` of the lattice they span; of the vectors of norm one themselves we
       # keep one of each pair
       N = lattice_in_same_ambient_space(L, change_base_ring(QQ, reduce(vcat, ones))*basis_matrix(L))
-      M = orthogonal_submodule(L, N)
+      M = lll(orthogonal_submodule(L, N)) # lll to improve basis quality
       if !is_zero(rank(M))
         B = change_base_ring(ZZ, solve(basis_matrix(L), basis_matrix(M); side=:left))
         append!(ones, ZZMatrix[matrix(ZZ, v)*B for v in _reduced_characteristic_vectors(M)])

--- a/test/QuadForm/Quad/CharacteristicVectors.jl
+++ b/test/QuadForm/Quad/CharacteristicVectors.jl
@@ -46,7 +46,7 @@
   for L in [integer_lattice(gram = matrix(QQ, 2, 2, [4,1,1,4])), integer_lattice(gram = identity_matrix(QQ, 4)),
             direct_sum(integer_lattice(gram = identity_matrix(QQ, 1)), root_lattice(:D, 6))[1],
             direct_sum(integer_lattice(gram = identity_matrix(QQ, 2)), integer_lattice(gram = matrix(QQ, 2, 2, [4,1,1,4])))[1]]
-    @test Set(vec(v) for v in Hecke._reduced_characteristic_vectors(L)) == generic_reduction(L)
+    @test length(Hecke._reduced_characteristic_vectors(L)) == length(generic_reduction(L)) # the sets are only equal up to the action of the Weyl group.
   end
 
   # the hardcoded minuscule tables agree with what the Cartan matrix says: `d`

--- a/test/QuadForm/Quad/CharacteristicVectors.jl
+++ b/test/QuadForm/Quad/CharacteristicVectors.jl
@@ -73,4 +73,10 @@
   norms(L) = sort!([(matrix(ZZ, v)*Hecke._integral_split_gram(L)[1]*transpose(matrix(ZZ, v)))[1, 1]
                     for v in Hecke._reduced_characteristic_vectors(L)])
   @test norms(integer_lattice(gram = G)) == norms(integer_lattice(gram = U*G*transpose(U)))
+
+  # why lll is needed:
+  L = integer_lattice(gram=QQ[-2 0 0 0 0 0 0 0 0 1 1 1 1 -1 0 0; 0 -2 1 -1 1 0 0 0 0 1 1 1 1 -1 1 0; 0 1 -2 1 -1 0 0 0 0 0 -1 0 -1 1 -1 0; 0 -1 1 -2 1 0 0 0 0 0 0 1 0 0 0 0; 0 1 -1 1 -2 0 0 0 0 0 -1 -1 0 1 -1 0; 0 0 0 0 0 -2 0 0 0 1 0 0 0 0 -1 -1; 0 0 0 0 0 0 -2 1 1 -1 -1 1 1 -1 1 0; 0 0 0 0 0 0 1 -2 -1 0 0 -1 -1 0 -1 0; 0 0 0 0 0 0 1 -1 -2 1 0 -1 -1 0 -1 0; 1 1 0 0 0 1 -1 0 1 -4 -2 0 -1 0 1 1; 1 1 -1 0 -1 0 -1 0 0 -2 -4 0 -1 1 -1 0; 1 1 0 1 -1 0 1 -1 -1 0 0 -4 -1 1 -1 0; 1 1 -1 0 0 0 1 -1 -1 -1 -1 -1 -4 2 -2 0; -1 -1 1 0 1 0 -1 0 0 0 1 1 2 -4 2 0; 0 1 -1 0 -1 -1 1 -1 -1 1 -1 -1 -2 2 -4 -1; 0 0 0 0 0 -1 0 0 0 1 0 0 0 0 -1 -2]);
+  @test length(Hecke._reduced_characteristic_vectors(lll(L))) == 288
+
+
 end


### PR DESCRIPTION
The hnf bases can be so badly conditoned that close and short vectors overflow.

Fixes:
```
julia> L = integer_lattice(gram=QQ[-2 0 0 0 0 0 0 0 0 1 1 1 1 -1 0 0; 0 -2 1 -1 1 0 0 0 0 1 1 1 1 -1 1 0; 0 1 -2 1 -1 0 0 0 0 0 -1 0 -1 1 -1 0; 0 -1 1 -2 1 0 0 0 0 0 0 1 0 0 0 0; 0 1 -1 1 -2 0 0 0 0 0 -1 -1 0 1 -1 0; 0 0 0 0 0 -2 0 0 0 1 0 0 0 0 -1 -1; 0 0 0 0 0 0 -2 1 1 -1 -1 1 1 -1 1 0; 0 0 0 0 0 0 1 -2 -1 0 0 -1 -1 0 -1 0; 0 0 0 0 0 0 1 -1 -2 1 0 -1 -1 0 -1 0; 1 1 0 0 0 1 -1 0 1 -4 -2 0 -1 0 1 1; 1 1 -1 0 -1 0 -1 0 0 -2 -4 0 -1 1 -1 0; 1 1 0 1 -1 0 1 -1 -1 0 0 -4 -1 1 -1 0; 1 1 -1 0 0 0 1 -1 -1 -1 -1 -1 -4 2 -2 0; -1 -1 1 0 1 0 -1 0 0 0 1 1 2 -4 2 0; 0 1 -1 0 -1 -1 1 -1 -1 1 -1 -1 -2 2 -4 -1; 0 0 0 0 0 -1 0 0 0 1 0 0 0 0 -1 -2]);

julia> Hecke._reduced_characteristic_vectors(lll(L))
ERROR: InexactError: convert(Int64, -21269068067019310378830191381278)
```