### PR TITLE
Pass on keywords in representatives(::ZZGenus)

### DIFF
--- a/src/QuadForm/IntegerLattices/ZGenus.jl
+++ b/src/QuadForm/IntegerLattices/ZGenus.jl
@@ -2160,9 +2160,9 @@ is_definite(G::ZZGenus) = any(is_zero, signature_pair(G))
 
 Return a list of representatives of the isometry classes in this genus.
 """
-@attr Vector{ZZLat} function representatives(G::ZZGenus)
+@attr Vector{ZZLat} function representatives(G::ZZGenus; kwargs...)
   L = representative(G)
-  rep = genus_representatives(L)
+  rep = genus_representatives(L; kwargs...)
   @hassert :Lattice 2 !is_definite(G) || mass(G) == sum(QQFieldElem[1//automorphism_group_order(S) for S in rep]; init=QQ(0))
   return rep
 end

--- a/src/QuadForm/IntegerLattices/ZGenus.jl
+++ b/src/QuadForm/IntegerLattices/ZGenus.jl
@@ -2160,10 +2160,14 @@ is_definite(G::ZZGenus) = any(is_zero, signature_pair(G))
 
 Return a list of representatives of the isometry classes in this genus.
 """
-@attr Vector{ZZLat} function representatives(G::ZZGenus; kwargs...)
+function representatives(G::ZZGenus; kwargs...)
+  if isdefined(G, :_representatives)
+    return G._representatives
+  end
   L = representative(G)
   rep = genus_representatives(L; kwargs...)
   @hassert :Lattice 2 !is_definite(G) || mass(G) == sum(QQFieldElem[1//automorphism_group_order(S) for S in rep]; init=QQ(0))
+  G._representatives = rep
   return rep
 end
 

--- a/src/QuadForm/IntegerLattices/ZLattices.jl
+++ b/src/QuadForm/IntegerLattices/ZLattices.jl
@@ -767,7 +767,7 @@ end
 
 Return representatives for the isometry classes in the genus of `L`.
 """
-function genus_representatives(_L::ZZLat)
+function genus_representatives(_L::ZZLat; kwargs...)
   if rank(_L) <= 1
     return ZZLat[_L]
   end
@@ -785,7 +785,7 @@ function genus_representatives(_L::ZZLat)
       push!(res, _to_ZLat(N; K=QQ))
     end
   elseif is_definite(L)
-    res = enumerate_definite_genus(L)
+    res = enumerate_definite_genus(L;kwargs...)
   else
     res = spinor_genera_in_genus(L)
   end

--- a/src/QuadForm/IntegerLattices/ZLattices.jl
+++ b/src/QuadForm/IntegerLattices/ZLattices.jl
@@ -785,7 +785,7 @@ function genus_representatives(_L::ZZLat; kwargs...)
       push!(res, _to_ZLat(N; K=QQ))
     end
   elseif is_definite(L)
-    res = enumerate_definite_genus([L], :default; kwargs...)
+    res = first(enumerate_definite_genus([L], :default; kwargs...))
   else
     res = spinor_genera_in_genus(L)
   end

--- a/src/QuadForm/IntegerLattices/ZLattices.jl
+++ b/src/QuadForm/IntegerLattices/ZLattices.jl
@@ -785,7 +785,7 @@ function genus_representatives(_L::ZZLat; kwargs...)
       push!(res, _to_ZLat(N; K=QQ))
     end
   elseif is_definite(L)
-    res = enumerate_definite_genus(L;kwargs...)
+    res = enumerate_definite_genus([L], :default; kwargs...)
   else
     res = spinor_genera_in_genus(L)
   end

--- a/src/QuadForm/Quad/Types.jl
+++ b/src/QuadForm/Quad/Types.jl
@@ -74,6 +74,7 @@ non-degenerate integer_lattice.
   _signature_pair::Tuple{Int, Int}
   _symbols::Vector{ZZLocalGenus} # assumed to be sorted by their primes
   _representative::ZZLat
+  _representatives::Vector{ZZLat}
 
   function ZZGenus(signature_pair, symbols::Vector{ZZLocalGenus})
     G = new()


### PR DESCRIPTION
- **forward keyword arguments from representatives(::ZZGenus) to enumerate_definite_genus**

We remove the @attr macro because that chokes on `kwargs...`
