### PR TITLE
Fix Int overflow for primes >= 2^63 in quadratic form invariants and p-adic sqrt

### DIFF
--- a/src/QuadForm/IntegerLattices/NormalForm.jl
+++ b/src/QuadForm/IntegerLattices/NormalForm.jl
@@ -1523,20 +1523,20 @@ end
 function _sqrt(d::Union{zzModRingElem,ZZModRingElem}, p)
   R = parent(d)
   v, p = is_perfect_power_with_data(R.n)
-  return _sqrt(d, Int(p), Int(v))
+  return _sqrt(d, p, Int(v))
 end
 
-function _sqrt(d::ZZModRingElem, p::Int, prec::Int)
+function _sqrt(d::ZZModRingElem, p::IntegerUnion, prec::Int)
   R = parent(d)
   dZ = lift(d)
   rt = Nemo.sqrtmod_pk(dZ, p, prec)
   return ZZModRingElem(rt, R)
 end
 
-function _sqrt(d::zzModRingElem, p::Int, prec::Int)
+function _sqrt(d::zzModRingElem, p::IntegerUnion, prec::Int)
   R = parent(d)
   dZ = Int(lift(d))
-  rt = Nemo._sqrtmod_pk_small(dZ, p, prec)
+  rt = Nemo._sqrtmod_pk_small(dZ, Int(p), prec)
   return zzModRingElem(rt, R)
 end
 

--- a/src/QuadForm/Quad/Spaces.jl
+++ b/src/QuadForm/Quad/Spaces.jl
@@ -541,7 +541,7 @@ function _quadratic_form_with_invariants(dim::Int, det::ZZRingElem,
 
   #// Pad with ones
   k = max(0, dim - max(3, negative))
-  D = ones(Int, k)
+  D = ones(ZZRingElem, k)
   dim = dim - k
 
   local PP::Vector{ZZRingElem}
@@ -556,7 +556,7 @@ function _quadratic_form_with_invariants(dim::Int, det::ZZRingElem,
     unique!(PP)
     finite = ZZRingElem[ p for p in PP if hilbert_symbol(d, -det, p) * (p in f ? -1 : 1) * (p in finite ? -1 : 1) == -1]
     unique!(finite)
-    D = append!(D, Int[-1 for i in 1:k])
+    D = append!(D, ZZRingElem[-1 for i in 1:k])
     det = isodd(k) ? -det : det
     dim = 3
     negative = 3

--- a/test/QuadForm/Quad/Genus.jl
+++ b/test/QuadForm/Quad/Genus.jl
@@ -214,3 +214,18 @@ end
   G = genus(L)
   @test length(unique([G, G, G])) == 1
 end
+
+
+@testset "representative at a prime above 2^63" begin
+  p = next_prime(ZZ(2)^63)
+  while p % 4 != 3
+    p = next_prime(p)
+  end
+  # II_(0,4) p^2: two copies of the even binary form of determinant p
+  B = ZZ[2 1; 1 divexact(p + 1, 2)]
+  L = integer_lattice(gram = -block_diagonal_matrix([B, B]))
+  G = genus(L)
+  # the symbol alone, with no representative attached to it
+  G2 = genus(discriminant_group(L), (0, 4))
+  @test genus(representative(G2)) == G
+end

--- a/test/QuadForm/Quad/NormalForm.jl
+++ b/test/QuadForm/Quad/NormalForm.jl
@@ -436,3 +436,16 @@ end
    @test !Hecke._ispadic_normal_form(matrix(QQ, 1, 1, [9]), 2)
 
  end
+
+@testset "NormalForm at a prime above 2^63" begin
+  p = next_prime(ZZ(2)^63)
+  G = QQ[4 0; 0 p]
+  D, B = Hecke.padic_normal_form(G, p)
+  @test D == QQ[1 0; 0 p]
+  @test Hecke._ispadic_normal_form(D, p)
+  X = B * G * transpose(B) - D
+  @test all(iszero(x) || valuation(x, p) >= 1 for x in X)
+  # a small modulus still goes through the machine-word routine
+  D, B = Hecke.padic_normal_form(QQ[4 0; 0 7], 7)
+  @test D == QQ[1 0; 0 7]
+end

--- a/test/QuadForm/Quad/Spaces.jl
+++ b/test/QuadForm/Quad/Spaces.jl
@@ -264,6 +264,15 @@
     @test hasse_invariant(q, 2) == -1
     @test hasse_invariant(q, ideal(ZZ,3)) == -1
     @test hasse_invariant(q, ZZ(3)) == -1
+    # a prime above 2^63 must not be narrowed to Int
+    pbig = next_prime(ZZ(2)^63)
+    qbig = Hecke._quadratic_form_with_invariants(4, ZZ(1), [ZZ(2), pbig], 4)
+    rkb, kerb, detb, finb, negb = Hecke._quadratic_form_invariants(qbig)
+    @test rkb == 4
+    @test kerb == 0
+    @test is_square(detb)
+    @test finb[ZZ(2)] == -1 && finb[pbig] == -1
+    @test negb[1][2] == 4
     # small ranks should be covered by the tests of GenusRep
     K, a = rationals_as_number_field()
     OK = maximal_order(K)


### PR DESCRIPTION
Fixes #2400.

Two places narrowed a prime `p` to `Int`, which raises `InexactError` for
`p >= 2^63`:

- `_quadratic_form_with_invariants` (`src/QuadForm/Quad/Spaces.jl`)
  accumulated the diagonal in a `Vector{Int}` and pushed `a = -p` into it.
  The vector is now a `Vector{ZZRingElem}`; it was converted to `QQ` before
  use anyway.
- `_sqrt` (`src/QuadForm/IntegerLattices/NormalForm.jl`) converted the modulus with
  `Int(p)` before calling `Nemo.sqrtmod_pk`, which accepts any integer type.
  The modulus is now passed through as is; the `zzModRingElem` method keeps
  its machine-word routine, where `Int(p)` is safe.

Both are reached from `representative(::ZZGenus)` (via `quadratic_space(G)`
and `local_modification` -> `padic_normal_form`), so any genus whose symbol
contains such a prime could not be given a representative.

Minimal reproduction on master:

```julia
julia> p = next_prime(ZZ(2)^63);

julia> Hecke._quadratic_form_with_invariants(4, ZZ(1), [ZZ(2), p], 4)
ERROR: InexactError: convert(Int64, -9223372036854775837)
```

Tests added in `test/QuadForm/Quad/Spaces.jl`,
`test/QuadForm/Quad/NormalForm.jl` and `test/QuadForm/Quad/ZGenus.jl`; each
fails with `InexactError` before this change and passes after it. The
`ZGenus` test builds a representative of `II_(0,4) p^2` from its symbol,
which is the call that originally failed. `Hecke.test_module("QuadForm")`
passes locally.

Context: found while computing isotropic vectors, through
`is_isotropic_with_vector`, of forms of rank 6 whose determinant is divisible
by the square of a prime of 100 to 1000 bits.